### PR TITLE
test: Fix build & spelling

### DIFF
--- a/cimgui_test.go
+++ b/cimgui_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 )
 
-func TestSetIOCofigFlags(t *testing.T) {
-	CreateContext(0)
-	defer DestroyContext(0)
+func TestSetIOConfigFlags(t *testing.T) {
+	CreateContext()
+	defer DestroyContext()
 
 	io := GetIO()
 	if io == 0 {


### PR DESCRIPTION
`CreateContext()` and `DestroyContext()` do not take arguments.