### PR TITLE
Add additional libraries to backend.go cgo statements for amd64,linux…

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -1,6 +1,6 @@
 package cimgui
 
-// #cgo amd64,linux LDFLAGS: ${SRCDIR}/lib/linux/x64/libglfw3.a
+// #cgo amd64,linux LDFLAGS: ${SRCDIR}/lib/linux/x64/libglfw3.a -ldl -lGL -lX11
 // #cgo amd64,windows LDFLAGS: -L${SRCDIR}/lib/windows/x64 -l:libglfw3.a -lgdi32 -lopengl32 -limm32
 // #cgo darwin LDFLAGS: -framework Cocoa -framework IOKit -framework CoreVideo
 // #cgo amd64,darwin LDFLAGS: ${SRCDIR}/lib/macos/x64/libglfw3.a

--- a/extra_types.go
+++ b/extra_types.go
@@ -46,16 +46,16 @@ func (vec *ImVec2) wrap() (out *C.ImVec2, finisher func()) {
 type ImVec4 struct {
 	X float32
 	Y float32
-	W float32
 	Z float32
+	W float32
 }
 
 func NewImVec4(r, g, b, a float32) ImVec4 {
 	return ImVec4{
 		X: r,
 		Y: g,
-		W: b,
-		Z: a,
+		Z: b,
+		W: a,
 	}
 }
 


### PR DESCRIPTION
… to build successfully

My c/c++ build skills are very rusty and I might not understand how to get this library working on amd64/linux, but I had to add additional libraries to the cgo statement for the amd64,linux build.  These additions allowed a `go build` to successfully complete without unresolved symbols and a working output binary.