### PR TITLE
Make glfw backend optional

### DIFF
--- a/backend.cpp
+++ b/backend.cpp
@@ -1,3 +1,4 @@
+#if defined(CIMGUI_GO_USE_GLFW)
 #define GL_SILENCE_DEPRECATION
 #define CIMGUI_USE_GLFW
 #define CIMGUI_USE_OPENGL3
@@ -276,3 +277,5 @@ void igDeleteTexture(ImTextureID id) {
 void igGLFWWindow_GetDisplaySize(GLFWwindow *window, int *width, int *height) {
   glfwGetWindowSize(window, width, height);
 }
+
+#endif

--- a/backend.go
+++ b/backend.go
@@ -1,3 +1,6 @@
+//go:build cimgui_glfw
+// +build cimgui_glfw
+
 package cimgui
 
 // #cgo amd64,linux LDFLAGS: ${SRCDIR}/lib/linux/x64/libglfw3.a -ldl -lGL -lX11
@@ -7,6 +10,7 @@ package cimgui
 // #cgo arm64,darwin LDFLAGS: ${SRCDIR}/lib/macos/arm64/libglfw3.a
 // #cgo !gles2,darwin LDFLAGS: -framework OpenGL
 // #cgo gles2,darwin LDFLAGS: -lGLESv2
+// #cgo CPPFLAGS: -DCIMGUI_GO_USE_GLFW
 // extern void glfwWindowLoopCallback();
 // extern void glfwBeforeRender();
 // extern void glfwAfterRender();

--- a/texture.go
+++ b/texture.go
@@ -1,3 +1,6 @@
+//go:build cimgui_glfw
+// +build cimgui_glfw
+
 package cimgui
 
 import (


### PR DESCRIPTION
This allows cimgui-go to "almost" be a drop-in replacement for [imgui-go](https://github.com/inkyblackness/imgui-go)

I choose to make the GLFW backend opt-in since that's what makes the most sense for my use-case, but depending on other uses it might be better to have it opt-out instead