### PR TITLE
extra types: rename NewColor's args from x,y,z,w to r,g,b,a

### DIFF
--- a/extra_types.go
+++ b/extra_types.go
@@ -67,13 +67,13 @@ type Color struct {
 	Value Vec4
 }
 
-func NewColor(x, y, z, w float32) Color {
+func NewColor(r, g, b, a float32) Color {
 	return Color{
 		Value: Vec4{
-			X: x,
-			Y: y,
-			Z: z,
-			W: w,
+			X: r,
+			Y: g,
+			Z: b,
+			W: a,
 		},
 	}
 }


### PR DESCRIPTION
its just cosmetical fix - it is more logical for a developer to see r, g, b, a (suggests color notation as RGBA nor HSV or CMYK) in color notation