### PR TITLE
codegen: remove pointer receivers

### DIFF
--- a/cimgui_funcs.go
+++ b/cimgui_funcs.go
@@ -5399,7 +5399,7 @@ func ValueFloat(prefix string, v float32) {
 	C.wrap_igValue_Float(prefixArg, C.float(v))
 }
 
-func (self *DrawCmd) SetClipRect(v Vec4) {
+func (self DrawCmd) SetClipRect(v Vec4) {
 	C.wrap_ImDrawCmd_SetClipRect(self.handle(), v.toC())
 }
 
@@ -5409,7 +5409,7 @@ func (self DrawCmd) ClipRect() Vec4 {
 	return *out
 }
 
-func (self *DrawCmd) SetTextureId(v TextureID) {
+func (self DrawCmd) SetTextureId(v TextureID) {
 	C.wrap_ImDrawCmd_SetTextureId(self.handle(), C.ImTextureID(v))
 }
 
@@ -5417,7 +5417,7 @@ func (self DrawCmd) TextureId() TextureID {
 	return TextureID(C.wrap_ImDrawCmd_GetTextureId(self.handle()))
 }
 
-func (self *DrawCmd) SetVtxOffset(v uint32) {
+func (self DrawCmd) SetVtxOffset(v uint32) {
 	C.wrap_ImDrawCmd_SetVtxOffset(self.handle(), C.uint(v))
 }
 
@@ -5425,7 +5425,7 @@ func (self DrawCmd) VtxOffset() uint32 {
 	return uint32(C.wrap_ImDrawCmd_GetVtxOffset(self.handle()))
 }
 
-func (self *DrawCmd) SetIdxOffset(v uint32) {
+func (self DrawCmd) SetIdxOffset(v uint32) {
 	C.wrap_ImDrawCmd_SetIdxOffset(self.handle(), C.uint(v))
 }
 
@@ -5433,7 +5433,7 @@ func (self DrawCmd) IdxOffset() uint32 {
 	return uint32(C.wrap_ImDrawCmd_GetIdxOffset(self.handle()))
 }
 
-func (self *DrawCmd) SetElemCount(v uint32) {
+func (self DrawCmd) SetElemCount(v uint32) {
 	C.wrap_ImDrawCmd_SetElemCount(self.handle(), C.uint(v))
 }
 
@@ -5441,7 +5441,7 @@ func (self DrawCmd) ElemCount() uint32 {
 	return uint32(C.wrap_ImDrawCmd_GetElemCount(self.handle()))
 }
 
-func (self *DrawCmd) SetUserCallbackData(v unsafe.Pointer) {
+func (self DrawCmd) SetUserCallbackData(v unsafe.Pointer) {
 	C.wrap_ImDrawCmd_SetUserCallbackData(self.handle(), (v))
 }
 
@@ -5449,7 +5449,7 @@ func (self DrawCmd) UserCallbackData() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImDrawCmd_GetUserCallbackData(self.handle()))
 }
 
-func (self *DrawCmdHeader) SetClipRect(v Vec4) {
+func (self DrawCmdHeader) SetClipRect(v Vec4) {
 	C.wrap_ImDrawCmdHeader_SetClipRect(self.handle(), v.toC())
 }
 
@@ -5459,7 +5459,7 @@ func (self DrawCmdHeader) ClipRect() Vec4 {
 	return *out
 }
 
-func (self *DrawCmdHeader) SetTextureId(v TextureID) {
+func (self DrawCmdHeader) SetTextureId(v TextureID) {
 	C.wrap_ImDrawCmdHeader_SetTextureId(self.handle(), C.ImTextureID(v))
 }
 
@@ -5467,7 +5467,7 @@ func (self DrawCmdHeader) TextureId() TextureID {
 	return TextureID(C.wrap_ImDrawCmdHeader_GetTextureId(self.handle()))
 }
 
-func (self *DrawCmdHeader) SetVtxOffset(v uint32) {
+func (self DrawCmdHeader) SetVtxOffset(v uint32) {
 	C.wrap_ImDrawCmdHeader_SetVtxOffset(self.handle(), C.uint(v))
 }
 
@@ -5475,7 +5475,7 @@ func (self DrawCmdHeader) VtxOffset() uint32 {
 	return uint32(C.wrap_ImDrawCmdHeader_GetVtxOffset(self.handle()))
 }
 
-func (self *DrawData) SetValid(v bool) {
+func (self DrawData) SetValid(v bool) {
 	C.wrap_ImDrawData_SetValid(self.handle(), C.bool(v))
 }
 
@@ -5483,7 +5483,7 @@ func (self DrawData) Valid() bool {
 	return C.wrap_ImDrawData_GetValid(self.handle()) == C.bool(true)
 }
 
-func (self *DrawData) SetCmdListsCount(v int32) {
+func (self DrawData) SetCmdListsCount(v int32) {
 	C.wrap_ImDrawData_SetCmdListsCount(self.handle(), C.int(v))
 }
 
@@ -5491,7 +5491,7 @@ func (self DrawData) CmdListsCount() int {
 	return int(C.wrap_ImDrawData_GetCmdListsCount(self.handle()))
 }
 
-func (self *DrawData) SetTotalIdxCount(v int32) {
+func (self DrawData) SetTotalIdxCount(v int32) {
 	C.wrap_ImDrawData_SetTotalIdxCount(self.handle(), C.int(v))
 }
 
@@ -5499,7 +5499,7 @@ func (self DrawData) TotalIdxCount() int {
 	return int(C.wrap_ImDrawData_GetTotalIdxCount(self.handle()))
 }
 
-func (self *DrawData) SetTotalVtxCount(v int32) {
+func (self DrawData) SetTotalVtxCount(v int32) {
 	C.wrap_ImDrawData_SetTotalVtxCount(self.handle(), C.int(v))
 }
 
@@ -5507,7 +5507,7 @@ func (self DrawData) TotalVtxCount() int {
 	return int(C.wrap_ImDrawData_GetTotalVtxCount(self.handle()))
 }
 
-func (self *DrawData) SetDisplayPos(v Vec2) {
+func (self DrawData) SetDisplayPos(v Vec2) {
 	C.wrap_ImDrawData_SetDisplayPos(self.handle(), v.toC())
 }
 
@@ -5517,7 +5517,7 @@ func (self DrawData) DisplayPos() Vec2 {
 	return *out
 }
 
-func (self *DrawData) SetDisplaySize(v Vec2) {
+func (self DrawData) SetDisplaySize(v Vec2) {
 	C.wrap_ImDrawData_SetDisplaySize(self.handle(), v.toC())
 }
 
@@ -5527,7 +5527,7 @@ func (self DrawData) DisplaySize() Vec2 {
 	return *out
 }
 
-func (self *DrawData) SetFramebufferScale(v Vec2) {
+func (self DrawData) SetFramebufferScale(v Vec2) {
 	C.wrap_ImDrawData_SetFramebufferScale(self.handle(), v.toC())
 }
 
@@ -5537,7 +5537,7 @@ func (self DrawData) FramebufferScale() Vec2 {
 	return *out
 }
 
-func (self *DrawData) SetOwnerViewport(v Viewport) {
+func (self DrawData) SetOwnerViewport(v Viewport) {
 	C.wrap_ImDrawData_SetOwnerViewport(self.handle(), v.handle())
 }
 
@@ -5545,7 +5545,7 @@ func (self DrawData) OwnerViewport() Viewport {
 	return (Viewport)(unsafe.Pointer(C.wrap_ImDrawData_GetOwnerViewport(self.handle())))
 }
 
-func (self *DrawList) SetFlags(v DrawListFlags) {
+func (self DrawList) SetFlags(v DrawListFlags) {
 	C.wrap_ImDrawList_SetFlags(self.handle(), C.ImDrawListFlags(v))
 }
 
@@ -5553,7 +5553,7 @@ func (self DrawList) Flags() DrawListFlags {
 	return DrawListFlags(C.wrap_ImDrawList_GetFlags(self.handle()))
 }
 
-func (self *DrawList) SetVtxCurrentIdx(v uint32) {
+func (self DrawList) SetVtxCurrentIdx(v uint32) {
 	C.wrap_ImDrawList_Set_VtxCurrentIdx(self.handle(), C.uint(v))
 }
 
@@ -5561,7 +5561,7 @@ func (self DrawList) VtxCurrentIdx() uint32 {
 	return uint32(C.wrap_ImDrawList_Get_VtxCurrentIdx(self.handle()))
 }
 
-func (self *DrawList) SetData(v DrawListSharedData) {
+func (self DrawList) SetData(v DrawListSharedData) {
 	C.wrap_ImDrawList_Set_Data(self.handle(), v.handle())
 }
 
@@ -5569,7 +5569,7 @@ func (self DrawList) Data() DrawListSharedData {
 	return (DrawListSharedData)(unsafe.Pointer(C.wrap_ImDrawList_Get_Data(self.handle())))
 }
 
-func (self *DrawList) SetOwnerName(v string) {
+func (self DrawList) SetOwnerName(v string) {
 	vArg, vFin := wrapString(v)
 	defer vFin()
 
@@ -5580,7 +5580,7 @@ func (self DrawList) OwnerName() string {
 	return C.GoString(C.wrap_ImDrawList_Get_OwnerName(self.handle()))
 }
 
-func (self *DrawList) SetVtxWritePtr(v DrawVert) {
+func (self DrawList) SetVtxWritePtr(v DrawVert) {
 	C.wrap_ImDrawList_Set_VtxWritePtr(self.handle(), v.handle())
 }
 
@@ -5596,7 +5596,7 @@ func (self DrawList) Splitter() DrawListSplitter {
 	return newDrawListSplitterFromC(C.wrap_ImDrawList_Get_Splitter(self.handle()))
 }
 
-func (self *DrawList) SetFringeScale(v float32) {
+func (self DrawList) SetFringeScale(v float32) {
 	C.wrap_ImDrawList_Set_FringeScale(self.handle(), C.float(v))
 }
 
@@ -5604,7 +5604,7 @@ func (self DrawList) FringeScale() float32 {
 	return float32(C.wrap_ImDrawList_Get_FringeScale(self.handle()))
 }
 
-func (self *DrawListSharedData) SetTexUvWhitePixel(v Vec2) {
+func (self DrawListSharedData) SetTexUvWhitePixel(v Vec2) {
 	C.wrap_ImDrawListSharedData_SetTexUvWhitePixel(self.handle(), v.toC())
 }
 
@@ -5614,7 +5614,7 @@ func (self DrawListSharedData) TexUvWhitePixel() Vec2 {
 	return *out
 }
 
-func (self *DrawListSharedData) SetFont(v Font) {
+func (self DrawListSharedData) SetFont(v Font) {
 	C.wrap_ImDrawListSharedData_SetFont(self.handle(), v.handle())
 }
 
@@ -5622,7 +5622,7 @@ func (self DrawListSharedData) Font() Font {
 	return (Font)(unsafe.Pointer(C.wrap_ImDrawListSharedData_GetFont(self.handle())))
 }
 
-func (self *DrawListSharedData) SetFontSize(v float32) {
+func (self DrawListSharedData) SetFontSize(v float32) {
 	C.wrap_ImDrawListSharedData_SetFontSize(self.handle(), C.float(v))
 }
 
@@ -5630,7 +5630,7 @@ func (self DrawListSharedData) FontSize() float32 {
 	return float32(C.wrap_ImDrawListSharedData_GetFontSize(self.handle()))
 }
 
-func (self *DrawListSharedData) SetCurveTessellationTol(v float32) {
+func (self DrawListSharedData) SetCurveTessellationTol(v float32) {
 	C.wrap_ImDrawListSharedData_SetCurveTessellationTol(self.handle(), C.float(v))
 }
 
@@ -5638,7 +5638,7 @@ func (self DrawListSharedData) CurveTessellationTol() float32 {
 	return float32(C.wrap_ImDrawListSharedData_GetCurveTessellationTol(self.handle()))
 }
 
-func (self *DrawListSharedData) SetCircleSegmentMaxError(v float32) {
+func (self DrawListSharedData) SetCircleSegmentMaxError(v float32) {
 	C.wrap_ImDrawListSharedData_SetCircleSegmentMaxError(self.handle(), C.float(v))
 }
 
@@ -5646,7 +5646,7 @@ func (self DrawListSharedData) CircleSegmentMaxError() float32 {
 	return float32(C.wrap_ImDrawListSharedData_GetCircleSegmentMaxError(self.handle()))
 }
 
-func (self *DrawListSharedData) SetClipRectFullscreen(v Vec4) {
+func (self DrawListSharedData) SetClipRectFullscreen(v Vec4) {
 	C.wrap_ImDrawListSharedData_SetClipRectFullscreen(self.handle(), v.toC())
 }
 
@@ -5656,7 +5656,7 @@ func (self DrawListSharedData) ClipRectFullscreen() Vec4 {
 	return *out
 }
 
-func (self *DrawListSharedData) SetInitialFlags(v DrawListFlags) {
+func (self DrawListSharedData) SetInitialFlags(v DrawListFlags) {
 	C.wrap_ImDrawListSharedData_SetInitialFlags(self.handle(), C.ImDrawListFlags(v))
 }
 
@@ -5664,7 +5664,7 @@ func (self DrawListSharedData) InitialFlags() DrawListFlags {
 	return DrawListFlags(C.wrap_ImDrawListSharedData_GetInitialFlags(self.handle()))
 }
 
-func (self *DrawListSharedData) SetArcFastRadiusCutoff(v float32) {
+func (self DrawListSharedData) SetArcFastRadiusCutoff(v float32) {
 	C.wrap_ImDrawListSharedData_SetArcFastRadiusCutoff(self.handle(), C.float(v))
 }
 
@@ -5672,7 +5672,7 @@ func (self DrawListSharedData) ArcFastRadiusCutoff() float32 {
 	return float32(C.wrap_ImDrawListSharedData_GetArcFastRadiusCutoff(self.handle()))
 }
 
-func (self *DrawListSharedData) SetTexUvLines(v *Vec4) {
+func (self DrawListSharedData) SetTexUvLines(v *Vec4) {
 	vArg, vFin := wrap[C.ImVec4, *Vec4](v)
 	defer vFin()
 
@@ -5685,7 +5685,7 @@ func (self DrawListSharedData) TexUvLines() *Vec4 {
 	return out
 }
 
-func (self *DrawListSplitter) SetCurrent(v int32) {
+func (self DrawListSplitter) SetCurrent(v int32) {
 	C.wrap_ImDrawListSplitter_Set_Current(self.handle(), C.int(v))
 }
 
@@ -5693,7 +5693,7 @@ func (self DrawListSplitter) Current() int {
 	return int(C.wrap_ImDrawListSplitter_Get_Current(self.handle()))
 }
 
-func (self *DrawListSplitter) SetCount(v int32) {
+func (self DrawListSplitter) SetCount(v int32) {
 	C.wrap_ImDrawListSplitter_Set_Count(self.handle(), C.int(v))
 }
 
@@ -5701,7 +5701,7 @@ func (self DrawListSplitter) Count() int {
 	return int(C.wrap_ImDrawListSplitter_Get_Count(self.handle()))
 }
 
-func (self *DrawVert) Setpos(v Vec2) {
+func (self DrawVert) Setpos(v Vec2) {
 	C.wrap_ImDrawVert_Setpos(self.handle(), v.toC())
 }
 
@@ -5711,7 +5711,7 @@ func (self DrawVert) pos() Vec2 {
 	return *out
 }
 
-func (self *DrawVert) Setuv(v Vec2) {
+func (self DrawVert) Setuv(v Vec2) {
 	C.wrap_ImDrawVert_Setuv(self.handle(), v.toC())
 }
 
@@ -5721,7 +5721,7 @@ func (self DrawVert) uv() Vec2 {
 	return *out
 }
 
-func (self *DrawVert) Setcol(v uint32) {
+func (self DrawVert) Setcol(v uint32) {
 	C.wrap_ImDrawVert_Setcol(self.handle(), C.ImU32(v))
 }
 
@@ -5729,7 +5729,7 @@ func (self DrawVert) col() uint32 {
 	return uint32(C.wrap_ImDrawVert_Getcol(self.handle()))
 }
 
-func (self *Font) SetFallbackAdvanceX(v float32) {
+func (self Font) SetFallbackAdvanceX(v float32) {
 	C.wrap_ImFont_SetFallbackAdvanceX(self.handle(), C.float(v))
 }
 
@@ -5737,7 +5737,7 @@ func (self Font) FallbackAdvanceX() float32 {
 	return float32(C.wrap_ImFont_GetFallbackAdvanceX(self.handle()))
 }
 
-func (self *Font) SetFontSize(v float32) {
+func (self Font) SetFontSize(v float32) {
 	C.wrap_ImFont_SetFontSize(self.handle(), C.float(v))
 }
 
@@ -5745,7 +5745,7 @@ func (self Font) FontSize() float32 {
 	return float32(C.wrap_ImFont_GetFontSize(self.handle()))
 }
 
-func (self *Font) SetFallbackGlyph(v FontGlyph) {
+func (self Font) SetFallbackGlyph(v FontGlyph) {
 	C.wrap_ImFont_SetFallbackGlyph(self.handle(), v.handle())
 }
 
@@ -5753,7 +5753,7 @@ func (self Font) FallbackGlyph() FontGlyph {
 	return (FontGlyph)(unsafe.Pointer(C.wrap_ImFont_GetFallbackGlyph(self.handle())))
 }
 
-func (self *Font) SetContainerAtlas(v FontAtlas) {
+func (self Font) SetContainerAtlas(v FontAtlas) {
 	C.wrap_ImFont_SetContainerAtlas(self.handle(), v.handle())
 }
 
@@ -5761,7 +5761,7 @@ func (self Font) ContainerAtlas() FontAtlas {
 	return (FontAtlas)(unsafe.Pointer(C.wrap_ImFont_GetContainerAtlas(self.handle())))
 }
 
-func (self *Font) SetConfigData(v FontConfig) {
+func (self Font) SetConfigData(v FontConfig) {
 	C.wrap_ImFont_SetConfigData(self.handle(), v.handle())
 }
 
@@ -5769,7 +5769,7 @@ func (self Font) ConfigData() FontConfig {
 	return (FontConfig)(unsafe.Pointer(C.wrap_ImFont_GetConfigData(self.handle())))
 }
 
-func (self *Font) SetConfigDataCount(v int) {
+func (self Font) SetConfigDataCount(v int) {
 	C.wrap_ImFont_SetConfigDataCount(self.handle(), C.short(v))
 }
 
@@ -5777,7 +5777,7 @@ func (self Font) ConfigDataCount() int {
 	return int(C.wrap_ImFont_GetConfigDataCount(self.handle()))
 }
 
-func (self *Font) SetFallbackChar(v Wchar) {
+func (self Font) SetFallbackChar(v Wchar) {
 	C.wrap_ImFont_SetFallbackChar(self.handle(), C.ImWchar(v))
 }
 
@@ -5785,7 +5785,7 @@ func (self Font) FallbackChar() Wchar {
 	return Wchar(C.wrap_ImFont_GetFallbackChar(self.handle()))
 }
 
-func (self *Font) SetEllipsisChar(v Wchar) {
+func (self Font) SetEllipsisChar(v Wchar) {
 	C.wrap_ImFont_SetEllipsisChar(self.handle(), C.ImWchar(v))
 }
 
@@ -5793,7 +5793,7 @@ func (self Font) EllipsisChar() Wchar {
 	return Wchar(C.wrap_ImFont_GetEllipsisChar(self.handle()))
 }
 
-func (self *Font) SetDotChar(v Wchar) {
+func (self Font) SetDotChar(v Wchar) {
 	C.wrap_ImFont_SetDotChar(self.handle(), C.ImWchar(v))
 }
 
@@ -5801,7 +5801,7 @@ func (self Font) DotChar() Wchar {
 	return Wchar(C.wrap_ImFont_GetDotChar(self.handle()))
 }
 
-func (self *Font) SetDirtyLookupTables(v bool) {
+func (self Font) SetDirtyLookupTables(v bool) {
 	C.wrap_ImFont_SetDirtyLookupTables(self.handle(), C.bool(v))
 }
 
@@ -5809,7 +5809,7 @@ func (self Font) DirtyLookupTables() bool {
 	return C.wrap_ImFont_GetDirtyLookupTables(self.handle()) == C.bool(true)
 }
 
-func (self *Font) SetScale(v float32) {
+func (self Font) SetScale(v float32) {
 	C.wrap_ImFont_SetScale(self.handle(), C.float(v))
 }
 
@@ -5817,7 +5817,7 @@ func (self Font) Scale() float32 {
 	return float32(C.wrap_ImFont_GetScale(self.handle()))
 }
 
-func (self *Font) SetAscent(v float32) {
+func (self Font) SetAscent(v float32) {
 	C.wrap_ImFont_SetAscent(self.handle(), C.float(v))
 }
 
@@ -5825,7 +5825,7 @@ func (self Font) Ascent() float32 {
 	return float32(C.wrap_ImFont_GetAscent(self.handle()))
 }
 
-func (self *Font) SetDescent(v float32) {
+func (self Font) SetDescent(v float32) {
 	C.wrap_ImFont_SetDescent(self.handle(), C.float(v))
 }
 
@@ -5833,7 +5833,7 @@ func (self Font) Descent() float32 {
 	return float32(C.wrap_ImFont_GetDescent(self.handle()))
 }
 
-func (self *Font) SetMetricsTotalSurface(v int32) {
+func (self Font) SetMetricsTotalSurface(v int32) {
 	C.wrap_ImFont_SetMetricsTotalSurface(self.handle(), C.int(v))
 }
 
@@ -5841,7 +5841,7 @@ func (self Font) MetricsTotalSurface() int {
 	return int(C.wrap_ImFont_GetMetricsTotalSurface(self.handle()))
 }
 
-func (self *FontAtlas) SetFlags(v FontAtlasFlags) {
+func (self FontAtlas) SetFlags(v FontAtlasFlags) {
 	C.wrap_ImFontAtlas_SetFlags(self.handle(), C.ImFontAtlasFlags(v))
 }
 
@@ -5849,7 +5849,7 @@ func (self FontAtlas) Flags() FontAtlasFlags {
 	return FontAtlasFlags(C.wrap_ImFontAtlas_GetFlags(self.handle()))
 }
 
-func (self *FontAtlas) SetTexDesiredWidth(v int32) {
+func (self FontAtlas) SetTexDesiredWidth(v int32) {
 	C.wrap_ImFontAtlas_SetTexDesiredWidth(self.handle(), C.int(v))
 }
 
@@ -5857,7 +5857,7 @@ func (self FontAtlas) TexDesiredWidth() int {
 	return int(C.wrap_ImFontAtlas_GetTexDesiredWidth(self.handle()))
 }
 
-func (self *FontAtlas) SetTexGlyphPadding(v int32) {
+func (self FontAtlas) SetTexGlyphPadding(v int32) {
 	C.wrap_ImFontAtlas_SetTexGlyphPadding(self.handle(), C.int(v))
 }
 
@@ -5865,7 +5865,7 @@ func (self FontAtlas) TexGlyphPadding() int {
 	return int(C.wrap_ImFontAtlas_GetTexGlyphPadding(self.handle()))
 }
 
-func (self *FontAtlas) SetLocked(v bool) {
+func (self FontAtlas) SetLocked(v bool) {
 	C.wrap_ImFontAtlas_SetLocked(self.handle(), C.bool(v))
 }
 
@@ -5873,7 +5873,7 @@ func (self FontAtlas) Locked() bool {
 	return C.wrap_ImFontAtlas_GetLocked(self.handle()) == C.bool(true)
 }
 
-func (self *FontAtlas) SetTexReady(v bool) {
+func (self FontAtlas) SetTexReady(v bool) {
 	C.wrap_ImFontAtlas_SetTexReady(self.handle(), C.bool(v))
 }
 
@@ -5881,7 +5881,7 @@ func (self FontAtlas) TexReady() bool {
 	return C.wrap_ImFontAtlas_GetTexReady(self.handle()) == C.bool(true)
 }
 
-func (self *FontAtlas) SetTexPixelsUseColors(v bool) {
+func (self FontAtlas) SetTexPixelsUseColors(v bool) {
 	C.wrap_ImFontAtlas_SetTexPixelsUseColors(self.handle(), C.bool(v))
 }
 
@@ -5889,14 +5889,14 @@ func (self FontAtlas) TexPixelsUseColors() bool {
 	return C.wrap_ImFontAtlas_GetTexPixelsUseColors(self.handle()) == C.bool(true)
 }
 
-func (self *FontAtlas) SetTexPixelsRGBA32(v *uint32) {
+func (self FontAtlas) SetTexPixelsRGBA32(v *uint32) {
 	vArg, vFin := wrapNumberPtr[C.uint, uint32](v)
 	defer vFin()
 
 	C.wrap_ImFontAtlas_SetTexPixelsRGBA32(self.handle(), vArg)
 }
 
-func (self *FontAtlas) SetTexWidth(v int32) {
+func (self FontAtlas) SetTexWidth(v int32) {
 	C.wrap_ImFontAtlas_SetTexWidth(self.handle(), C.int(v))
 }
 
@@ -5904,7 +5904,7 @@ func (self FontAtlas) TexWidth() int {
 	return int(C.wrap_ImFontAtlas_GetTexWidth(self.handle()))
 }
 
-func (self *FontAtlas) SetTexHeight(v int32) {
+func (self FontAtlas) SetTexHeight(v int32) {
 	C.wrap_ImFontAtlas_SetTexHeight(self.handle(), C.int(v))
 }
 
@@ -5912,7 +5912,7 @@ func (self FontAtlas) TexHeight() int {
 	return int(C.wrap_ImFontAtlas_GetTexHeight(self.handle()))
 }
 
-func (self *FontAtlas) SetTexUvScale(v Vec2) {
+func (self FontAtlas) SetTexUvScale(v Vec2) {
 	C.wrap_ImFontAtlas_SetTexUvScale(self.handle(), v.toC())
 }
 
@@ -5922,7 +5922,7 @@ func (self FontAtlas) TexUvScale() Vec2 {
 	return *out
 }
 
-func (self *FontAtlas) SetTexUvWhitePixel(v Vec2) {
+func (self FontAtlas) SetTexUvWhitePixel(v Vec2) {
 	C.wrap_ImFontAtlas_SetTexUvWhitePixel(self.handle(), v.toC())
 }
 
@@ -5932,7 +5932,7 @@ func (self FontAtlas) TexUvWhitePixel() Vec2 {
 	return *out
 }
 
-func (self *FontAtlas) SetFontBuilderIO(v FontBuilderIO) {
+func (self FontAtlas) SetFontBuilderIO(v FontBuilderIO) {
 	C.wrap_ImFontAtlas_SetFontBuilderIO(self.handle(), v.handle())
 }
 
@@ -5940,7 +5940,7 @@ func (self FontAtlas) FontBuilderIO() FontBuilderIO {
 	return (FontBuilderIO)(unsafe.Pointer(C.wrap_ImFontAtlas_GetFontBuilderIO(self.handle())))
 }
 
-func (self *FontAtlas) SetFontBuilderFlags(v uint32) {
+func (self FontAtlas) SetFontBuilderFlags(v uint32) {
 	C.wrap_ImFontAtlas_SetFontBuilderFlags(self.handle(), C.uint(v))
 }
 
@@ -5948,7 +5948,7 @@ func (self FontAtlas) FontBuilderFlags() uint32 {
 	return uint32(C.wrap_ImFontAtlas_GetFontBuilderFlags(self.handle()))
 }
 
-func (self *FontAtlas) SetPackIdMouseCursors(v int32) {
+func (self FontAtlas) SetPackIdMouseCursors(v int32) {
 	C.wrap_ImFontAtlas_SetPackIdMouseCursors(self.handle(), C.int(v))
 }
 
@@ -5956,7 +5956,7 @@ func (self FontAtlas) PackIdMouseCursors() int {
 	return int(C.wrap_ImFontAtlas_GetPackIdMouseCursors(self.handle()))
 }
 
-func (self *FontAtlas) SetPackIdLines(v int32) {
+func (self FontAtlas) SetPackIdLines(v int32) {
 	C.wrap_ImFontAtlas_SetPackIdLines(self.handle(), C.int(v))
 }
 
@@ -5964,23 +5964,23 @@ func (self FontAtlas) PackIdLines() int {
 	return int(C.wrap_ImFontAtlas_GetPackIdLines(self.handle()))
 }
 
-func (self *FontAtlasCustomRect) SetWidth(v uint) {
+func (self FontAtlasCustomRect) SetWidth(v uint) {
 	C.wrap_ImFontAtlasCustomRect_SetWidth(self.handle(), C.ushort(v))
 }
 
-func (self *FontAtlasCustomRect) SetHeight(v uint) {
+func (self FontAtlasCustomRect) SetHeight(v uint) {
 	C.wrap_ImFontAtlasCustomRect_SetHeight(self.handle(), C.ushort(v))
 }
 
-func (self *FontAtlasCustomRect) SetX(v uint) {
+func (self FontAtlasCustomRect) SetX(v uint) {
 	C.wrap_ImFontAtlasCustomRect_SetX(self.handle(), C.ushort(v))
 }
 
-func (self *FontAtlasCustomRect) SetY(v uint) {
+func (self FontAtlasCustomRect) SetY(v uint) {
 	C.wrap_ImFontAtlasCustomRect_SetY(self.handle(), C.ushort(v))
 }
 
-func (self *FontAtlasCustomRect) SetGlyphID(v uint32) {
+func (self FontAtlasCustomRect) SetGlyphID(v uint32) {
 	C.wrap_ImFontAtlasCustomRect_SetGlyphID(self.handle(), C.uint(v))
 }
 
@@ -5988,7 +5988,7 @@ func (self FontAtlasCustomRect) GlyphID() uint32 {
 	return uint32(C.wrap_ImFontAtlasCustomRect_GetGlyphID(self.handle()))
 }
 
-func (self *FontAtlasCustomRect) SetGlyphAdvanceX(v float32) {
+func (self FontAtlasCustomRect) SetGlyphAdvanceX(v float32) {
 	C.wrap_ImFontAtlasCustomRect_SetGlyphAdvanceX(self.handle(), C.float(v))
 }
 
@@ -5996,7 +5996,7 @@ func (self FontAtlasCustomRect) GlyphAdvanceX() float32 {
 	return float32(C.wrap_ImFontAtlasCustomRect_GetGlyphAdvanceX(self.handle()))
 }
 
-func (self *FontAtlasCustomRect) SetGlyphOffset(v Vec2) {
+func (self FontAtlasCustomRect) SetGlyphOffset(v Vec2) {
 	C.wrap_ImFontAtlasCustomRect_SetGlyphOffset(self.handle(), v.toC())
 }
 
@@ -6006,7 +6006,7 @@ func (self FontAtlasCustomRect) GlyphOffset() Vec2 {
 	return *out
 }
 
-func (self *FontAtlasCustomRect) SetFont(v Font) {
+func (self FontAtlasCustomRect) SetFont(v Font) {
 	C.wrap_ImFontAtlasCustomRect_SetFont(self.handle(), v.handle())
 }
 
@@ -6014,7 +6014,7 @@ func (self FontAtlasCustomRect) Font() Font {
 	return (Font)(unsafe.Pointer(C.wrap_ImFontAtlasCustomRect_GetFont(self.handle())))
 }
 
-func (self *FontConfig) SetFontData(v unsafe.Pointer) {
+func (self FontConfig) SetFontData(v unsafe.Pointer) {
 	C.wrap_ImFontConfig_SetFontData(self.handle(), (v))
 }
 
@@ -6022,7 +6022,7 @@ func (self FontConfig) FontData() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImFontConfig_GetFontData(self.handle()))
 }
 
-func (self *FontConfig) SetFontDataSize(v int32) {
+func (self FontConfig) SetFontDataSize(v int32) {
 	C.wrap_ImFontConfig_SetFontDataSize(self.handle(), C.int(v))
 }
 
@@ -6030,7 +6030,7 @@ func (self FontConfig) FontDataSize() int {
 	return int(C.wrap_ImFontConfig_GetFontDataSize(self.handle()))
 }
 
-func (self *FontConfig) SetFontDataOwnedByAtlas(v bool) {
+func (self FontConfig) SetFontDataOwnedByAtlas(v bool) {
 	C.wrap_ImFontConfig_SetFontDataOwnedByAtlas(self.handle(), C.bool(v))
 }
 
@@ -6038,7 +6038,7 @@ func (self FontConfig) FontDataOwnedByAtlas() bool {
 	return C.wrap_ImFontConfig_GetFontDataOwnedByAtlas(self.handle()) == C.bool(true)
 }
 
-func (self *FontConfig) SetFontNo(v int32) {
+func (self FontConfig) SetFontNo(v int32) {
 	C.wrap_ImFontConfig_SetFontNo(self.handle(), C.int(v))
 }
 
@@ -6046,7 +6046,7 @@ func (self FontConfig) FontNo() int {
 	return int(C.wrap_ImFontConfig_GetFontNo(self.handle()))
 }
 
-func (self *FontConfig) SetSizePixels(v float32) {
+func (self FontConfig) SetSizePixels(v float32) {
 	C.wrap_ImFontConfig_SetSizePixels(self.handle(), C.float(v))
 }
 
@@ -6054,7 +6054,7 @@ func (self FontConfig) SizePixels() float32 {
 	return float32(C.wrap_ImFontConfig_GetSizePixels(self.handle()))
 }
 
-func (self *FontConfig) SetOversampleH(v int32) {
+func (self FontConfig) SetOversampleH(v int32) {
 	C.wrap_ImFontConfig_SetOversampleH(self.handle(), C.int(v))
 }
 
@@ -6062,7 +6062,7 @@ func (self FontConfig) OversampleH() int {
 	return int(C.wrap_ImFontConfig_GetOversampleH(self.handle()))
 }
 
-func (self *FontConfig) SetOversampleV(v int32) {
+func (self FontConfig) SetOversampleV(v int32) {
 	C.wrap_ImFontConfig_SetOversampleV(self.handle(), C.int(v))
 }
 
@@ -6070,7 +6070,7 @@ func (self FontConfig) OversampleV() int {
 	return int(C.wrap_ImFontConfig_GetOversampleV(self.handle()))
 }
 
-func (self *FontConfig) SetPixelSnapH(v bool) {
+func (self FontConfig) SetPixelSnapH(v bool) {
 	C.wrap_ImFontConfig_SetPixelSnapH(self.handle(), C.bool(v))
 }
 
@@ -6078,7 +6078,7 @@ func (self FontConfig) PixelSnapH() bool {
 	return C.wrap_ImFontConfig_GetPixelSnapH(self.handle()) == C.bool(true)
 }
 
-func (self *FontConfig) SetGlyphExtraSpacing(v Vec2) {
+func (self FontConfig) SetGlyphExtraSpacing(v Vec2) {
 	C.wrap_ImFontConfig_SetGlyphExtraSpacing(self.handle(), v.toC())
 }
 
@@ -6088,7 +6088,7 @@ func (self FontConfig) GlyphExtraSpacing() Vec2 {
 	return *out
 }
 
-func (self *FontConfig) SetGlyphOffset(v Vec2) {
+func (self FontConfig) SetGlyphOffset(v Vec2) {
 	C.wrap_ImFontConfig_SetGlyphOffset(self.handle(), v.toC())
 }
 
@@ -6098,7 +6098,7 @@ func (self FontConfig) GlyphOffset() Vec2 {
 	return *out
 }
 
-func (self *FontConfig) SetGlyphRanges(v *Wchar) {
+func (self FontConfig) SetGlyphRanges(v *Wchar) {
 	C.wrap_ImFontConfig_SetGlyphRanges(self.handle(), (*C.ImWchar)(v))
 }
 
@@ -6106,7 +6106,7 @@ func (self FontConfig) GlyphRanges() *Wchar {
 	return (*Wchar)(C.wrap_ImFontConfig_GetGlyphRanges(self.handle()))
 }
 
-func (self *FontConfig) SetGlyphMinAdvanceX(v float32) {
+func (self FontConfig) SetGlyphMinAdvanceX(v float32) {
 	C.wrap_ImFontConfig_SetGlyphMinAdvanceX(self.handle(), C.float(v))
 }
 
@@ -6114,7 +6114,7 @@ func (self FontConfig) GlyphMinAdvanceX() float32 {
 	return float32(C.wrap_ImFontConfig_GetGlyphMinAdvanceX(self.handle()))
 }
 
-func (self *FontConfig) SetGlyphMaxAdvanceX(v float32) {
+func (self FontConfig) SetGlyphMaxAdvanceX(v float32) {
 	C.wrap_ImFontConfig_SetGlyphMaxAdvanceX(self.handle(), C.float(v))
 }
 
@@ -6122,7 +6122,7 @@ func (self FontConfig) GlyphMaxAdvanceX() float32 {
 	return float32(C.wrap_ImFontConfig_GetGlyphMaxAdvanceX(self.handle()))
 }
 
-func (self *FontConfig) SetMergeMode(v bool) {
+func (self FontConfig) SetMergeMode(v bool) {
 	C.wrap_ImFontConfig_SetMergeMode(self.handle(), C.bool(v))
 }
 
@@ -6130,7 +6130,7 @@ func (self FontConfig) MergeMode() bool {
 	return C.wrap_ImFontConfig_GetMergeMode(self.handle()) == C.bool(true)
 }
 
-func (self *FontConfig) SetFontBuilderFlags(v uint32) {
+func (self FontConfig) SetFontBuilderFlags(v uint32) {
 	C.wrap_ImFontConfig_SetFontBuilderFlags(self.handle(), C.uint(v))
 }
 
@@ -6138,7 +6138,7 @@ func (self FontConfig) FontBuilderFlags() uint32 {
 	return uint32(C.wrap_ImFontConfig_GetFontBuilderFlags(self.handle()))
 }
 
-func (self *FontConfig) SetRasterizerMultiply(v float32) {
+func (self FontConfig) SetRasterizerMultiply(v float32) {
 	C.wrap_ImFontConfig_SetRasterizerMultiply(self.handle(), C.float(v))
 }
 
@@ -6146,7 +6146,7 @@ func (self FontConfig) RasterizerMultiply() float32 {
 	return float32(C.wrap_ImFontConfig_GetRasterizerMultiply(self.handle()))
 }
 
-func (self *FontConfig) SetEllipsisChar(v Wchar) {
+func (self FontConfig) SetEllipsisChar(v Wchar) {
 	C.wrap_ImFontConfig_SetEllipsisChar(self.handle(), C.ImWchar(v))
 }
 
@@ -6154,7 +6154,7 @@ func (self FontConfig) EllipsisChar() Wchar {
 	return Wchar(C.wrap_ImFontConfig_GetEllipsisChar(self.handle()))
 }
 
-func (self *FontConfig) SetDstFont(v Font) {
+func (self FontConfig) SetDstFont(v Font) {
 	C.wrap_ImFontConfig_SetDstFont(self.handle(), v.handle())
 }
 
@@ -6162,7 +6162,7 @@ func (self FontConfig) DstFont() Font {
 	return (Font)(unsafe.Pointer(C.wrap_ImFontConfig_GetDstFont(self.handle())))
 }
 
-func (self *FontGlyph) SetColored(v uint32) {
+func (self FontGlyph) SetColored(v uint32) {
 	C.wrap_ImFontGlyph_SetColored(self.handle(), C.uint(v))
 }
 
@@ -6170,7 +6170,7 @@ func (self FontGlyph) Colored() uint32 {
 	return uint32(C.wrap_ImFontGlyph_GetColored(self.handle()))
 }
 
-func (self *FontGlyph) SetVisible(v uint32) {
+func (self FontGlyph) SetVisible(v uint32) {
 	C.wrap_ImFontGlyph_SetVisible(self.handle(), C.uint(v))
 }
 
@@ -6178,7 +6178,7 @@ func (self FontGlyph) Visible() uint32 {
 	return uint32(C.wrap_ImFontGlyph_GetVisible(self.handle()))
 }
 
-func (self *FontGlyph) SetCodepoint(v uint32) {
+func (self FontGlyph) SetCodepoint(v uint32) {
 	C.wrap_ImFontGlyph_SetCodepoint(self.handle(), C.uint(v))
 }
 
@@ -6186,7 +6186,7 @@ func (self FontGlyph) Codepoint() uint32 {
 	return uint32(C.wrap_ImFontGlyph_GetCodepoint(self.handle()))
 }
 
-func (self *FontGlyph) SetAdvanceX(v float32) {
+func (self FontGlyph) SetAdvanceX(v float32) {
 	C.wrap_ImFontGlyph_SetAdvanceX(self.handle(), C.float(v))
 }
 
@@ -6194,7 +6194,7 @@ func (self FontGlyph) AdvanceX() float32 {
 	return float32(C.wrap_ImFontGlyph_GetAdvanceX(self.handle()))
 }
 
-func (self *FontGlyph) SetX0(v float32) {
+func (self FontGlyph) SetX0(v float32) {
 	C.wrap_ImFontGlyph_SetX0(self.handle(), C.float(v))
 }
 
@@ -6202,7 +6202,7 @@ func (self FontGlyph) X0() float32 {
 	return float32(C.wrap_ImFontGlyph_GetX0(self.handle()))
 }
 
-func (self *FontGlyph) SetY0(v float32) {
+func (self FontGlyph) SetY0(v float32) {
 	C.wrap_ImFontGlyph_SetY0(self.handle(), C.float(v))
 }
 
@@ -6210,7 +6210,7 @@ func (self FontGlyph) Y0() float32 {
 	return float32(C.wrap_ImFontGlyph_GetY0(self.handle()))
 }
 
-func (self *FontGlyph) SetX1(v float32) {
+func (self FontGlyph) SetX1(v float32) {
 	C.wrap_ImFontGlyph_SetX1(self.handle(), C.float(v))
 }
 
@@ -6218,7 +6218,7 @@ func (self FontGlyph) X1() float32 {
 	return float32(C.wrap_ImFontGlyph_GetX1(self.handle()))
 }
 
-func (self *FontGlyph) SetY1(v float32) {
+func (self FontGlyph) SetY1(v float32) {
 	C.wrap_ImFontGlyph_SetY1(self.handle(), C.float(v))
 }
 
@@ -6226,7 +6226,7 @@ func (self FontGlyph) Y1() float32 {
 	return float32(C.wrap_ImFontGlyph_GetY1(self.handle()))
 }
 
-func (self *FontGlyph) SetU0(v float32) {
+func (self FontGlyph) SetU0(v float32) {
 	C.wrap_ImFontGlyph_SetU0(self.handle(), C.float(v))
 }
 
@@ -6234,7 +6234,7 @@ func (self FontGlyph) U0() float32 {
 	return float32(C.wrap_ImFontGlyph_GetU0(self.handle()))
 }
 
-func (self *FontGlyph) SetV0(v float32) {
+func (self FontGlyph) SetV0(v float32) {
 	C.wrap_ImFontGlyph_SetV0(self.handle(), C.float(v))
 }
 
@@ -6242,7 +6242,7 @@ func (self FontGlyph) V0() float32 {
 	return float32(C.wrap_ImFontGlyph_GetV0(self.handle()))
 }
 
-func (self *FontGlyph) SetU1(v float32) {
+func (self FontGlyph) SetU1(v float32) {
 	C.wrap_ImFontGlyph_SetU1(self.handle(), C.float(v))
 }
 
@@ -6250,7 +6250,7 @@ func (self FontGlyph) U1() float32 {
 	return float32(C.wrap_ImFontGlyph_GetU1(self.handle()))
 }
 
-func (self *FontGlyph) SetV1(v float32) {
+func (self FontGlyph) SetV1(v float32) {
 	C.wrap_ImFontGlyph_SetV1(self.handle(), C.float(v))
 }
 
@@ -6258,7 +6258,7 @@ func (self FontGlyph) V1() float32 {
 	return float32(C.wrap_ImFontGlyph_GetV1(self.handle()))
 }
 
-func (self *ColorMod) SetCol(v Col) {
+func (self ColorMod) SetCol(v Col) {
 	C.wrap_ImGuiColorMod_SetCol(self.handle(), C.ImGuiCol(v))
 }
 
@@ -6266,7 +6266,7 @@ func (self ColorMod) Col() Col {
 	return Col(C.wrap_ImGuiColorMod_GetCol(self.handle()))
 }
 
-func (self *ColorMod) SetBackupValue(v Vec4) {
+func (self ColorMod) SetBackupValue(v Vec4) {
 	C.wrap_ImGuiColorMod_SetBackupValue(self.handle(), v.toC())
 }
 
@@ -6276,7 +6276,7 @@ func (self ColorMod) BackupValue() Vec4 {
 	return *out
 }
 
-func (self *ComboPreviewData) SetPreviewRect(v Rect) {
+func (self ComboPreviewData) SetPreviewRect(v Rect) {
 	C.wrap_ImGuiComboPreviewData_SetPreviewRect(self.handle(), v.toC())
 }
 
@@ -6286,7 +6286,7 @@ func (self ComboPreviewData) PreviewRect() Rect {
 	return *out
 }
 
-func (self *ComboPreviewData) SetBackupCursorPos(v Vec2) {
+func (self ComboPreviewData) SetBackupCursorPos(v Vec2) {
 	C.wrap_ImGuiComboPreviewData_SetBackupCursorPos(self.handle(), v.toC())
 }
 
@@ -6296,7 +6296,7 @@ func (self ComboPreviewData) BackupCursorPos() Vec2 {
 	return *out
 }
 
-func (self *ComboPreviewData) SetBackupCursorMaxPos(v Vec2) {
+func (self ComboPreviewData) SetBackupCursorMaxPos(v Vec2) {
 	C.wrap_ImGuiComboPreviewData_SetBackupCursorMaxPos(self.handle(), v.toC())
 }
 
@@ -6306,7 +6306,7 @@ func (self ComboPreviewData) BackupCursorMaxPos() Vec2 {
 	return *out
 }
 
-func (self *ComboPreviewData) SetBackupCursorPosPrevLine(v Vec2) {
+func (self ComboPreviewData) SetBackupCursorPosPrevLine(v Vec2) {
 	C.wrap_ImGuiComboPreviewData_SetBackupCursorPosPrevLine(self.handle(), v.toC())
 }
 
@@ -6316,7 +6316,7 @@ func (self ComboPreviewData) BackupCursorPosPrevLine() Vec2 {
 	return *out
 }
 
-func (self *ComboPreviewData) SetBackupPrevLineTextBaseOffset(v float32) {
+func (self ComboPreviewData) SetBackupPrevLineTextBaseOffset(v float32) {
 	C.wrap_ImGuiComboPreviewData_SetBackupPrevLineTextBaseOffset(self.handle(), C.float(v))
 }
 
@@ -6324,7 +6324,7 @@ func (self ComboPreviewData) BackupPrevLineTextBaseOffset() float32 {
 	return float32(C.wrap_ImGuiComboPreviewData_GetBackupPrevLineTextBaseOffset(self.handle()))
 }
 
-func (self *ComboPreviewData) SetBackupLayout(v LayoutType) {
+func (self ComboPreviewData) SetBackupLayout(v LayoutType) {
 	C.wrap_ImGuiComboPreviewData_SetBackupLayout(self.handle(), C.ImGuiLayoutType(v))
 }
 
@@ -6332,7 +6332,7 @@ func (self ComboPreviewData) BackupLayout() LayoutType {
 	return LayoutType(C.wrap_ImGuiComboPreviewData_GetBackupLayout(self.handle()))
 }
 
-func (self *Context) SetInitialized(v bool) {
+func (self Context) SetInitialized(v bool) {
 	C.wrap_ImGuiContext_SetInitialized(self.handle(), C.bool(v))
 }
 
@@ -6340,7 +6340,7 @@ func (self Context) Initialized() bool {
 	return C.wrap_ImGuiContext_GetInitialized(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetFontAtlasOwnedByContext(v bool) {
+func (self Context) SetFontAtlasOwnedByContext(v bool) {
 	C.wrap_ImGuiContext_SetFontAtlasOwnedByContext(self.handle(), C.bool(v))
 }
 
@@ -6360,7 +6360,7 @@ func (self Context) Style() Style {
 	return newStyleFromC(C.wrap_ImGuiContext_GetStyle(self.handle()))
 }
 
-func (self *Context) SetConfigFlagsCurrFrame(v ConfigFlags) {
+func (self Context) SetConfigFlagsCurrFrame(v ConfigFlags) {
 	C.wrap_ImGuiContext_SetConfigFlagsCurrFrame(self.handle(), C.ImGuiConfigFlags(v))
 }
 
@@ -6368,7 +6368,7 @@ func (self Context) ConfigFlagsCurrFrame() ConfigFlags {
 	return ConfigFlags(C.wrap_ImGuiContext_GetConfigFlagsCurrFrame(self.handle()))
 }
 
-func (self *Context) SetConfigFlagsLastFrame(v ConfigFlags) {
+func (self Context) SetConfigFlagsLastFrame(v ConfigFlags) {
 	C.wrap_ImGuiContext_SetConfigFlagsLastFrame(self.handle(), C.ImGuiConfigFlags(v))
 }
 
@@ -6376,7 +6376,7 @@ func (self Context) ConfigFlagsLastFrame() ConfigFlags {
 	return ConfigFlags(C.wrap_ImGuiContext_GetConfigFlagsLastFrame(self.handle()))
 }
 
-func (self *Context) SetFont(v Font) {
+func (self Context) SetFont(v Font) {
 	C.wrap_ImGuiContext_SetFont(self.handle(), v.handle())
 }
 
@@ -6384,7 +6384,7 @@ func (self Context) Font() Font {
 	return (Font)(unsafe.Pointer(C.wrap_ImGuiContext_GetFont(self.handle())))
 }
 
-func (self *Context) SetFontSize(v float32) {
+func (self Context) SetFontSize(v float32) {
 	C.wrap_ImGuiContext_SetFontSize(self.handle(), C.float(v))
 }
 
@@ -6392,7 +6392,7 @@ func (self Context) FontSize() float32 {
 	return float32(C.wrap_ImGuiContext_GetFontSize(self.handle()))
 }
 
-func (self *Context) SetFontBaseSize(v float32) {
+func (self Context) SetFontBaseSize(v float32) {
 	C.wrap_ImGuiContext_SetFontBaseSize(self.handle(), C.float(v))
 }
 
@@ -6404,7 +6404,7 @@ func (self Context) DrawListSharedData() DrawListSharedData {
 	return newDrawListSharedDataFromC(C.wrap_ImGuiContext_GetDrawListSharedData(self.handle()))
 }
 
-func (self *Context) SetTime(v float64) {
+func (self Context) SetTime(v float64) {
 	C.wrap_ImGuiContext_SetTime(self.handle(), C.double(v))
 }
 
@@ -6412,7 +6412,7 @@ func (self Context) Time() float64 {
 	return float64(C.wrap_ImGuiContext_GetTime(self.handle()))
 }
 
-func (self *Context) SetFrameCount(v int32) {
+func (self Context) SetFrameCount(v int32) {
 	C.wrap_ImGuiContext_SetFrameCount(self.handle(), C.int(v))
 }
 
@@ -6420,7 +6420,7 @@ func (self Context) FrameCount() int {
 	return int(C.wrap_ImGuiContext_GetFrameCount(self.handle()))
 }
 
-func (self *Context) SetFrameCountEnded(v int32) {
+func (self Context) SetFrameCountEnded(v int32) {
 	C.wrap_ImGuiContext_SetFrameCountEnded(self.handle(), C.int(v))
 }
 
@@ -6428,7 +6428,7 @@ func (self Context) FrameCountEnded() int {
 	return int(C.wrap_ImGuiContext_GetFrameCountEnded(self.handle()))
 }
 
-func (self *Context) SetFrameCountPlatformEnded(v int32) {
+func (self Context) SetFrameCountPlatformEnded(v int32) {
 	C.wrap_ImGuiContext_SetFrameCountPlatformEnded(self.handle(), C.int(v))
 }
 
@@ -6436,7 +6436,7 @@ func (self Context) FrameCountPlatformEnded() int {
 	return int(C.wrap_ImGuiContext_GetFrameCountPlatformEnded(self.handle()))
 }
 
-func (self *Context) SetFrameCountRendered(v int32) {
+func (self Context) SetFrameCountRendered(v int32) {
 	C.wrap_ImGuiContext_SetFrameCountRendered(self.handle(), C.int(v))
 }
 
@@ -6444,7 +6444,7 @@ func (self Context) FrameCountRendered() int {
 	return int(C.wrap_ImGuiContext_GetFrameCountRendered(self.handle()))
 }
 
-func (self *Context) SetWithinFrameScope(v bool) {
+func (self Context) SetWithinFrameScope(v bool) {
 	C.wrap_ImGuiContext_SetWithinFrameScope(self.handle(), C.bool(v))
 }
 
@@ -6452,7 +6452,7 @@ func (self Context) WithinFrameScope() bool {
 	return C.wrap_ImGuiContext_GetWithinFrameScope(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetWithinFrameScopeWithImplicitWindow(v bool) {
+func (self Context) SetWithinFrameScopeWithImplicitWindow(v bool) {
 	C.wrap_ImGuiContext_SetWithinFrameScopeWithImplicitWindow(self.handle(), C.bool(v))
 }
 
@@ -6460,7 +6460,7 @@ func (self Context) WithinFrameScopeWithImplicitWindow() bool {
 	return C.wrap_ImGuiContext_GetWithinFrameScopeWithImplicitWindow(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetWithinEndChild(v bool) {
+func (self Context) SetWithinEndChild(v bool) {
 	C.wrap_ImGuiContext_SetWithinEndChild(self.handle(), C.bool(v))
 }
 
@@ -6468,7 +6468,7 @@ func (self Context) WithinEndChild() bool {
 	return C.wrap_ImGuiContext_GetWithinEndChild(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetGcCompactAll(v bool) {
+func (self Context) SetGcCompactAll(v bool) {
 	C.wrap_ImGuiContext_SetGcCompactAll(self.handle(), C.bool(v))
 }
 
@@ -6476,7 +6476,7 @@ func (self Context) GcCompactAll() bool {
 	return C.wrap_ImGuiContext_GetGcCompactAll(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetTestEngineHookItems(v bool) {
+func (self Context) SetTestEngineHookItems(v bool) {
 	C.wrap_ImGuiContext_SetTestEngineHookItems(self.handle(), C.bool(v))
 }
 
@@ -6484,7 +6484,7 @@ func (self Context) TestEngineHookItems() bool {
 	return C.wrap_ImGuiContext_GetTestEngineHookItems(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetTestEngine(v unsafe.Pointer) {
+func (self Context) SetTestEngine(v unsafe.Pointer) {
 	C.wrap_ImGuiContext_SetTestEngine(self.handle(), (v))
 }
 
@@ -6496,7 +6496,7 @@ func (self Context) WindowsById() Storage {
 	return newStorageFromC(C.wrap_ImGuiContext_GetWindowsById(self.handle()))
 }
 
-func (self *Context) SetWindowsActiveCount(v int32) {
+func (self Context) SetWindowsActiveCount(v int32) {
 	C.wrap_ImGuiContext_SetWindowsActiveCount(self.handle(), C.int(v))
 }
 
@@ -6504,7 +6504,7 @@ func (self Context) WindowsActiveCount() int {
 	return int(C.wrap_ImGuiContext_GetWindowsActiveCount(self.handle()))
 }
 
-func (self *Context) SetWindowsHoverPadding(v Vec2) {
+func (self Context) SetWindowsHoverPadding(v Vec2) {
 	C.wrap_ImGuiContext_SetWindowsHoverPadding(self.handle(), v.toC())
 }
 
@@ -6514,7 +6514,7 @@ func (self Context) WindowsHoverPadding() Vec2 {
 	return *out
 }
 
-func (self *Context) SetCurrentWindow(v Window) {
+func (self Context) SetCurrentWindow(v Window) {
 	C.wrap_ImGuiContext_SetCurrentWindow(self.handle(), v.handle())
 }
 
@@ -6522,7 +6522,7 @@ func (self Context) CurrentWindow() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiContext_GetCurrentWindow(self.handle())))
 }
 
-func (self *Context) SetHoveredWindow(v Window) {
+func (self Context) SetHoveredWindow(v Window) {
 	C.wrap_ImGuiContext_SetHoveredWindow(self.handle(), v.handle())
 }
 
@@ -6530,7 +6530,7 @@ func (self Context) HoveredWindow() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiContext_GetHoveredWindow(self.handle())))
 }
 
-func (self *Context) SetHoveredWindowUnderMovingWindow(v Window) {
+func (self Context) SetHoveredWindowUnderMovingWindow(v Window) {
 	C.wrap_ImGuiContext_SetHoveredWindowUnderMovingWindow(self.handle(), v.handle())
 }
 
@@ -6538,7 +6538,7 @@ func (self Context) HoveredWindowUnderMovingWindow() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiContext_GetHoveredWindowUnderMovingWindow(self.handle())))
 }
 
-func (self *Context) SetMovingWindow(v Window) {
+func (self Context) SetMovingWindow(v Window) {
 	C.wrap_ImGuiContext_SetMovingWindow(self.handle(), v.handle())
 }
 
@@ -6546,7 +6546,7 @@ func (self Context) MovingWindow() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiContext_GetMovingWindow(self.handle())))
 }
 
-func (self *Context) SetWheelingWindow(v Window) {
+func (self Context) SetWheelingWindow(v Window) {
 	C.wrap_ImGuiContext_SetWheelingWindow(self.handle(), v.handle())
 }
 
@@ -6554,7 +6554,7 @@ func (self Context) WheelingWindow() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiContext_GetWheelingWindow(self.handle())))
 }
 
-func (self *Context) SetWheelingWindowRefMousePos(v Vec2) {
+func (self Context) SetWheelingWindowRefMousePos(v Vec2) {
 	C.wrap_ImGuiContext_SetWheelingWindowRefMousePos(self.handle(), v.toC())
 }
 
@@ -6564,7 +6564,7 @@ func (self Context) WheelingWindowRefMousePos() Vec2 {
 	return *out
 }
 
-func (self *Context) SetWheelingWindowTimer(v float32) {
+func (self Context) SetWheelingWindowTimer(v float32) {
 	C.wrap_ImGuiContext_SetWheelingWindowTimer(self.handle(), C.float(v))
 }
 
@@ -6572,7 +6572,7 @@ func (self Context) WheelingWindowTimer() float32 {
 	return float32(C.wrap_ImGuiContext_GetWheelingWindowTimer(self.handle()))
 }
 
-func (self *Context) SetDebugHookIdInfo(v ID) {
+func (self Context) SetDebugHookIdInfo(v ID) {
 	C.wrap_ImGuiContext_SetDebugHookIdInfo(self.handle(), C.ImGuiID(v))
 }
 
@@ -6580,7 +6580,7 @@ func (self Context) DebugHookIdInfo() ID {
 	return ID(C.wrap_ImGuiContext_GetDebugHookIdInfo(self.handle()))
 }
 
-func (self *Context) SetHoveredId(v ID) {
+func (self Context) SetHoveredId(v ID) {
 	C.wrap_ImGuiContext_SetHoveredId(self.handle(), C.ImGuiID(v))
 }
 
@@ -6588,7 +6588,7 @@ func (self Context) HoveredId() ID {
 	return ID(C.wrap_ImGuiContext_GetHoveredId(self.handle()))
 }
 
-func (self *Context) SetHoveredIdPreviousFrame(v ID) {
+func (self Context) SetHoveredIdPreviousFrame(v ID) {
 	C.wrap_ImGuiContext_SetHoveredIdPreviousFrame(self.handle(), C.ImGuiID(v))
 }
 
@@ -6596,7 +6596,7 @@ func (self Context) HoveredIdPreviousFrame() ID {
 	return ID(C.wrap_ImGuiContext_GetHoveredIdPreviousFrame(self.handle()))
 }
 
-func (self *Context) SetHoveredIdAllowOverlap(v bool) {
+func (self Context) SetHoveredIdAllowOverlap(v bool) {
 	C.wrap_ImGuiContext_SetHoveredIdAllowOverlap(self.handle(), C.bool(v))
 }
 
@@ -6604,7 +6604,7 @@ func (self Context) HoveredIdAllowOverlap() bool {
 	return C.wrap_ImGuiContext_GetHoveredIdAllowOverlap(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetHoveredIdUsingMouseWheel(v bool) {
+func (self Context) SetHoveredIdUsingMouseWheel(v bool) {
 	C.wrap_ImGuiContext_SetHoveredIdUsingMouseWheel(self.handle(), C.bool(v))
 }
 
@@ -6612,7 +6612,7 @@ func (self Context) HoveredIdUsingMouseWheel() bool {
 	return C.wrap_ImGuiContext_GetHoveredIdUsingMouseWheel(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetHoveredIdPreviousFrameUsingMouseWheel(v bool) {
+func (self Context) SetHoveredIdPreviousFrameUsingMouseWheel(v bool) {
 	C.wrap_ImGuiContext_SetHoveredIdPreviousFrameUsingMouseWheel(self.handle(), C.bool(v))
 }
 
@@ -6620,7 +6620,7 @@ func (self Context) HoveredIdPreviousFrameUsingMouseWheel() bool {
 	return C.wrap_ImGuiContext_GetHoveredIdPreviousFrameUsingMouseWheel(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetHoveredIdDisabled(v bool) {
+func (self Context) SetHoveredIdDisabled(v bool) {
 	C.wrap_ImGuiContext_SetHoveredIdDisabled(self.handle(), C.bool(v))
 }
 
@@ -6628,7 +6628,7 @@ func (self Context) HoveredIdDisabled() bool {
 	return C.wrap_ImGuiContext_GetHoveredIdDisabled(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetHoveredIdTimer(v float32) {
+func (self Context) SetHoveredIdTimer(v float32) {
 	C.wrap_ImGuiContext_SetHoveredIdTimer(self.handle(), C.float(v))
 }
 
@@ -6636,7 +6636,7 @@ func (self Context) HoveredIdTimer() float32 {
 	return float32(C.wrap_ImGuiContext_GetHoveredIdTimer(self.handle()))
 }
 
-func (self *Context) SetHoveredIdNotActiveTimer(v float32) {
+func (self Context) SetHoveredIdNotActiveTimer(v float32) {
 	C.wrap_ImGuiContext_SetHoveredIdNotActiveTimer(self.handle(), C.float(v))
 }
 
@@ -6644,7 +6644,7 @@ func (self Context) HoveredIdNotActiveTimer() float32 {
 	return float32(C.wrap_ImGuiContext_GetHoveredIdNotActiveTimer(self.handle()))
 }
 
-func (self *Context) SetActiveId(v ID) {
+func (self Context) SetActiveId(v ID) {
 	C.wrap_ImGuiContext_SetActiveId(self.handle(), C.ImGuiID(v))
 }
 
@@ -6652,7 +6652,7 @@ func (self Context) ActiveId() ID {
 	return ID(C.wrap_ImGuiContext_GetActiveId(self.handle()))
 }
 
-func (self *Context) SetActiveIdIsAlive(v ID) {
+func (self Context) SetActiveIdIsAlive(v ID) {
 	C.wrap_ImGuiContext_SetActiveIdIsAlive(self.handle(), C.ImGuiID(v))
 }
 
@@ -6660,7 +6660,7 @@ func (self Context) ActiveIdIsAlive() ID {
 	return ID(C.wrap_ImGuiContext_GetActiveIdIsAlive(self.handle()))
 }
 
-func (self *Context) SetActiveIdTimer(v float32) {
+func (self Context) SetActiveIdTimer(v float32) {
 	C.wrap_ImGuiContext_SetActiveIdTimer(self.handle(), C.float(v))
 }
 
@@ -6668,7 +6668,7 @@ func (self Context) ActiveIdTimer() float32 {
 	return float32(C.wrap_ImGuiContext_GetActiveIdTimer(self.handle()))
 }
 
-func (self *Context) SetActiveIdIsJustActivated(v bool) {
+func (self Context) SetActiveIdIsJustActivated(v bool) {
 	C.wrap_ImGuiContext_SetActiveIdIsJustActivated(self.handle(), C.bool(v))
 }
 
@@ -6676,7 +6676,7 @@ func (self Context) ActiveIdIsJustActivated() bool {
 	return C.wrap_ImGuiContext_GetActiveIdIsJustActivated(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetActiveIdAllowOverlap(v bool) {
+func (self Context) SetActiveIdAllowOverlap(v bool) {
 	C.wrap_ImGuiContext_SetActiveIdAllowOverlap(self.handle(), C.bool(v))
 }
 
@@ -6684,7 +6684,7 @@ func (self Context) ActiveIdAllowOverlap() bool {
 	return C.wrap_ImGuiContext_GetActiveIdAllowOverlap(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetActiveIdNoClearOnFocusLoss(v bool) {
+func (self Context) SetActiveIdNoClearOnFocusLoss(v bool) {
 	C.wrap_ImGuiContext_SetActiveIdNoClearOnFocusLoss(self.handle(), C.bool(v))
 }
 
@@ -6692,7 +6692,7 @@ func (self Context) ActiveIdNoClearOnFocusLoss() bool {
 	return C.wrap_ImGuiContext_GetActiveIdNoClearOnFocusLoss(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetActiveIdHasBeenPressedBefore(v bool) {
+func (self Context) SetActiveIdHasBeenPressedBefore(v bool) {
 	C.wrap_ImGuiContext_SetActiveIdHasBeenPressedBefore(self.handle(), C.bool(v))
 }
 
@@ -6700,7 +6700,7 @@ func (self Context) ActiveIdHasBeenPressedBefore() bool {
 	return C.wrap_ImGuiContext_GetActiveIdHasBeenPressedBefore(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetActiveIdHasBeenEditedBefore(v bool) {
+func (self Context) SetActiveIdHasBeenEditedBefore(v bool) {
 	C.wrap_ImGuiContext_SetActiveIdHasBeenEditedBefore(self.handle(), C.bool(v))
 }
 
@@ -6708,7 +6708,7 @@ func (self Context) ActiveIdHasBeenEditedBefore() bool {
 	return C.wrap_ImGuiContext_GetActiveIdHasBeenEditedBefore(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetActiveIdHasBeenEditedThisFrame(v bool) {
+func (self Context) SetActiveIdHasBeenEditedThisFrame(v bool) {
 	C.wrap_ImGuiContext_SetActiveIdHasBeenEditedThisFrame(self.handle(), C.bool(v))
 }
 
@@ -6716,7 +6716,7 @@ func (self Context) ActiveIdHasBeenEditedThisFrame() bool {
 	return C.wrap_ImGuiContext_GetActiveIdHasBeenEditedThisFrame(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetActiveIdClickOffset(v Vec2) {
+func (self Context) SetActiveIdClickOffset(v Vec2) {
 	C.wrap_ImGuiContext_SetActiveIdClickOffset(self.handle(), v.toC())
 }
 
@@ -6726,7 +6726,7 @@ func (self Context) ActiveIdClickOffset() Vec2 {
 	return *out
 }
 
-func (self *Context) SetActiveIdWindow(v Window) {
+func (self Context) SetActiveIdWindow(v Window) {
 	C.wrap_ImGuiContext_SetActiveIdWindow(self.handle(), v.handle())
 }
 
@@ -6734,7 +6734,7 @@ func (self Context) ActiveIdWindow() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiContext_GetActiveIdWindow(self.handle())))
 }
 
-func (self *Context) SetActiveIdSource(v InputSource) {
+func (self Context) SetActiveIdSource(v InputSource) {
 	C.wrap_ImGuiContext_SetActiveIdSource(self.handle(), C.ImGuiInputSource(v))
 }
 
@@ -6742,7 +6742,7 @@ func (self Context) ActiveIdSource() InputSource {
 	return InputSource(C.wrap_ImGuiContext_GetActiveIdSource(self.handle()))
 }
 
-func (self *Context) SetActiveIdMouseButton(v int32) {
+func (self Context) SetActiveIdMouseButton(v int32) {
 	C.wrap_ImGuiContext_SetActiveIdMouseButton(self.handle(), C.int(v))
 }
 
@@ -6750,7 +6750,7 @@ func (self Context) ActiveIdMouseButton() int {
 	return int(C.wrap_ImGuiContext_GetActiveIdMouseButton(self.handle()))
 }
 
-func (self *Context) SetActiveIdPreviousFrame(v ID) {
+func (self Context) SetActiveIdPreviousFrame(v ID) {
 	C.wrap_ImGuiContext_SetActiveIdPreviousFrame(self.handle(), C.ImGuiID(v))
 }
 
@@ -6758,7 +6758,7 @@ func (self Context) ActiveIdPreviousFrame() ID {
 	return ID(C.wrap_ImGuiContext_GetActiveIdPreviousFrame(self.handle()))
 }
 
-func (self *Context) SetActiveIdPreviousFrameIsAlive(v bool) {
+func (self Context) SetActiveIdPreviousFrameIsAlive(v bool) {
 	C.wrap_ImGuiContext_SetActiveIdPreviousFrameIsAlive(self.handle(), C.bool(v))
 }
 
@@ -6766,7 +6766,7 @@ func (self Context) ActiveIdPreviousFrameIsAlive() bool {
 	return C.wrap_ImGuiContext_GetActiveIdPreviousFrameIsAlive(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetActiveIdPreviousFrameHasBeenEditedBefore(v bool) {
+func (self Context) SetActiveIdPreviousFrameHasBeenEditedBefore(v bool) {
 	C.wrap_ImGuiContext_SetActiveIdPreviousFrameHasBeenEditedBefore(self.handle(), C.bool(v))
 }
 
@@ -6774,7 +6774,7 @@ func (self Context) ActiveIdPreviousFrameHasBeenEditedBefore() bool {
 	return C.wrap_ImGuiContext_GetActiveIdPreviousFrameHasBeenEditedBefore(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetActiveIdPreviousFrameWindow(v Window) {
+func (self Context) SetActiveIdPreviousFrameWindow(v Window) {
 	C.wrap_ImGuiContext_SetActiveIdPreviousFrameWindow(self.handle(), v.handle())
 }
 
@@ -6782,7 +6782,7 @@ func (self Context) ActiveIdPreviousFrameWindow() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiContext_GetActiveIdPreviousFrameWindow(self.handle())))
 }
 
-func (self *Context) SetLastActiveId(v ID) {
+func (self Context) SetLastActiveId(v ID) {
 	C.wrap_ImGuiContext_SetLastActiveId(self.handle(), C.ImGuiID(v))
 }
 
@@ -6790,7 +6790,7 @@ func (self Context) LastActiveId() ID {
 	return ID(C.wrap_ImGuiContext_GetLastActiveId(self.handle()))
 }
 
-func (self *Context) SetLastActiveIdTimer(v float32) {
+func (self Context) SetLastActiveIdTimer(v float32) {
 	C.wrap_ImGuiContext_SetLastActiveIdTimer(self.handle(), C.float(v))
 }
 
@@ -6798,7 +6798,7 @@ func (self Context) LastActiveIdTimer() float32 {
 	return float32(C.wrap_ImGuiContext_GetLastActiveIdTimer(self.handle()))
 }
 
-func (self *Context) SetActiveIdUsingNavDirMask(v uint32) {
+func (self Context) SetActiveIdUsingNavDirMask(v uint32) {
 	C.wrap_ImGuiContext_SetActiveIdUsingNavDirMask(self.handle(), C.ImU32(v))
 }
 
@@ -6806,7 +6806,7 @@ func (self Context) ActiveIdUsingNavDirMask() uint32 {
 	return uint32(C.wrap_ImGuiContext_GetActiveIdUsingNavDirMask(self.handle()))
 }
 
-func (self *Context) SetActiveIdUsingNavInputMask(v uint32) {
+func (self Context) SetActiveIdUsingNavInputMask(v uint32) {
 	C.wrap_ImGuiContext_SetActiveIdUsingNavInputMask(self.handle(), C.ImU32(v))
 }
 
@@ -6814,7 +6814,7 @@ func (self Context) ActiveIdUsingNavInputMask() uint32 {
 	return uint32(C.wrap_ImGuiContext_GetActiveIdUsingNavInputMask(self.handle()))
 }
 
-func (self *Context) SetCurrentItemFlags(v ItemFlags) {
+func (self Context) SetCurrentItemFlags(v ItemFlags) {
 	C.wrap_ImGuiContext_SetCurrentItemFlags(self.handle(), C.ImGuiItemFlags(v))
 }
 
@@ -6834,7 +6834,7 @@ func (self Context) NextWindowData() NextWindowData {
 	return newNextWindowDataFromC(C.wrap_ImGuiContext_GetNextWindowData(self.handle()))
 }
 
-func (self *Context) SetBeginMenuCount(v int32) {
+func (self Context) SetBeginMenuCount(v int32) {
 	C.wrap_ImGuiContext_SetBeginMenuCount(self.handle(), C.int(v))
 }
 
@@ -6842,7 +6842,7 @@ func (self Context) BeginMenuCount() int {
 	return int(C.wrap_ImGuiContext_GetBeginMenuCount(self.handle()))
 }
 
-func (self *Context) SetCurrentDpiScale(v float32) {
+func (self Context) SetCurrentDpiScale(v float32) {
 	C.wrap_ImGuiContext_SetCurrentDpiScale(self.handle(), C.float(v))
 }
 
@@ -6850,7 +6850,7 @@ func (self Context) CurrentDpiScale() float32 {
 	return float32(C.wrap_ImGuiContext_GetCurrentDpiScale(self.handle()))
 }
 
-func (self *Context) SetCurrentViewport(v ViewportP) {
+func (self Context) SetCurrentViewport(v ViewportP) {
 	C.wrap_ImGuiContext_SetCurrentViewport(self.handle(), v.handle())
 }
 
@@ -6858,7 +6858,7 @@ func (self Context) CurrentViewport() ViewportP {
 	return (ViewportP)(unsafe.Pointer(C.wrap_ImGuiContext_GetCurrentViewport(self.handle())))
 }
 
-func (self *Context) SetMouseViewport(v ViewportP) {
+func (self Context) SetMouseViewport(v ViewportP) {
 	C.wrap_ImGuiContext_SetMouseViewport(self.handle(), v.handle())
 }
 
@@ -6866,7 +6866,7 @@ func (self Context) MouseViewport() ViewportP {
 	return (ViewportP)(unsafe.Pointer(C.wrap_ImGuiContext_GetMouseViewport(self.handle())))
 }
 
-func (self *Context) SetMouseLastHoveredViewport(v ViewportP) {
+func (self Context) SetMouseLastHoveredViewport(v ViewportP) {
 	C.wrap_ImGuiContext_SetMouseLastHoveredViewport(self.handle(), v.handle())
 }
 
@@ -6874,7 +6874,7 @@ func (self Context) MouseLastHoveredViewport() ViewportP {
 	return (ViewportP)(unsafe.Pointer(C.wrap_ImGuiContext_GetMouseLastHoveredViewport(self.handle())))
 }
 
-func (self *Context) SetPlatformLastFocusedViewportId(v ID) {
+func (self Context) SetPlatformLastFocusedViewportId(v ID) {
 	C.wrap_ImGuiContext_SetPlatformLastFocusedViewportId(self.handle(), C.ImGuiID(v))
 }
 
@@ -6886,7 +6886,7 @@ func (self Context) FallbackMonitor() PlatformMonitor {
 	return newPlatformMonitorFromC(C.wrap_ImGuiContext_GetFallbackMonitor(self.handle()))
 }
 
-func (self *Context) SetViewportFrontMostStampCount(v int32) {
+func (self Context) SetViewportFrontMostStampCount(v int32) {
 	C.wrap_ImGuiContext_SetViewportFrontMostStampCount(self.handle(), C.int(v))
 }
 
@@ -6894,7 +6894,7 @@ func (self Context) ViewportFrontMostStampCount() int {
 	return int(C.wrap_ImGuiContext_GetViewportFrontMostStampCount(self.handle()))
 }
 
-func (self *Context) SetNavWindow(v Window) {
+func (self Context) SetNavWindow(v Window) {
 	C.wrap_ImGuiContext_SetNavWindow(self.handle(), v.handle())
 }
 
@@ -6902,7 +6902,7 @@ func (self Context) NavWindow() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiContext_GetNavWindow(self.handle())))
 }
 
-func (self *Context) SetNavId(v ID) {
+func (self Context) SetNavId(v ID) {
 	C.wrap_ImGuiContext_SetNavId(self.handle(), C.ImGuiID(v))
 }
 
@@ -6910,7 +6910,7 @@ func (self Context) NavId() ID {
 	return ID(C.wrap_ImGuiContext_GetNavId(self.handle()))
 }
 
-func (self *Context) SetNavFocusScopeId(v ID) {
+func (self Context) SetNavFocusScopeId(v ID) {
 	C.wrap_ImGuiContext_SetNavFocusScopeId(self.handle(), C.ImGuiID(v))
 }
 
@@ -6918,7 +6918,7 @@ func (self Context) NavFocusScopeId() ID {
 	return ID(C.wrap_ImGuiContext_GetNavFocusScopeId(self.handle()))
 }
 
-func (self *Context) SetNavActivateId(v ID) {
+func (self Context) SetNavActivateId(v ID) {
 	C.wrap_ImGuiContext_SetNavActivateId(self.handle(), C.ImGuiID(v))
 }
 
@@ -6926,7 +6926,7 @@ func (self Context) NavActivateId() ID {
 	return ID(C.wrap_ImGuiContext_GetNavActivateId(self.handle()))
 }
 
-func (self *Context) SetNavActivateDownId(v ID) {
+func (self Context) SetNavActivateDownId(v ID) {
 	C.wrap_ImGuiContext_SetNavActivateDownId(self.handle(), C.ImGuiID(v))
 }
 
@@ -6934,7 +6934,7 @@ func (self Context) NavActivateDownId() ID {
 	return ID(C.wrap_ImGuiContext_GetNavActivateDownId(self.handle()))
 }
 
-func (self *Context) SetNavActivatePressedId(v ID) {
+func (self Context) SetNavActivatePressedId(v ID) {
 	C.wrap_ImGuiContext_SetNavActivatePressedId(self.handle(), C.ImGuiID(v))
 }
 
@@ -6942,7 +6942,7 @@ func (self Context) NavActivatePressedId() ID {
 	return ID(C.wrap_ImGuiContext_GetNavActivatePressedId(self.handle()))
 }
 
-func (self *Context) SetNavActivateInputId(v ID) {
+func (self Context) SetNavActivateInputId(v ID) {
 	C.wrap_ImGuiContext_SetNavActivateInputId(self.handle(), C.ImGuiID(v))
 }
 
@@ -6950,7 +6950,7 @@ func (self Context) NavActivateInputId() ID {
 	return ID(C.wrap_ImGuiContext_GetNavActivateInputId(self.handle()))
 }
 
-func (self *Context) SetNavActivateFlags(v ActivateFlags) {
+func (self Context) SetNavActivateFlags(v ActivateFlags) {
 	C.wrap_ImGuiContext_SetNavActivateFlags(self.handle(), C.ImGuiActivateFlags(v))
 }
 
@@ -6958,7 +6958,7 @@ func (self Context) NavActivateFlags() ActivateFlags {
 	return ActivateFlags(C.wrap_ImGuiContext_GetNavActivateFlags(self.handle()))
 }
 
-func (self *Context) SetNavJustMovedToId(v ID) {
+func (self Context) SetNavJustMovedToId(v ID) {
 	C.wrap_ImGuiContext_SetNavJustMovedToId(self.handle(), C.ImGuiID(v))
 }
 
@@ -6966,7 +6966,7 @@ func (self Context) NavJustMovedToId() ID {
 	return ID(C.wrap_ImGuiContext_GetNavJustMovedToId(self.handle()))
 }
 
-func (self *Context) SetNavJustMovedToFocusScopeId(v ID) {
+func (self Context) SetNavJustMovedToFocusScopeId(v ID) {
 	C.wrap_ImGuiContext_SetNavJustMovedToFocusScopeId(self.handle(), C.ImGuiID(v))
 }
 
@@ -6974,7 +6974,7 @@ func (self Context) NavJustMovedToFocusScopeId() ID {
 	return ID(C.wrap_ImGuiContext_GetNavJustMovedToFocusScopeId(self.handle()))
 }
 
-func (self *Context) SetNavJustMovedToKeyMods(v ModFlags) {
+func (self Context) SetNavJustMovedToKeyMods(v ModFlags) {
 	C.wrap_ImGuiContext_SetNavJustMovedToKeyMods(self.handle(), C.ImGuiModFlags(v))
 }
 
@@ -6982,7 +6982,7 @@ func (self Context) NavJustMovedToKeyMods() ModFlags {
 	return ModFlags(C.wrap_ImGuiContext_GetNavJustMovedToKeyMods(self.handle()))
 }
 
-func (self *Context) SetNavNextActivateId(v ID) {
+func (self Context) SetNavNextActivateId(v ID) {
 	C.wrap_ImGuiContext_SetNavNextActivateId(self.handle(), C.ImGuiID(v))
 }
 
@@ -6990,7 +6990,7 @@ func (self Context) NavNextActivateId() ID {
 	return ID(C.wrap_ImGuiContext_GetNavNextActivateId(self.handle()))
 }
 
-func (self *Context) SetNavNextActivateFlags(v ActivateFlags) {
+func (self Context) SetNavNextActivateFlags(v ActivateFlags) {
 	C.wrap_ImGuiContext_SetNavNextActivateFlags(self.handle(), C.ImGuiActivateFlags(v))
 }
 
@@ -6998,7 +6998,7 @@ func (self Context) NavNextActivateFlags() ActivateFlags {
 	return ActivateFlags(C.wrap_ImGuiContext_GetNavNextActivateFlags(self.handle()))
 }
 
-func (self *Context) SetNavInputSource(v InputSource) {
+func (self Context) SetNavInputSource(v InputSource) {
 	C.wrap_ImGuiContext_SetNavInputSource(self.handle(), C.ImGuiInputSource(v))
 }
 
@@ -7006,7 +7006,7 @@ func (self Context) NavInputSource() InputSource {
 	return InputSource(C.wrap_ImGuiContext_GetNavInputSource(self.handle()))
 }
 
-func (self *Context) SetNavLayer(v NavLayer) {
+func (self Context) SetNavLayer(v NavLayer) {
 	C.wrap_ImGuiContext_SetNavLayer(self.handle(), C.ImGuiNavLayer(v))
 }
 
@@ -7014,7 +7014,7 @@ func (self Context) NavLayer() NavLayer {
 	return NavLayer(C.wrap_ImGuiContext_GetNavLayer(self.handle()))
 }
 
-func (self *Context) SetNavIdIsAlive(v bool) {
+func (self Context) SetNavIdIsAlive(v bool) {
 	C.wrap_ImGuiContext_SetNavIdIsAlive(self.handle(), C.bool(v))
 }
 
@@ -7022,7 +7022,7 @@ func (self Context) NavIdIsAlive() bool {
 	return C.wrap_ImGuiContext_GetNavIdIsAlive(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetNavMousePosDirty(v bool) {
+func (self Context) SetNavMousePosDirty(v bool) {
 	C.wrap_ImGuiContext_SetNavMousePosDirty(self.handle(), C.bool(v))
 }
 
@@ -7030,7 +7030,7 @@ func (self Context) NavMousePosDirty() bool {
 	return C.wrap_ImGuiContext_GetNavMousePosDirty(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetNavDisableHighlight(v bool) {
+func (self Context) SetNavDisableHighlight(v bool) {
 	C.wrap_ImGuiContext_SetNavDisableHighlight(self.handle(), C.bool(v))
 }
 
@@ -7038,7 +7038,7 @@ func (self Context) NavDisableHighlight() bool {
 	return C.wrap_ImGuiContext_GetNavDisableHighlight(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetNavDisableMouseHover(v bool) {
+func (self Context) SetNavDisableMouseHover(v bool) {
 	C.wrap_ImGuiContext_SetNavDisableMouseHover(self.handle(), C.bool(v))
 }
 
@@ -7046,7 +7046,7 @@ func (self Context) NavDisableMouseHover() bool {
 	return C.wrap_ImGuiContext_GetNavDisableMouseHover(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetNavAnyRequest(v bool) {
+func (self Context) SetNavAnyRequest(v bool) {
 	C.wrap_ImGuiContext_SetNavAnyRequest(self.handle(), C.bool(v))
 }
 
@@ -7054,7 +7054,7 @@ func (self Context) NavAnyRequest() bool {
 	return C.wrap_ImGuiContext_GetNavAnyRequest(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetNavInitRequest(v bool) {
+func (self Context) SetNavInitRequest(v bool) {
 	C.wrap_ImGuiContext_SetNavInitRequest(self.handle(), C.bool(v))
 }
 
@@ -7062,7 +7062,7 @@ func (self Context) NavInitRequest() bool {
 	return C.wrap_ImGuiContext_GetNavInitRequest(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetNavInitRequestFromMove(v bool) {
+func (self Context) SetNavInitRequestFromMove(v bool) {
 	C.wrap_ImGuiContext_SetNavInitRequestFromMove(self.handle(), C.bool(v))
 }
 
@@ -7070,7 +7070,7 @@ func (self Context) NavInitRequestFromMove() bool {
 	return C.wrap_ImGuiContext_GetNavInitRequestFromMove(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetNavInitResultId(v ID) {
+func (self Context) SetNavInitResultId(v ID) {
 	C.wrap_ImGuiContext_SetNavInitResultId(self.handle(), C.ImGuiID(v))
 }
 
@@ -7078,7 +7078,7 @@ func (self Context) NavInitResultId() ID {
 	return ID(C.wrap_ImGuiContext_GetNavInitResultId(self.handle()))
 }
 
-func (self *Context) SetNavInitResultRectRel(v Rect) {
+func (self Context) SetNavInitResultRectRel(v Rect) {
 	C.wrap_ImGuiContext_SetNavInitResultRectRel(self.handle(), v.toC())
 }
 
@@ -7088,7 +7088,7 @@ func (self Context) NavInitResultRectRel() Rect {
 	return *out
 }
 
-func (self *Context) SetNavMoveSubmitted(v bool) {
+func (self Context) SetNavMoveSubmitted(v bool) {
 	C.wrap_ImGuiContext_SetNavMoveSubmitted(self.handle(), C.bool(v))
 }
 
@@ -7096,7 +7096,7 @@ func (self Context) NavMoveSubmitted() bool {
 	return C.wrap_ImGuiContext_GetNavMoveSubmitted(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetNavMoveScoringItems(v bool) {
+func (self Context) SetNavMoveScoringItems(v bool) {
 	C.wrap_ImGuiContext_SetNavMoveScoringItems(self.handle(), C.bool(v))
 }
 
@@ -7104,7 +7104,7 @@ func (self Context) NavMoveScoringItems() bool {
 	return C.wrap_ImGuiContext_GetNavMoveScoringItems(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetNavMoveForwardToNextFrame(v bool) {
+func (self Context) SetNavMoveForwardToNextFrame(v bool) {
 	C.wrap_ImGuiContext_SetNavMoveForwardToNextFrame(self.handle(), C.bool(v))
 }
 
@@ -7112,7 +7112,7 @@ func (self Context) NavMoveForwardToNextFrame() bool {
 	return C.wrap_ImGuiContext_GetNavMoveForwardToNextFrame(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetNavMoveFlags(v NavMoveFlags) {
+func (self Context) SetNavMoveFlags(v NavMoveFlags) {
 	C.wrap_ImGuiContext_SetNavMoveFlags(self.handle(), C.ImGuiNavMoveFlags(v))
 }
 
@@ -7120,7 +7120,7 @@ func (self Context) NavMoveFlags() NavMoveFlags {
 	return NavMoveFlags(C.wrap_ImGuiContext_GetNavMoveFlags(self.handle()))
 }
 
-func (self *Context) SetNavMoveScrollFlags(v ScrollFlags) {
+func (self Context) SetNavMoveScrollFlags(v ScrollFlags) {
 	C.wrap_ImGuiContext_SetNavMoveScrollFlags(self.handle(), C.ImGuiScrollFlags(v))
 }
 
@@ -7128,7 +7128,7 @@ func (self Context) NavMoveScrollFlags() ScrollFlags {
 	return ScrollFlags(C.wrap_ImGuiContext_GetNavMoveScrollFlags(self.handle()))
 }
 
-func (self *Context) SetNavMoveKeyMods(v ModFlags) {
+func (self Context) SetNavMoveKeyMods(v ModFlags) {
 	C.wrap_ImGuiContext_SetNavMoveKeyMods(self.handle(), C.ImGuiModFlags(v))
 }
 
@@ -7136,7 +7136,7 @@ func (self Context) NavMoveKeyMods() ModFlags {
 	return ModFlags(C.wrap_ImGuiContext_GetNavMoveKeyMods(self.handle()))
 }
 
-func (self *Context) SetNavMoveDir(v Dir) {
+func (self Context) SetNavMoveDir(v Dir) {
 	C.wrap_ImGuiContext_SetNavMoveDir(self.handle(), C.ImGuiDir(v))
 }
 
@@ -7144,7 +7144,7 @@ func (self Context) NavMoveDir() Dir {
 	return Dir(C.wrap_ImGuiContext_GetNavMoveDir(self.handle()))
 }
 
-func (self *Context) SetNavMoveDirForDebug(v Dir) {
+func (self Context) SetNavMoveDirForDebug(v Dir) {
 	C.wrap_ImGuiContext_SetNavMoveDirForDebug(self.handle(), C.ImGuiDir(v))
 }
 
@@ -7152,7 +7152,7 @@ func (self Context) NavMoveDirForDebug() Dir {
 	return Dir(C.wrap_ImGuiContext_GetNavMoveDirForDebug(self.handle()))
 }
 
-func (self *Context) SetNavMoveClipDir(v Dir) {
+func (self Context) SetNavMoveClipDir(v Dir) {
 	C.wrap_ImGuiContext_SetNavMoveClipDir(self.handle(), C.ImGuiDir(v))
 }
 
@@ -7160,7 +7160,7 @@ func (self Context) NavMoveClipDir() Dir {
 	return Dir(C.wrap_ImGuiContext_GetNavMoveClipDir(self.handle()))
 }
 
-func (self *Context) SetNavScoringRect(v Rect) {
+func (self Context) SetNavScoringRect(v Rect) {
 	C.wrap_ImGuiContext_SetNavScoringRect(self.handle(), v.toC())
 }
 
@@ -7170,7 +7170,7 @@ func (self Context) NavScoringRect() Rect {
 	return *out
 }
 
-func (self *Context) SetNavScoringNoClipRect(v Rect) {
+func (self Context) SetNavScoringNoClipRect(v Rect) {
 	C.wrap_ImGuiContext_SetNavScoringNoClipRect(self.handle(), v.toC())
 }
 
@@ -7180,7 +7180,7 @@ func (self Context) NavScoringNoClipRect() Rect {
 	return *out
 }
 
-func (self *Context) SetNavScoringDebugCount(v int32) {
+func (self Context) SetNavScoringDebugCount(v int32) {
 	C.wrap_ImGuiContext_SetNavScoringDebugCount(self.handle(), C.int(v))
 }
 
@@ -7188,7 +7188,7 @@ func (self Context) NavScoringDebugCount() int {
 	return int(C.wrap_ImGuiContext_GetNavScoringDebugCount(self.handle()))
 }
 
-func (self *Context) SetNavTabbingDir(v int32) {
+func (self Context) SetNavTabbingDir(v int32) {
 	C.wrap_ImGuiContext_SetNavTabbingDir(self.handle(), C.int(v))
 }
 
@@ -7196,7 +7196,7 @@ func (self Context) NavTabbingDir() int {
 	return int(C.wrap_ImGuiContext_GetNavTabbingDir(self.handle()))
 }
 
-func (self *Context) SetNavTabbingCounter(v int32) {
+func (self Context) SetNavTabbingCounter(v int32) {
 	C.wrap_ImGuiContext_SetNavTabbingCounter(self.handle(), C.int(v))
 }
 
@@ -7220,7 +7220,7 @@ func (self Context) NavTabbingResultFirst() NavItemData {
 	return newNavItemDataFromC(C.wrap_ImGuiContext_GetNavTabbingResultFirst(self.handle()))
 }
 
-func (self *Context) SetNavWindowingTarget(v Window) {
+func (self Context) SetNavWindowingTarget(v Window) {
 	C.wrap_ImGuiContext_SetNavWindowingTarget(self.handle(), v.handle())
 }
 
@@ -7228,7 +7228,7 @@ func (self Context) NavWindowingTarget() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiContext_GetNavWindowingTarget(self.handle())))
 }
 
-func (self *Context) SetNavWindowingTargetAnim(v Window) {
+func (self Context) SetNavWindowingTargetAnim(v Window) {
 	C.wrap_ImGuiContext_SetNavWindowingTargetAnim(self.handle(), v.handle())
 }
 
@@ -7236,7 +7236,7 @@ func (self Context) NavWindowingTargetAnim() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiContext_GetNavWindowingTargetAnim(self.handle())))
 }
 
-func (self *Context) SetNavWindowingListWindow(v Window) {
+func (self Context) SetNavWindowingListWindow(v Window) {
 	C.wrap_ImGuiContext_SetNavWindowingListWindow(self.handle(), v.handle())
 }
 
@@ -7244,7 +7244,7 @@ func (self Context) NavWindowingListWindow() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiContext_GetNavWindowingListWindow(self.handle())))
 }
 
-func (self *Context) SetNavWindowingTimer(v float32) {
+func (self Context) SetNavWindowingTimer(v float32) {
 	C.wrap_ImGuiContext_SetNavWindowingTimer(self.handle(), C.float(v))
 }
 
@@ -7252,7 +7252,7 @@ func (self Context) NavWindowingTimer() float32 {
 	return float32(C.wrap_ImGuiContext_GetNavWindowingTimer(self.handle()))
 }
 
-func (self *Context) SetNavWindowingHighlightAlpha(v float32) {
+func (self Context) SetNavWindowingHighlightAlpha(v float32) {
 	C.wrap_ImGuiContext_SetNavWindowingHighlightAlpha(self.handle(), C.float(v))
 }
 
@@ -7260,7 +7260,7 @@ func (self Context) NavWindowingHighlightAlpha() float32 {
 	return float32(C.wrap_ImGuiContext_GetNavWindowingHighlightAlpha(self.handle()))
 }
 
-func (self *Context) SetNavWindowingToggleLayer(v bool) {
+func (self Context) SetNavWindowingToggleLayer(v bool) {
 	C.wrap_ImGuiContext_SetNavWindowingToggleLayer(self.handle(), C.bool(v))
 }
 
@@ -7268,7 +7268,7 @@ func (self Context) NavWindowingToggleLayer() bool {
 	return C.wrap_ImGuiContext_GetNavWindowingToggleLayer(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetNavWindowingAccumDeltaPos(v Vec2) {
+func (self Context) SetNavWindowingAccumDeltaPos(v Vec2) {
 	C.wrap_ImGuiContext_SetNavWindowingAccumDeltaPos(self.handle(), v.toC())
 }
 
@@ -7278,7 +7278,7 @@ func (self Context) NavWindowingAccumDeltaPos() Vec2 {
 	return *out
 }
 
-func (self *Context) SetNavWindowingAccumDeltaSize(v Vec2) {
+func (self Context) SetNavWindowingAccumDeltaSize(v Vec2) {
 	C.wrap_ImGuiContext_SetNavWindowingAccumDeltaSize(self.handle(), v.toC())
 }
 
@@ -7288,7 +7288,7 @@ func (self Context) NavWindowingAccumDeltaSize() Vec2 {
 	return *out
 }
 
-func (self *Context) SetDimBgRatio(v float32) {
+func (self Context) SetDimBgRatio(v float32) {
 	C.wrap_ImGuiContext_SetDimBgRatio(self.handle(), C.float(v))
 }
 
@@ -7296,7 +7296,7 @@ func (self Context) DimBgRatio() float32 {
 	return float32(C.wrap_ImGuiContext_GetDimBgRatio(self.handle()))
 }
 
-func (self *Context) SetMouseCursor(v MouseCursor) {
+func (self Context) SetMouseCursor(v MouseCursor) {
 	C.wrap_ImGuiContext_SetMouseCursor(self.handle(), C.ImGuiMouseCursor(v))
 }
 
@@ -7304,7 +7304,7 @@ func (self Context) MouseCursor() MouseCursor {
 	return MouseCursor(C.wrap_ImGuiContext_GetMouseCursor(self.handle()))
 }
 
-func (self *Context) SetDragDropActive(v bool) {
+func (self Context) SetDragDropActive(v bool) {
 	C.wrap_ImGuiContext_SetDragDropActive(self.handle(), C.bool(v))
 }
 
@@ -7312,7 +7312,7 @@ func (self Context) DragDropActive() bool {
 	return C.wrap_ImGuiContext_GetDragDropActive(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetDragDropWithinSource(v bool) {
+func (self Context) SetDragDropWithinSource(v bool) {
 	C.wrap_ImGuiContext_SetDragDropWithinSource(self.handle(), C.bool(v))
 }
 
@@ -7320,7 +7320,7 @@ func (self Context) DragDropWithinSource() bool {
 	return C.wrap_ImGuiContext_GetDragDropWithinSource(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetDragDropWithinTarget(v bool) {
+func (self Context) SetDragDropWithinTarget(v bool) {
 	C.wrap_ImGuiContext_SetDragDropWithinTarget(self.handle(), C.bool(v))
 }
 
@@ -7328,7 +7328,7 @@ func (self Context) DragDropWithinTarget() bool {
 	return C.wrap_ImGuiContext_GetDragDropWithinTarget(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetDragDropSourceFlags(v DragDropFlags) {
+func (self Context) SetDragDropSourceFlags(v DragDropFlags) {
 	C.wrap_ImGuiContext_SetDragDropSourceFlags(self.handle(), C.ImGuiDragDropFlags(v))
 }
 
@@ -7336,7 +7336,7 @@ func (self Context) DragDropSourceFlags() DragDropFlags {
 	return DragDropFlags(C.wrap_ImGuiContext_GetDragDropSourceFlags(self.handle()))
 }
 
-func (self *Context) SetDragDropSourceFrameCount(v int32) {
+func (self Context) SetDragDropSourceFrameCount(v int32) {
 	C.wrap_ImGuiContext_SetDragDropSourceFrameCount(self.handle(), C.int(v))
 }
 
@@ -7344,7 +7344,7 @@ func (self Context) DragDropSourceFrameCount() int {
 	return int(C.wrap_ImGuiContext_GetDragDropSourceFrameCount(self.handle()))
 }
 
-func (self *Context) SetDragDropMouseButton(v int32) {
+func (self Context) SetDragDropMouseButton(v int32) {
 	C.wrap_ImGuiContext_SetDragDropMouseButton(self.handle(), C.int(v))
 }
 
@@ -7356,7 +7356,7 @@ func (self Context) DragDropPayload() Payload {
 	return newPayloadFromC(C.wrap_ImGuiContext_GetDragDropPayload(self.handle()))
 }
 
-func (self *Context) SetDragDropTargetRect(v Rect) {
+func (self Context) SetDragDropTargetRect(v Rect) {
 	C.wrap_ImGuiContext_SetDragDropTargetRect(self.handle(), v.toC())
 }
 
@@ -7366,7 +7366,7 @@ func (self Context) DragDropTargetRect() Rect {
 	return *out
 }
 
-func (self *Context) SetDragDropTargetId(v ID) {
+func (self Context) SetDragDropTargetId(v ID) {
 	C.wrap_ImGuiContext_SetDragDropTargetId(self.handle(), C.ImGuiID(v))
 }
 
@@ -7374,7 +7374,7 @@ func (self Context) DragDropTargetId() ID {
 	return ID(C.wrap_ImGuiContext_GetDragDropTargetId(self.handle()))
 }
 
-func (self *Context) SetDragDropAcceptFlags(v DragDropFlags) {
+func (self Context) SetDragDropAcceptFlags(v DragDropFlags) {
 	C.wrap_ImGuiContext_SetDragDropAcceptFlags(self.handle(), C.ImGuiDragDropFlags(v))
 }
 
@@ -7382,7 +7382,7 @@ func (self Context) DragDropAcceptFlags() DragDropFlags {
 	return DragDropFlags(C.wrap_ImGuiContext_GetDragDropAcceptFlags(self.handle()))
 }
 
-func (self *Context) SetDragDropAcceptIdCurrRectSurface(v float32) {
+func (self Context) SetDragDropAcceptIdCurrRectSurface(v float32) {
 	C.wrap_ImGuiContext_SetDragDropAcceptIdCurrRectSurface(self.handle(), C.float(v))
 }
 
@@ -7390,7 +7390,7 @@ func (self Context) DragDropAcceptIdCurrRectSurface() float32 {
 	return float32(C.wrap_ImGuiContext_GetDragDropAcceptIdCurrRectSurface(self.handle()))
 }
 
-func (self *Context) SetDragDropAcceptIdCurr(v ID) {
+func (self Context) SetDragDropAcceptIdCurr(v ID) {
 	C.wrap_ImGuiContext_SetDragDropAcceptIdCurr(self.handle(), C.ImGuiID(v))
 }
 
@@ -7398,7 +7398,7 @@ func (self Context) DragDropAcceptIdCurr() ID {
 	return ID(C.wrap_ImGuiContext_GetDragDropAcceptIdCurr(self.handle()))
 }
 
-func (self *Context) SetDragDropAcceptIdPrev(v ID) {
+func (self Context) SetDragDropAcceptIdPrev(v ID) {
 	C.wrap_ImGuiContext_SetDragDropAcceptIdPrev(self.handle(), C.ImGuiID(v))
 }
 
@@ -7406,7 +7406,7 @@ func (self Context) DragDropAcceptIdPrev() ID {
 	return ID(C.wrap_ImGuiContext_GetDragDropAcceptIdPrev(self.handle()))
 }
 
-func (self *Context) SetDragDropAcceptFrameCount(v int32) {
+func (self Context) SetDragDropAcceptFrameCount(v int32) {
 	C.wrap_ImGuiContext_SetDragDropAcceptFrameCount(self.handle(), C.int(v))
 }
 
@@ -7414,7 +7414,7 @@ func (self Context) DragDropAcceptFrameCount() int {
 	return int(C.wrap_ImGuiContext_GetDragDropAcceptFrameCount(self.handle()))
 }
 
-func (self *Context) SetDragDropHoldJustPressedId(v ID) {
+func (self Context) SetDragDropHoldJustPressedId(v ID) {
 	C.wrap_ImGuiContext_SetDragDropHoldJustPressedId(self.handle(), C.ImGuiID(v))
 }
 
@@ -7422,7 +7422,7 @@ func (self Context) DragDropHoldJustPressedId() ID {
 	return ID(C.wrap_ImGuiContext_GetDragDropHoldJustPressedId(self.handle()))
 }
 
-func (self *Context) SetClipperTempDataStacked(v int32) {
+func (self Context) SetClipperTempDataStacked(v int32) {
 	C.wrap_ImGuiContext_SetClipperTempDataStacked(self.handle(), C.int(v))
 }
 
@@ -7430,7 +7430,7 @@ func (self Context) ClipperTempDataStacked() int {
 	return int(C.wrap_ImGuiContext_GetClipperTempDataStacked(self.handle()))
 }
 
-func (self *Context) SetCurrentTable(v Table) {
+func (self Context) SetCurrentTable(v Table) {
 	C.wrap_ImGuiContext_SetCurrentTable(self.handle(), v.handle())
 }
 
@@ -7438,7 +7438,7 @@ func (self Context) CurrentTable() Table {
 	return (Table)(unsafe.Pointer(C.wrap_ImGuiContext_GetCurrentTable(self.handle())))
 }
 
-func (self *Context) SetTablesTempDataStacked(v int32) {
+func (self Context) SetTablesTempDataStacked(v int32) {
 	C.wrap_ImGuiContext_SetTablesTempDataStacked(self.handle(), C.int(v))
 }
 
@@ -7446,7 +7446,7 @@ func (self Context) TablesTempDataStacked() int {
 	return int(C.wrap_ImGuiContext_GetTablesTempDataStacked(self.handle()))
 }
 
-func (self *Context) SetCurrentTabBar(v TabBar) {
+func (self Context) SetCurrentTabBar(v TabBar) {
 	C.wrap_ImGuiContext_SetCurrentTabBar(self.handle(), v.handle())
 }
 
@@ -7454,7 +7454,7 @@ func (self Context) CurrentTabBar() TabBar {
 	return (TabBar)(unsafe.Pointer(C.wrap_ImGuiContext_GetCurrentTabBar(self.handle())))
 }
 
-func (self *Context) SetMouseLastValidPos(v Vec2) {
+func (self Context) SetMouseLastValidPos(v Vec2) {
 	C.wrap_ImGuiContext_SetMouseLastValidPos(self.handle(), v.toC())
 }
 
@@ -7472,7 +7472,7 @@ func (self Context) InputTextPasswordFont() Font {
 	return newFontFromC(C.wrap_ImGuiContext_GetInputTextPasswordFont(self.handle()))
 }
 
-func (self *Context) SetTempInputId(v ID) {
+func (self Context) SetTempInputId(v ID) {
 	C.wrap_ImGuiContext_SetTempInputId(self.handle(), C.ImGuiID(v))
 }
 
@@ -7480,7 +7480,7 @@ func (self Context) TempInputId() ID {
 	return ID(C.wrap_ImGuiContext_GetTempInputId(self.handle()))
 }
 
-func (self *Context) SetColorEditOptions(v ColorEditFlags) {
+func (self Context) SetColorEditOptions(v ColorEditFlags) {
 	C.wrap_ImGuiContext_SetColorEditOptions(self.handle(), C.ImGuiColorEditFlags(v))
 }
 
@@ -7488,7 +7488,7 @@ func (self Context) ColorEditOptions() ColorEditFlags {
 	return ColorEditFlags(C.wrap_ImGuiContext_GetColorEditOptions(self.handle()))
 }
 
-func (self *Context) SetColorEditLastHue(v float32) {
+func (self Context) SetColorEditLastHue(v float32) {
 	C.wrap_ImGuiContext_SetColorEditLastHue(self.handle(), C.float(v))
 }
 
@@ -7496,7 +7496,7 @@ func (self Context) ColorEditLastHue() float32 {
 	return float32(C.wrap_ImGuiContext_GetColorEditLastHue(self.handle()))
 }
 
-func (self *Context) SetColorEditLastSat(v float32) {
+func (self Context) SetColorEditLastSat(v float32) {
 	C.wrap_ImGuiContext_SetColorEditLastSat(self.handle(), C.float(v))
 }
 
@@ -7504,7 +7504,7 @@ func (self Context) ColorEditLastSat() float32 {
 	return float32(C.wrap_ImGuiContext_GetColorEditLastSat(self.handle()))
 }
 
-func (self *Context) SetColorEditLastColor(v uint32) {
+func (self Context) SetColorEditLastColor(v uint32) {
 	C.wrap_ImGuiContext_SetColorEditLastColor(self.handle(), C.ImU32(v))
 }
 
@@ -7512,7 +7512,7 @@ func (self Context) ColorEditLastColor() uint32 {
 	return uint32(C.wrap_ImGuiContext_GetColorEditLastColor(self.handle()))
 }
 
-func (self *Context) SetColorPickerRef(v Vec4) {
+func (self Context) SetColorPickerRef(v Vec4) {
 	C.wrap_ImGuiContext_SetColorPickerRef(self.handle(), v.toC())
 }
 
@@ -7526,7 +7526,7 @@ func (self Context) ComboPreviewData() ComboPreviewData {
 	return newComboPreviewDataFromC(C.wrap_ImGuiContext_GetComboPreviewData(self.handle()))
 }
 
-func (self *Context) SetSliderGrabClickOffset(v float32) {
+func (self Context) SetSliderGrabClickOffset(v float32) {
 	C.wrap_ImGuiContext_SetSliderGrabClickOffset(self.handle(), C.float(v))
 }
 
@@ -7534,7 +7534,7 @@ func (self Context) SliderGrabClickOffset() float32 {
 	return float32(C.wrap_ImGuiContext_GetSliderGrabClickOffset(self.handle()))
 }
 
-func (self *Context) SetSliderCurrentAccum(v float32) {
+func (self Context) SetSliderCurrentAccum(v float32) {
 	C.wrap_ImGuiContext_SetSliderCurrentAccum(self.handle(), C.float(v))
 }
 
@@ -7542,7 +7542,7 @@ func (self Context) SliderCurrentAccum() float32 {
 	return float32(C.wrap_ImGuiContext_GetSliderCurrentAccum(self.handle()))
 }
 
-func (self *Context) SetSliderCurrentAccumDirty(v bool) {
+func (self Context) SetSliderCurrentAccumDirty(v bool) {
 	C.wrap_ImGuiContext_SetSliderCurrentAccumDirty(self.handle(), C.bool(v))
 }
 
@@ -7550,7 +7550,7 @@ func (self Context) SliderCurrentAccumDirty() bool {
 	return C.wrap_ImGuiContext_GetSliderCurrentAccumDirty(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetDragCurrentAccumDirty(v bool) {
+func (self Context) SetDragCurrentAccumDirty(v bool) {
 	C.wrap_ImGuiContext_SetDragCurrentAccumDirty(self.handle(), C.bool(v))
 }
 
@@ -7558,7 +7558,7 @@ func (self Context) DragCurrentAccumDirty() bool {
 	return C.wrap_ImGuiContext_GetDragCurrentAccumDirty(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetDragCurrentAccum(v float32) {
+func (self Context) SetDragCurrentAccum(v float32) {
 	C.wrap_ImGuiContext_SetDragCurrentAccum(self.handle(), C.float(v))
 }
 
@@ -7566,7 +7566,7 @@ func (self Context) DragCurrentAccum() float32 {
 	return float32(C.wrap_ImGuiContext_GetDragCurrentAccum(self.handle()))
 }
 
-func (self *Context) SetDragSpeedDefaultRatio(v float32) {
+func (self Context) SetDragSpeedDefaultRatio(v float32) {
 	C.wrap_ImGuiContext_SetDragSpeedDefaultRatio(self.handle(), C.float(v))
 }
 
@@ -7574,7 +7574,7 @@ func (self Context) DragSpeedDefaultRatio() float32 {
 	return float32(C.wrap_ImGuiContext_GetDragSpeedDefaultRatio(self.handle()))
 }
 
-func (self *Context) SetScrollbarClickDeltaToGrabCenter(v float32) {
+func (self Context) SetScrollbarClickDeltaToGrabCenter(v float32) {
 	C.wrap_ImGuiContext_SetScrollbarClickDeltaToGrabCenter(self.handle(), C.float(v))
 }
 
@@ -7582,7 +7582,7 @@ func (self Context) ScrollbarClickDeltaToGrabCenter() float32 {
 	return float32(C.wrap_ImGuiContext_GetScrollbarClickDeltaToGrabCenter(self.handle()))
 }
 
-func (self *Context) SetDisabledAlphaBackup(v float32) {
+func (self Context) SetDisabledAlphaBackup(v float32) {
 	C.wrap_ImGuiContext_SetDisabledAlphaBackup(self.handle(), C.float(v))
 }
 
@@ -7590,7 +7590,7 @@ func (self Context) DisabledAlphaBackup() float32 {
 	return float32(C.wrap_ImGuiContext_GetDisabledAlphaBackup(self.handle()))
 }
 
-func (self *Context) SetDisabledStackSize(v int) {
+func (self Context) SetDisabledStackSize(v int) {
 	C.wrap_ImGuiContext_SetDisabledStackSize(self.handle(), C.short(v))
 }
 
@@ -7598,7 +7598,7 @@ func (self Context) DisabledStackSize() int {
 	return int(C.wrap_ImGuiContext_GetDisabledStackSize(self.handle()))
 }
 
-func (self *Context) SetTooltipOverrideCount(v int) {
+func (self Context) SetTooltipOverrideCount(v int) {
 	C.wrap_ImGuiContext_SetTooltipOverrideCount(self.handle(), C.short(v))
 }
 
@@ -7606,7 +7606,7 @@ func (self Context) TooltipOverrideCount() int {
 	return int(C.wrap_ImGuiContext_GetTooltipOverrideCount(self.handle()))
 }
 
-func (self *Context) SetTooltipSlowDelay(v float32) {
+func (self Context) SetTooltipSlowDelay(v float32) {
 	C.wrap_ImGuiContext_SetTooltipSlowDelay(self.handle(), C.float(v))
 }
 
@@ -7622,7 +7622,7 @@ func (self Context) PlatformImeDataPrev() PlatformImeData {
 	return newPlatformImeDataFromC(C.wrap_ImGuiContext_GetPlatformImeDataPrev(self.handle()))
 }
 
-func (self *Context) SetPlatformImeViewport(v ID) {
+func (self Context) SetPlatformImeViewport(v ID) {
 	C.wrap_ImGuiContext_SetPlatformImeViewport(self.handle(), C.ImGuiID(v))
 }
 
@@ -7634,7 +7634,7 @@ func (self Context) DockContext() DockContext {
 	return newDockContextFromC(C.wrap_ImGuiContext_GetDockContext(self.handle()))
 }
 
-func (self *Context) SetSettingsLoaded(v bool) {
+func (self Context) SetSettingsLoaded(v bool) {
 	C.wrap_ImGuiContext_SetSettingsLoaded(self.handle(), C.bool(v))
 }
 
@@ -7642,7 +7642,7 @@ func (self Context) SettingsLoaded() bool {
 	return C.wrap_ImGuiContext_GetSettingsLoaded(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetSettingsDirtyTimer(v float32) {
+func (self Context) SetSettingsDirtyTimer(v float32) {
 	C.wrap_ImGuiContext_SetSettingsDirtyTimer(self.handle(), C.float(v))
 }
 
@@ -7654,7 +7654,7 @@ func (self Context) SettingsIniData() TextBuffer {
 	return newTextBufferFromC(C.wrap_ImGuiContext_GetSettingsIniData(self.handle()))
 }
 
-func (self *Context) SetHookIdNext(v ID) {
+func (self Context) SetHookIdNext(v ID) {
 	C.wrap_ImGuiContext_SetHookIdNext(self.handle(), C.ImGuiID(v))
 }
 
@@ -7662,7 +7662,7 @@ func (self Context) HookIdNext() ID {
 	return ID(C.wrap_ImGuiContext_GetHookIdNext(self.handle()))
 }
 
-func (self *Context) SetLogEnabled(v bool) {
+func (self Context) SetLogEnabled(v bool) {
 	C.wrap_ImGuiContext_SetLogEnabled(self.handle(), C.bool(v))
 }
 
@@ -7670,7 +7670,7 @@ func (self Context) LogEnabled() bool {
 	return C.wrap_ImGuiContext_GetLogEnabled(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetLogType(v LogType) {
+func (self Context) SetLogType(v LogType) {
 	C.wrap_ImGuiContext_SetLogType(self.handle(), C.ImGuiLogType(v))
 }
 
@@ -7682,7 +7682,7 @@ func (self Context) LogBuffer() TextBuffer {
 	return newTextBufferFromC(C.wrap_ImGuiContext_GetLogBuffer(self.handle()))
 }
 
-func (self *Context) SetLogNextPrefix(v string) {
+func (self Context) SetLogNextPrefix(v string) {
 	vArg, vFin := wrapString(v)
 	defer vFin()
 
@@ -7693,7 +7693,7 @@ func (self Context) LogNextPrefix() string {
 	return C.GoString(C.wrap_ImGuiContext_GetLogNextPrefix(self.handle()))
 }
 
-func (self *Context) SetLogNextSuffix(v string) {
+func (self Context) SetLogNextSuffix(v string) {
 	vArg, vFin := wrapString(v)
 	defer vFin()
 
@@ -7704,7 +7704,7 @@ func (self Context) LogNextSuffix() string {
 	return C.GoString(C.wrap_ImGuiContext_GetLogNextSuffix(self.handle()))
 }
 
-func (self *Context) SetLogLinePosY(v float32) {
+func (self Context) SetLogLinePosY(v float32) {
 	C.wrap_ImGuiContext_SetLogLinePosY(self.handle(), C.float(v))
 }
 
@@ -7712,7 +7712,7 @@ func (self Context) LogLinePosY() float32 {
 	return float32(C.wrap_ImGuiContext_GetLogLinePosY(self.handle()))
 }
 
-func (self *Context) SetLogLineFirstItem(v bool) {
+func (self Context) SetLogLineFirstItem(v bool) {
 	C.wrap_ImGuiContext_SetLogLineFirstItem(self.handle(), C.bool(v))
 }
 
@@ -7720,7 +7720,7 @@ func (self Context) LogLineFirstItem() bool {
 	return C.wrap_ImGuiContext_GetLogLineFirstItem(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetLogDepthRef(v int32) {
+func (self Context) SetLogDepthRef(v int32) {
 	C.wrap_ImGuiContext_SetLogDepthRef(self.handle(), C.int(v))
 }
 
@@ -7728,7 +7728,7 @@ func (self Context) LogDepthRef() int {
 	return int(C.wrap_ImGuiContext_GetLogDepthRef(self.handle()))
 }
 
-func (self *Context) SetLogDepthToExpand(v int32) {
+func (self Context) SetLogDepthToExpand(v int32) {
 	C.wrap_ImGuiContext_SetLogDepthToExpand(self.handle(), C.int(v))
 }
 
@@ -7736,7 +7736,7 @@ func (self Context) LogDepthToExpand() int {
 	return int(C.wrap_ImGuiContext_GetLogDepthToExpand(self.handle()))
 }
 
-func (self *Context) SetLogDepthToExpandDefault(v int32) {
+func (self Context) SetLogDepthToExpandDefault(v int32) {
 	C.wrap_ImGuiContext_SetLogDepthToExpandDefault(self.handle(), C.int(v))
 }
 
@@ -7744,7 +7744,7 @@ func (self Context) LogDepthToExpandDefault() int {
 	return int(C.wrap_ImGuiContext_GetLogDepthToExpandDefault(self.handle()))
 }
 
-func (self *Context) SetDebugLogFlags(v DebugLogFlags) {
+func (self Context) SetDebugLogFlags(v DebugLogFlags) {
 	C.wrap_ImGuiContext_SetDebugLogFlags(self.handle(), C.ImGuiDebugLogFlags(v))
 }
 
@@ -7756,7 +7756,7 @@ func (self Context) DebugLogBuf() TextBuffer {
 	return newTextBufferFromC(C.wrap_ImGuiContext_GetDebugLogBuf(self.handle()))
 }
 
-func (self *Context) SetDebugItemPickerActive(v bool) {
+func (self Context) SetDebugItemPickerActive(v bool) {
 	C.wrap_ImGuiContext_SetDebugItemPickerActive(self.handle(), C.bool(v))
 }
 
@@ -7764,7 +7764,7 @@ func (self Context) DebugItemPickerActive() bool {
 	return C.wrap_ImGuiContext_GetDebugItemPickerActive(self.handle()) == C.bool(true)
 }
 
-func (self *Context) SetDebugItemPickerMouseButton(v uint) {
+func (self Context) SetDebugItemPickerMouseButton(v uint) {
 	C.wrap_ImGuiContext_SetDebugItemPickerMouseButton(self.handle(), C.ImU8(v))
 }
 
@@ -7772,7 +7772,7 @@ func (self Context) DebugItemPickerMouseButton() uint32 {
 	return uint32(C.wrap_ImGuiContext_GetDebugItemPickerMouseButton(self.handle()))
 }
 
-func (self *Context) SetDebugItemPickerBreakId(v ID) {
+func (self Context) SetDebugItemPickerBreakId(v ID) {
 	C.wrap_ImGuiContext_SetDebugItemPickerBreakId(self.handle(), C.ImGuiID(v))
 }
 
@@ -7788,7 +7788,7 @@ func (self Context) DebugStackTool() StackTool {
 	return newStackToolFromC(C.wrap_ImGuiContext_GetDebugStackTool(self.handle()))
 }
 
-func (self *Context) SetDebugHoveredDockNode(v DockNode) {
+func (self Context) SetDebugHoveredDockNode(v DockNode) {
 	C.wrap_ImGuiContext_SetDebugHoveredDockNode(self.handle(), v.handle())
 }
 
@@ -7796,7 +7796,7 @@ func (self Context) DebugHoveredDockNode() DockNode {
 	return (DockNode)(unsafe.Pointer(C.wrap_ImGuiContext_GetDebugHoveredDockNode(self.handle())))
 }
 
-func (self *Context) SetFramerateSecPerFrameIdx(v int32) {
+func (self Context) SetFramerateSecPerFrameIdx(v int32) {
 	C.wrap_ImGuiContext_SetFramerateSecPerFrameIdx(self.handle(), C.int(v))
 }
 
@@ -7804,7 +7804,7 @@ func (self Context) FramerateSecPerFrameIdx() int {
 	return int(C.wrap_ImGuiContext_GetFramerateSecPerFrameIdx(self.handle()))
 }
 
-func (self *Context) SetFramerateSecPerFrameCount(v int32) {
+func (self Context) SetFramerateSecPerFrameCount(v int32) {
 	C.wrap_ImGuiContext_SetFramerateSecPerFrameCount(self.handle(), C.int(v))
 }
 
@@ -7812,7 +7812,7 @@ func (self Context) FramerateSecPerFrameCount() int {
 	return int(C.wrap_ImGuiContext_GetFramerateSecPerFrameCount(self.handle()))
 }
 
-func (self *Context) SetFramerateSecPerFrameAccum(v float32) {
+func (self Context) SetFramerateSecPerFrameAccum(v float32) {
 	C.wrap_ImGuiContext_SetFramerateSecPerFrameAccum(self.handle(), C.float(v))
 }
 
@@ -7820,7 +7820,7 @@ func (self Context) FramerateSecPerFrameAccum() float32 {
 	return float32(C.wrap_ImGuiContext_GetFramerateSecPerFrameAccum(self.handle()))
 }
 
-func (self *Context) SetWantCaptureMouseNextFrame(v int32) {
+func (self Context) SetWantCaptureMouseNextFrame(v int32) {
 	C.wrap_ImGuiContext_SetWantCaptureMouseNextFrame(self.handle(), C.int(v))
 }
 
@@ -7828,7 +7828,7 @@ func (self Context) WantCaptureMouseNextFrame() int {
 	return int(C.wrap_ImGuiContext_GetWantCaptureMouseNextFrame(self.handle()))
 }
 
-func (self *Context) SetWantCaptureKeyboardNextFrame(v int32) {
+func (self Context) SetWantCaptureKeyboardNextFrame(v int32) {
 	C.wrap_ImGuiContext_SetWantCaptureKeyboardNextFrame(self.handle(), C.int(v))
 }
 
@@ -7836,7 +7836,7 @@ func (self Context) WantCaptureKeyboardNextFrame() int {
 	return int(C.wrap_ImGuiContext_GetWantCaptureKeyboardNextFrame(self.handle()))
 }
 
-func (self *Context) SetWantTextInputNextFrame(v int32) {
+func (self Context) SetWantTextInputNextFrame(v int32) {
 	C.wrap_ImGuiContext_SetWantTextInputNextFrame(self.handle(), C.int(v))
 }
 
@@ -7844,7 +7844,7 @@ func (self Context) WantTextInputNextFrame() int {
 	return int(C.wrap_ImGuiContext_GetWantTextInputNextFrame(self.handle()))
 }
 
-func (self *ContextHook) SetHookId(v ID) {
+func (self ContextHook) SetHookId(v ID) {
 	C.wrap_ImGuiContextHook_SetHookId(self.handle(), C.ImGuiID(v))
 }
 
@@ -7852,7 +7852,7 @@ func (self ContextHook) HookId() ID {
 	return ID(C.wrap_ImGuiContextHook_GetHookId(self.handle()))
 }
 
-func (self *ContextHook) SetType(v ContextHookType) {
+func (self ContextHook) SetType(v ContextHookType) {
 	C.wrap_ImGuiContextHook_SetType(self.handle(), C.ImGuiContextHookType(v))
 }
 
@@ -7860,7 +7860,7 @@ func (self ContextHook) Type() ContextHookType {
 	return ContextHookType(C.wrap_ImGuiContextHook_GetType(self.handle()))
 }
 
-func (self *ContextHook) SetOwner(v ID) {
+func (self ContextHook) SetOwner(v ID) {
 	C.wrap_ImGuiContextHook_SetOwner(self.handle(), C.ImGuiID(v))
 }
 
@@ -7868,7 +7868,7 @@ func (self ContextHook) Owner() ID {
 	return ID(C.wrap_ImGuiContextHook_GetOwner(self.handle()))
 }
 
-func (self *ContextHook) SetUserData(v unsafe.Pointer) {
+func (self ContextHook) SetUserData(v unsafe.Pointer) {
 	C.wrap_ImGuiContextHook_SetUserData(self.handle(), (v))
 }
 
@@ -7876,7 +7876,7 @@ func (self ContextHook) UserData() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImGuiContextHook_GetUserData(self.handle()))
 }
 
-func (self *DataTypeInfo) SetSize(v uint64) {
+func (self DataTypeInfo) SetSize(v uint64) {
 	C.wrap_ImGuiDataTypeInfo_SetSize(self.handle(), C.xlong(v))
 }
 
@@ -7884,7 +7884,7 @@ func (self DataTypeInfo) Size() float64 {
 	return float64(C.wrap_ImGuiDataTypeInfo_GetSize(self.handle()))
 }
 
-func (self *DataTypeInfo) SetName(v string) {
+func (self DataTypeInfo) SetName(v string) {
 	vArg, vFin := wrapString(v)
 	defer vFin()
 
@@ -7895,7 +7895,7 @@ func (self DataTypeInfo) Name() string {
 	return C.GoString(C.wrap_ImGuiDataTypeInfo_GetName(self.handle()))
 }
 
-func (self *DataTypeInfo) SetPrintFmt(v string) {
+func (self DataTypeInfo) SetPrintFmt(v string) {
 	vArg, vFin := wrapString(v)
 	defer vFin()
 
@@ -7906,7 +7906,7 @@ func (self DataTypeInfo) PrintFmt() string {
 	return C.GoString(C.wrap_ImGuiDataTypeInfo_GetPrintFmt(self.handle()))
 }
 
-func (self *DataTypeInfo) SetScanFmt(v string) {
+func (self DataTypeInfo) SetScanFmt(v string) {
 	vArg, vFin := wrapString(v)
 	defer vFin()
 
@@ -7921,7 +7921,7 @@ func (self DockContext) Nodes() Storage {
 	return newStorageFromC(C.wrap_ImGuiDockContext_GetNodes(self.handle()))
 }
 
-func (self *DockContext) SetWantFullRebuild(v bool) {
+func (self DockContext) SetWantFullRebuild(v bool) {
 	C.wrap_ImGuiDockContext_SetWantFullRebuild(self.handle(), C.bool(v))
 }
 
@@ -7929,7 +7929,7 @@ func (self DockContext) WantFullRebuild() bool {
 	return C.wrap_ImGuiDockContext_GetWantFullRebuild(self.handle()) == C.bool(true)
 }
 
-func (self *DockNode) SetID(v ID) {
+func (self DockNode) SetID(v ID) {
 	C.wrap_ImGuiDockNode_SetID(self.handle(), C.ImGuiID(v))
 }
 
@@ -7937,7 +7937,7 @@ func (self DockNode) ID() ID {
 	return ID(C.wrap_ImGuiDockNode_GetID(self.handle()))
 }
 
-func (self *DockNode) SetSharedFlags(v DockNodeFlags) {
+func (self DockNode) SetSharedFlags(v DockNodeFlags) {
 	C.wrap_ImGuiDockNode_SetSharedFlags(self.handle(), C.ImGuiDockNodeFlags(v))
 }
 
@@ -7945,7 +7945,7 @@ func (self DockNode) SharedFlags() DockNodeFlags {
 	return DockNodeFlags(C.wrap_ImGuiDockNode_GetSharedFlags(self.handle()))
 }
 
-func (self *DockNode) SetLocalFlagsInWindows(v DockNodeFlags) {
+func (self DockNode) SetLocalFlagsInWindows(v DockNodeFlags) {
 	C.wrap_ImGuiDockNode_SetLocalFlagsInWindows(self.handle(), C.ImGuiDockNodeFlags(v))
 }
 
@@ -7953,7 +7953,7 @@ func (self DockNode) LocalFlagsInWindows() DockNodeFlags {
 	return DockNodeFlags(C.wrap_ImGuiDockNode_GetLocalFlagsInWindows(self.handle()))
 }
 
-func (self *DockNode) SetMergedFlags(v DockNodeFlags) {
+func (self DockNode) SetMergedFlags(v DockNodeFlags) {
 	C.wrap_ImGuiDockNode_SetMergedFlags(self.handle(), C.ImGuiDockNodeFlags(v))
 }
 
@@ -7961,7 +7961,7 @@ func (self DockNode) MergedFlags() DockNodeFlags {
 	return DockNodeFlags(C.wrap_ImGuiDockNode_GetMergedFlags(self.handle()))
 }
 
-func (self *DockNode) SetState(v DockNodeState) {
+func (self DockNode) SetState(v DockNodeState) {
 	C.wrap_ImGuiDockNode_SetState(self.handle(), C.ImGuiDockNodeState(v))
 }
 
@@ -7969,7 +7969,7 @@ func (self DockNode) State() DockNodeState {
 	return DockNodeState(C.wrap_ImGuiDockNode_GetState(self.handle()))
 }
 
-func (self *DockNode) SetParentNode(v DockNode) {
+func (self DockNode) SetParentNode(v DockNode) {
 	C.wrap_ImGuiDockNode_SetParentNode(self.handle(), v.handle())
 }
 
@@ -7977,7 +7977,7 @@ func (self DockNode) ParentNode() DockNode {
 	return (DockNode)(unsafe.Pointer(C.wrap_ImGuiDockNode_GetParentNode(self.handle())))
 }
 
-func (self *DockNode) SetTabBar(v TabBar) {
+func (self DockNode) SetTabBar(v TabBar) {
 	C.wrap_ImGuiDockNode_SetTabBar(self.handle(), v.handle())
 }
 
@@ -7985,7 +7985,7 @@ func (self DockNode) TabBar() TabBar {
 	return (TabBar)(unsafe.Pointer(C.wrap_ImGuiDockNode_GetTabBar(self.handle())))
 }
 
-func (self *DockNode) SetPos(v Vec2) {
+func (self DockNode) SetPos(v Vec2) {
 	C.wrap_ImGuiDockNode_SetPos(self.handle(), v.toC())
 }
 
@@ -7995,7 +7995,7 @@ func (self DockNode) Pos() Vec2 {
 	return *out
 }
 
-func (self *DockNode) SetSize(v Vec2) {
+func (self DockNode) SetSize(v Vec2) {
 	C.wrap_ImGuiDockNode_SetSize(self.handle(), v.toC())
 }
 
@@ -8005,7 +8005,7 @@ func (self DockNode) Size() Vec2 {
 	return *out
 }
 
-func (self *DockNode) SetSizeRef(v Vec2) {
+func (self DockNode) SetSizeRef(v Vec2) {
 	C.wrap_ImGuiDockNode_SetSizeRef(self.handle(), v.toC())
 }
 
@@ -8015,7 +8015,7 @@ func (self DockNode) SizeRef() Vec2 {
 	return *out
 }
 
-func (self *DockNode) SetSplitAxis(v Axis) {
+func (self DockNode) SetSplitAxis(v Axis) {
 	C.wrap_ImGuiDockNode_SetSplitAxis(self.handle(), C.ImGuiAxis(v))
 }
 
@@ -8027,7 +8027,7 @@ func (self DockNode) WindowClass() WindowClass {
 	return newWindowClassFromC(C.wrap_ImGuiDockNode_GetWindowClass(self.handle()))
 }
 
-func (self *DockNode) SetLastBgColor(v uint32) {
+func (self DockNode) SetLastBgColor(v uint32) {
 	C.wrap_ImGuiDockNode_SetLastBgColor(self.handle(), C.ImU32(v))
 }
 
@@ -8035,7 +8035,7 @@ func (self DockNode) LastBgColor() uint32 {
 	return uint32(C.wrap_ImGuiDockNode_GetLastBgColor(self.handle()))
 }
 
-func (self *DockNode) SetHostWindow(v Window) {
+func (self DockNode) SetHostWindow(v Window) {
 	C.wrap_ImGuiDockNode_SetHostWindow(self.handle(), v.handle())
 }
 
@@ -8043,7 +8043,7 @@ func (self DockNode) HostWindow() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiDockNode_GetHostWindow(self.handle())))
 }
 
-func (self *DockNode) SetVisibleWindow(v Window) {
+func (self DockNode) SetVisibleWindow(v Window) {
 	C.wrap_ImGuiDockNode_SetVisibleWindow(self.handle(), v.handle())
 }
 
@@ -8051,7 +8051,7 @@ func (self DockNode) VisibleWindow() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiDockNode_GetVisibleWindow(self.handle())))
 }
 
-func (self *DockNode) SetCentralNode(v DockNode) {
+func (self DockNode) SetCentralNode(v DockNode) {
 	C.wrap_ImGuiDockNode_SetCentralNode(self.handle(), v.handle())
 }
 
@@ -8059,7 +8059,7 @@ func (self DockNode) CentralNode() DockNode {
 	return (DockNode)(unsafe.Pointer(C.wrap_ImGuiDockNode_GetCentralNode(self.handle())))
 }
 
-func (self *DockNode) SetOnlyNodeWithWindows(v DockNode) {
+func (self DockNode) SetOnlyNodeWithWindows(v DockNode) {
 	C.wrap_ImGuiDockNode_SetOnlyNodeWithWindows(self.handle(), v.handle())
 }
 
@@ -8067,7 +8067,7 @@ func (self DockNode) OnlyNodeWithWindows() DockNode {
 	return (DockNode)(unsafe.Pointer(C.wrap_ImGuiDockNode_GetOnlyNodeWithWindows(self.handle())))
 }
 
-func (self *DockNode) SetCountNodeWithWindows(v int32) {
+func (self DockNode) SetCountNodeWithWindows(v int32) {
 	C.wrap_ImGuiDockNode_SetCountNodeWithWindows(self.handle(), C.int(v))
 }
 
@@ -8075,7 +8075,7 @@ func (self DockNode) CountNodeWithWindows() int {
 	return int(C.wrap_ImGuiDockNode_GetCountNodeWithWindows(self.handle()))
 }
 
-func (self *DockNode) SetLastFrameAlive(v int32) {
+func (self DockNode) SetLastFrameAlive(v int32) {
 	C.wrap_ImGuiDockNode_SetLastFrameAlive(self.handle(), C.int(v))
 }
 
@@ -8083,7 +8083,7 @@ func (self DockNode) LastFrameAlive() int {
 	return int(C.wrap_ImGuiDockNode_GetLastFrameAlive(self.handle()))
 }
 
-func (self *DockNode) SetLastFrameActive(v int32) {
+func (self DockNode) SetLastFrameActive(v int32) {
 	C.wrap_ImGuiDockNode_SetLastFrameActive(self.handle(), C.int(v))
 }
 
@@ -8091,7 +8091,7 @@ func (self DockNode) LastFrameActive() int {
 	return int(C.wrap_ImGuiDockNode_GetLastFrameActive(self.handle()))
 }
 
-func (self *DockNode) SetLastFrameFocused(v int32) {
+func (self DockNode) SetLastFrameFocused(v int32) {
 	C.wrap_ImGuiDockNode_SetLastFrameFocused(self.handle(), C.int(v))
 }
 
@@ -8099,7 +8099,7 @@ func (self DockNode) LastFrameFocused() int {
 	return int(C.wrap_ImGuiDockNode_GetLastFrameFocused(self.handle()))
 }
 
-func (self *DockNode) SetLastFocusedNodeId(v ID) {
+func (self DockNode) SetLastFocusedNodeId(v ID) {
 	C.wrap_ImGuiDockNode_SetLastFocusedNodeId(self.handle(), C.ImGuiID(v))
 }
 
@@ -8107,7 +8107,7 @@ func (self DockNode) LastFocusedNodeId() ID {
 	return ID(C.wrap_ImGuiDockNode_GetLastFocusedNodeId(self.handle()))
 }
 
-func (self *DockNode) SetSelectedTabId(v ID) {
+func (self DockNode) SetSelectedTabId(v ID) {
 	C.wrap_ImGuiDockNode_SetSelectedTabId(self.handle(), C.ImGuiID(v))
 }
 
@@ -8115,7 +8115,7 @@ func (self DockNode) SelectedTabId() ID {
 	return ID(C.wrap_ImGuiDockNode_GetSelectedTabId(self.handle()))
 }
 
-func (self *DockNode) SetWantCloseTabId(v ID) {
+func (self DockNode) SetWantCloseTabId(v ID) {
 	C.wrap_ImGuiDockNode_SetWantCloseTabId(self.handle(), C.ImGuiID(v))
 }
 
@@ -8123,7 +8123,7 @@ func (self DockNode) WantCloseTabId() ID {
 	return ID(C.wrap_ImGuiDockNode_GetWantCloseTabId(self.handle()))
 }
 
-func (self *DockNode) SetAuthorityForPos(v DataAuthority) {
+func (self DockNode) SetAuthorityForPos(v DataAuthority) {
 	C.wrap_ImGuiDockNode_SetAuthorityForPos(self.handle(), C.ImGuiDataAuthority(v))
 }
 
@@ -8131,7 +8131,7 @@ func (self DockNode) AuthorityForPos() DataAuthority {
 	return DataAuthority(C.wrap_ImGuiDockNode_GetAuthorityForPos(self.handle()))
 }
 
-func (self *DockNode) SetAuthorityForSize(v DataAuthority) {
+func (self DockNode) SetAuthorityForSize(v DataAuthority) {
 	C.wrap_ImGuiDockNode_SetAuthorityForSize(self.handle(), C.ImGuiDataAuthority(v))
 }
 
@@ -8139,7 +8139,7 @@ func (self DockNode) AuthorityForSize() DataAuthority {
 	return DataAuthority(C.wrap_ImGuiDockNode_GetAuthorityForSize(self.handle()))
 }
 
-func (self *DockNode) SetAuthorityForViewport(v DataAuthority) {
+func (self DockNode) SetAuthorityForViewport(v DataAuthority) {
 	C.wrap_ImGuiDockNode_SetAuthorityForViewport(self.handle(), C.ImGuiDataAuthority(v))
 }
 
@@ -8147,7 +8147,7 @@ func (self DockNode) AuthorityForViewport() DataAuthority {
 	return DataAuthority(C.wrap_ImGuiDockNode_GetAuthorityForViewport(self.handle()))
 }
 
-func (self *DockNode) SetIsVisible(v bool) {
+func (self DockNode) SetIsVisible(v bool) {
 	C.wrap_ImGuiDockNode_SetIsVisible(self.handle(), C.bool(v))
 }
 
@@ -8155,7 +8155,7 @@ func (self DockNode) IsVisible() bool {
 	return C.wrap_ImGuiDockNode_GetIsVisible(self.handle()) == C.bool(true)
 }
 
-func (self *DockNode) SetIsFocused(v bool) {
+func (self DockNode) SetIsFocused(v bool) {
 	C.wrap_ImGuiDockNode_SetIsFocused(self.handle(), C.bool(v))
 }
 
@@ -8163,7 +8163,7 @@ func (self DockNode) IsFocused() bool {
 	return C.wrap_ImGuiDockNode_GetIsFocused(self.handle()) == C.bool(true)
 }
 
-func (self *DockNode) SetIsBgDrawnThisFrame(v bool) {
+func (self DockNode) SetIsBgDrawnThisFrame(v bool) {
 	C.wrap_ImGuiDockNode_SetIsBgDrawnThisFrame(self.handle(), C.bool(v))
 }
 
@@ -8171,7 +8171,7 @@ func (self DockNode) IsBgDrawnThisFrame() bool {
 	return C.wrap_ImGuiDockNode_GetIsBgDrawnThisFrame(self.handle()) == C.bool(true)
 }
 
-func (self *DockNode) SetHasCloseButton(v bool) {
+func (self DockNode) SetHasCloseButton(v bool) {
 	C.wrap_ImGuiDockNode_SetHasCloseButton(self.handle(), C.bool(v))
 }
 
@@ -8179,7 +8179,7 @@ func (self DockNode) HasCloseButton() bool {
 	return C.wrap_ImGuiDockNode_GetHasCloseButton(self.handle()) == C.bool(true)
 }
 
-func (self *DockNode) SetHasWindowMenuButton(v bool) {
+func (self DockNode) SetHasWindowMenuButton(v bool) {
 	C.wrap_ImGuiDockNode_SetHasWindowMenuButton(self.handle(), C.bool(v))
 }
 
@@ -8187,7 +8187,7 @@ func (self DockNode) HasWindowMenuButton() bool {
 	return C.wrap_ImGuiDockNode_GetHasWindowMenuButton(self.handle()) == C.bool(true)
 }
 
-func (self *DockNode) SetHasCentralNodeChild(v bool) {
+func (self DockNode) SetHasCentralNodeChild(v bool) {
 	C.wrap_ImGuiDockNode_SetHasCentralNodeChild(self.handle(), C.bool(v))
 }
 
@@ -8195,7 +8195,7 @@ func (self DockNode) HasCentralNodeChild() bool {
 	return C.wrap_ImGuiDockNode_GetHasCentralNodeChild(self.handle()) == C.bool(true)
 }
 
-func (self *DockNode) SetWantCloseAll(v bool) {
+func (self DockNode) SetWantCloseAll(v bool) {
 	C.wrap_ImGuiDockNode_SetWantCloseAll(self.handle(), C.bool(v))
 }
 
@@ -8203,7 +8203,7 @@ func (self DockNode) WantCloseAll() bool {
 	return C.wrap_ImGuiDockNode_GetWantCloseAll(self.handle()) == C.bool(true)
 }
 
-func (self *DockNode) SetWantLockSizeOnce(v bool) {
+func (self DockNode) SetWantLockSizeOnce(v bool) {
 	C.wrap_ImGuiDockNode_SetWantLockSizeOnce(self.handle(), C.bool(v))
 }
 
@@ -8211,7 +8211,7 @@ func (self DockNode) WantLockSizeOnce() bool {
 	return C.wrap_ImGuiDockNode_GetWantLockSizeOnce(self.handle()) == C.bool(true)
 }
 
-func (self *DockNode) SetWantMouseMove(v bool) {
+func (self DockNode) SetWantMouseMove(v bool) {
 	C.wrap_ImGuiDockNode_SetWantMouseMove(self.handle(), C.bool(v))
 }
 
@@ -8219,7 +8219,7 @@ func (self DockNode) WantMouseMove() bool {
 	return C.wrap_ImGuiDockNode_GetWantMouseMove(self.handle()) == C.bool(true)
 }
 
-func (self *DockNode) SetWantHiddenTabBarUpdate(v bool) {
+func (self DockNode) SetWantHiddenTabBarUpdate(v bool) {
 	C.wrap_ImGuiDockNode_SetWantHiddenTabBarUpdate(self.handle(), C.bool(v))
 }
 
@@ -8227,7 +8227,7 @@ func (self DockNode) WantHiddenTabBarUpdate() bool {
 	return C.wrap_ImGuiDockNode_GetWantHiddenTabBarUpdate(self.handle()) == C.bool(true)
 }
 
-func (self *DockNode) SetWantHiddenTabBarToggle(v bool) {
+func (self DockNode) SetWantHiddenTabBarToggle(v bool) {
 	C.wrap_ImGuiDockNode_SetWantHiddenTabBarToggle(self.handle(), C.bool(v))
 }
 
@@ -8235,7 +8235,7 @@ func (self DockNode) WantHiddenTabBarToggle() bool {
 	return C.wrap_ImGuiDockNode_GetWantHiddenTabBarToggle(self.handle()) == C.bool(true)
 }
 
-func (self *GroupData) SetWindowID(v ID) {
+func (self GroupData) SetWindowID(v ID) {
 	C.wrap_ImGuiGroupData_SetWindowID(self.handle(), C.ImGuiID(v))
 }
 
@@ -8243,7 +8243,7 @@ func (self GroupData) WindowID() ID {
 	return ID(C.wrap_ImGuiGroupData_GetWindowID(self.handle()))
 }
 
-func (self *GroupData) SetBackupCursorPos(v Vec2) {
+func (self GroupData) SetBackupCursorPos(v Vec2) {
 	C.wrap_ImGuiGroupData_SetBackupCursorPos(self.handle(), v.toC())
 }
 
@@ -8253,7 +8253,7 @@ func (self GroupData) BackupCursorPos() Vec2 {
 	return *out
 }
 
-func (self *GroupData) SetBackupCursorMaxPos(v Vec2) {
+func (self GroupData) SetBackupCursorMaxPos(v Vec2) {
 	C.wrap_ImGuiGroupData_SetBackupCursorMaxPos(self.handle(), v.toC())
 }
 
@@ -8263,7 +8263,7 @@ func (self GroupData) BackupCursorMaxPos() Vec2 {
 	return *out
 }
 
-func (self *GroupData) SetBackupCurrLineSize(v Vec2) {
+func (self GroupData) SetBackupCurrLineSize(v Vec2) {
 	C.wrap_ImGuiGroupData_SetBackupCurrLineSize(self.handle(), v.toC())
 }
 
@@ -8273,7 +8273,7 @@ func (self GroupData) BackupCurrLineSize() Vec2 {
 	return *out
 }
 
-func (self *GroupData) SetBackupCurrLineTextBaseOffset(v float32) {
+func (self GroupData) SetBackupCurrLineTextBaseOffset(v float32) {
 	C.wrap_ImGuiGroupData_SetBackupCurrLineTextBaseOffset(self.handle(), C.float(v))
 }
 
@@ -8281,7 +8281,7 @@ func (self GroupData) BackupCurrLineTextBaseOffset() float32 {
 	return float32(C.wrap_ImGuiGroupData_GetBackupCurrLineTextBaseOffset(self.handle()))
 }
 
-func (self *GroupData) SetBackupActiveIdIsAlive(v ID) {
+func (self GroupData) SetBackupActiveIdIsAlive(v ID) {
 	C.wrap_ImGuiGroupData_SetBackupActiveIdIsAlive(self.handle(), C.ImGuiID(v))
 }
 
@@ -8289,7 +8289,7 @@ func (self GroupData) BackupActiveIdIsAlive() ID {
 	return ID(C.wrap_ImGuiGroupData_GetBackupActiveIdIsAlive(self.handle()))
 }
 
-func (self *GroupData) SetBackupActiveIdPreviousFrameIsAlive(v bool) {
+func (self GroupData) SetBackupActiveIdPreviousFrameIsAlive(v bool) {
 	C.wrap_ImGuiGroupData_SetBackupActiveIdPreviousFrameIsAlive(self.handle(), C.bool(v))
 }
 
@@ -8297,7 +8297,7 @@ func (self GroupData) BackupActiveIdPreviousFrameIsAlive() bool {
 	return C.wrap_ImGuiGroupData_GetBackupActiveIdPreviousFrameIsAlive(self.handle()) == C.bool(true)
 }
 
-func (self *GroupData) SetBackupHoveredIdIsAlive(v bool) {
+func (self GroupData) SetBackupHoveredIdIsAlive(v bool) {
 	C.wrap_ImGuiGroupData_SetBackupHoveredIdIsAlive(self.handle(), C.bool(v))
 }
 
@@ -8305,7 +8305,7 @@ func (self GroupData) BackupHoveredIdIsAlive() bool {
 	return C.wrap_ImGuiGroupData_GetBackupHoveredIdIsAlive(self.handle()) == C.bool(true)
 }
 
-func (self *GroupData) SetEmitItem(v bool) {
+func (self GroupData) SetEmitItem(v bool) {
 	C.wrap_ImGuiGroupData_SetEmitItem(self.handle(), C.bool(v))
 }
 
@@ -8313,7 +8313,7 @@ func (self GroupData) EmitItem() bool {
 	return C.wrap_ImGuiGroupData_GetEmitItem(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetConfigFlags(v ConfigFlags) {
+func (self IO) SetConfigFlags(v ConfigFlags) {
 	C.wrap_ImGuiIO_SetConfigFlags(self.handle(), C.ImGuiConfigFlags(v))
 }
 
@@ -8321,7 +8321,7 @@ func (self IO) ConfigFlags() ConfigFlags {
 	return ConfigFlags(C.wrap_ImGuiIO_GetConfigFlags(self.handle()))
 }
 
-func (self *IO) SetBackendFlags(v BackendFlags) {
+func (self IO) SetBackendFlags(v BackendFlags) {
 	C.wrap_ImGuiIO_SetBackendFlags(self.handle(), C.ImGuiBackendFlags(v))
 }
 
@@ -8329,7 +8329,7 @@ func (self IO) BackendFlags() BackendFlags {
 	return BackendFlags(C.wrap_ImGuiIO_GetBackendFlags(self.handle()))
 }
 
-func (self *IO) SetDisplaySize(v Vec2) {
+func (self IO) SetDisplaySize(v Vec2) {
 	C.wrap_ImGuiIO_SetDisplaySize(self.handle(), v.toC())
 }
 
@@ -8339,7 +8339,7 @@ func (self IO) DisplaySize() Vec2 {
 	return *out
 }
 
-func (self *IO) SetDeltaTime(v float32) {
+func (self IO) SetDeltaTime(v float32) {
 	C.wrap_ImGuiIO_SetDeltaTime(self.handle(), C.float(v))
 }
 
@@ -8347,7 +8347,7 @@ func (self IO) DeltaTime() float32 {
 	return float32(C.wrap_ImGuiIO_GetDeltaTime(self.handle()))
 }
 
-func (self *IO) SetIniSavingRate(v float32) {
+func (self IO) SetIniSavingRate(v float32) {
 	C.wrap_ImGuiIO_SetIniSavingRate(self.handle(), C.float(v))
 }
 
@@ -8355,7 +8355,7 @@ func (self IO) IniSavingRate() float32 {
 	return float32(C.wrap_ImGuiIO_GetIniSavingRate(self.handle()))
 }
 
-func (self *IO) SetIniFilename(v string) {
+func (self IO) SetIniFilename(v string) {
 	vArg, vFin := wrapString(v)
 	defer vFin()
 
@@ -8366,7 +8366,7 @@ func (self IO) IniFilename() string {
 	return C.GoString(C.wrap_ImGuiIO_GetIniFilename(self.handle()))
 }
 
-func (self *IO) SetLogFilename(v string) {
+func (self IO) SetLogFilename(v string) {
 	vArg, vFin := wrapString(v)
 	defer vFin()
 
@@ -8377,7 +8377,7 @@ func (self IO) LogFilename() string {
 	return C.GoString(C.wrap_ImGuiIO_GetLogFilename(self.handle()))
 }
 
-func (self *IO) SetMouseDoubleClickTime(v float32) {
+func (self IO) SetMouseDoubleClickTime(v float32) {
 	C.wrap_ImGuiIO_SetMouseDoubleClickTime(self.handle(), C.float(v))
 }
 
@@ -8385,7 +8385,7 @@ func (self IO) MouseDoubleClickTime() float32 {
 	return float32(C.wrap_ImGuiIO_GetMouseDoubleClickTime(self.handle()))
 }
 
-func (self *IO) SetMouseDoubleClickMaxDist(v float32) {
+func (self IO) SetMouseDoubleClickMaxDist(v float32) {
 	C.wrap_ImGuiIO_SetMouseDoubleClickMaxDist(self.handle(), C.float(v))
 }
 
@@ -8393,7 +8393,7 @@ func (self IO) MouseDoubleClickMaxDist() float32 {
 	return float32(C.wrap_ImGuiIO_GetMouseDoubleClickMaxDist(self.handle()))
 }
 
-func (self *IO) SetMouseDragThreshold(v float32) {
+func (self IO) SetMouseDragThreshold(v float32) {
 	C.wrap_ImGuiIO_SetMouseDragThreshold(self.handle(), C.float(v))
 }
 
@@ -8401,7 +8401,7 @@ func (self IO) MouseDragThreshold() float32 {
 	return float32(C.wrap_ImGuiIO_GetMouseDragThreshold(self.handle()))
 }
 
-func (self *IO) SetKeyRepeatDelay(v float32) {
+func (self IO) SetKeyRepeatDelay(v float32) {
 	C.wrap_ImGuiIO_SetKeyRepeatDelay(self.handle(), C.float(v))
 }
 
@@ -8409,7 +8409,7 @@ func (self IO) KeyRepeatDelay() float32 {
 	return float32(C.wrap_ImGuiIO_GetKeyRepeatDelay(self.handle()))
 }
 
-func (self *IO) SetKeyRepeatRate(v float32) {
+func (self IO) SetKeyRepeatRate(v float32) {
 	C.wrap_ImGuiIO_SetKeyRepeatRate(self.handle(), C.float(v))
 }
 
@@ -8417,7 +8417,7 @@ func (self IO) KeyRepeatRate() float32 {
 	return float32(C.wrap_ImGuiIO_GetKeyRepeatRate(self.handle()))
 }
 
-func (self *IO) SetUserData(v unsafe.Pointer) {
+func (self IO) SetUserData(v unsafe.Pointer) {
 	C.wrap_ImGuiIO_SetUserData(self.handle(), (v))
 }
 
@@ -8425,7 +8425,7 @@ func (self IO) UserData() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImGuiIO_GetUserData(self.handle()))
 }
 
-func (self *IO) SetFonts(v FontAtlas) {
+func (self IO) SetFonts(v FontAtlas) {
 	C.wrap_ImGuiIO_SetFonts(self.handle(), v.handle())
 }
 
@@ -8433,7 +8433,7 @@ func (self IO) Fonts() FontAtlas {
 	return (FontAtlas)(unsafe.Pointer(C.wrap_ImGuiIO_GetFonts(self.handle())))
 }
 
-func (self *IO) SetFontGlobalScale(v float32) {
+func (self IO) SetFontGlobalScale(v float32) {
 	C.wrap_ImGuiIO_SetFontGlobalScale(self.handle(), C.float(v))
 }
 
@@ -8441,7 +8441,7 @@ func (self IO) FontGlobalScale() float32 {
 	return float32(C.wrap_ImGuiIO_GetFontGlobalScale(self.handle()))
 }
 
-func (self *IO) SetFontAllowUserScaling(v bool) {
+func (self IO) SetFontAllowUserScaling(v bool) {
 	C.wrap_ImGuiIO_SetFontAllowUserScaling(self.handle(), C.bool(v))
 }
 
@@ -8449,7 +8449,7 @@ func (self IO) FontAllowUserScaling() bool {
 	return C.wrap_ImGuiIO_GetFontAllowUserScaling(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetFontDefault(v Font) {
+func (self IO) SetFontDefault(v Font) {
 	C.wrap_ImGuiIO_SetFontDefault(self.handle(), v.handle())
 }
 
@@ -8457,7 +8457,7 @@ func (self IO) FontDefault() Font {
 	return (Font)(unsafe.Pointer(C.wrap_ImGuiIO_GetFontDefault(self.handle())))
 }
 
-func (self *IO) SetDisplayFramebufferScale(v Vec2) {
+func (self IO) SetDisplayFramebufferScale(v Vec2) {
 	C.wrap_ImGuiIO_SetDisplayFramebufferScale(self.handle(), v.toC())
 }
 
@@ -8467,7 +8467,7 @@ func (self IO) DisplayFramebufferScale() Vec2 {
 	return *out
 }
 
-func (self *IO) SetConfigDockingNoSplit(v bool) {
+func (self IO) SetConfigDockingNoSplit(v bool) {
 	C.wrap_ImGuiIO_SetConfigDockingNoSplit(self.handle(), C.bool(v))
 }
 
@@ -8475,7 +8475,7 @@ func (self IO) ConfigDockingNoSplit() bool {
 	return C.wrap_ImGuiIO_GetConfigDockingNoSplit(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetConfigDockingWithShift(v bool) {
+func (self IO) SetConfigDockingWithShift(v bool) {
 	C.wrap_ImGuiIO_SetConfigDockingWithShift(self.handle(), C.bool(v))
 }
 
@@ -8483,7 +8483,7 @@ func (self IO) ConfigDockingWithShift() bool {
 	return C.wrap_ImGuiIO_GetConfigDockingWithShift(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetConfigDockingAlwaysTabBar(v bool) {
+func (self IO) SetConfigDockingAlwaysTabBar(v bool) {
 	C.wrap_ImGuiIO_SetConfigDockingAlwaysTabBar(self.handle(), C.bool(v))
 }
 
@@ -8491,7 +8491,7 @@ func (self IO) ConfigDockingAlwaysTabBar() bool {
 	return C.wrap_ImGuiIO_GetConfigDockingAlwaysTabBar(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetConfigDockingTransparentPayload(v bool) {
+func (self IO) SetConfigDockingTransparentPayload(v bool) {
 	C.wrap_ImGuiIO_SetConfigDockingTransparentPayload(self.handle(), C.bool(v))
 }
 
@@ -8499,7 +8499,7 @@ func (self IO) ConfigDockingTransparentPayload() bool {
 	return C.wrap_ImGuiIO_GetConfigDockingTransparentPayload(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetConfigViewportsNoAutoMerge(v bool) {
+func (self IO) SetConfigViewportsNoAutoMerge(v bool) {
 	C.wrap_ImGuiIO_SetConfigViewportsNoAutoMerge(self.handle(), C.bool(v))
 }
 
@@ -8507,7 +8507,7 @@ func (self IO) ConfigViewportsNoAutoMerge() bool {
 	return C.wrap_ImGuiIO_GetConfigViewportsNoAutoMerge(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetConfigViewportsNoTaskBarIcon(v bool) {
+func (self IO) SetConfigViewportsNoTaskBarIcon(v bool) {
 	C.wrap_ImGuiIO_SetConfigViewportsNoTaskBarIcon(self.handle(), C.bool(v))
 }
 
@@ -8515,7 +8515,7 @@ func (self IO) ConfigViewportsNoTaskBarIcon() bool {
 	return C.wrap_ImGuiIO_GetConfigViewportsNoTaskBarIcon(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetConfigViewportsNoDecoration(v bool) {
+func (self IO) SetConfigViewportsNoDecoration(v bool) {
 	C.wrap_ImGuiIO_SetConfigViewportsNoDecoration(self.handle(), C.bool(v))
 }
 
@@ -8523,7 +8523,7 @@ func (self IO) ConfigViewportsNoDecoration() bool {
 	return C.wrap_ImGuiIO_GetConfigViewportsNoDecoration(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetConfigViewportsNoDefaultParent(v bool) {
+func (self IO) SetConfigViewportsNoDefaultParent(v bool) {
 	C.wrap_ImGuiIO_SetConfigViewportsNoDefaultParent(self.handle(), C.bool(v))
 }
 
@@ -8531,7 +8531,7 @@ func (self IO) ConfigViewportsNoDefaultParent() bool {
 	return C.wrap_ImGuiIO_GetConfigViewportsNoDefaultParent(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetMouseDrawCursor(v bool) {
+func (self IO) SetMouseDrawCursor(v bool) {
 	C.wrap_ImGuiIO_SetMouseDrawCursor(self.handle(), C.bool(v))
 }
 
@@ -8539,7 +8539,7 @@ func (self IO) MouseDrawCursor() bool {
 	return C.wrap_ImGuiIO_GetMouseDrawCursor(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetConfigMacOSXBehaviors(v bool) {
+func (self IO) SetConfigMacOSXBehaviors(v bool) {
 	C.wrap_ImGuiIO_SetConfigMacOSXBehaviors(self.handle(), C.bool(v))
 }
 
@@ -8547,7 +8547,7 @@ func (self IO) ConfigMacOSXBehaviors() bool {
 	return C.wrap_ImGuiIO_GetConfigMacOSXBehaviors(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetConfigInputTrickleEventQueue(v bool) {
+func (self IO) SetConfigInputTrickleEventQueue(v bool) {
 	C.wrap_ImGuiIO_SetConfigInputTrickleEventQueue(self.handle(), C.bool(v))
 }
 
@@ -8555,7 +8555,7 @@ func (self IO) ConfigInputTrickleEventQueue() bool {
 	return C.wrap_ImGuiIO_GetConfigInputTrickleEventQueue(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetConfigInputTextCursorBlink(v bool) {
+func (self IO) SetConfigInputTextCursorBlink(v bool) {
 	C.wrap_ImGuiIO_SetConfigInputTextCursorBlink(self.handle(), C.bool(v))
 }
 
@@ -8563,7 +8563,7 @@ func (self IO) ConfigInputTextCursorBlink() bool {
 	return C.wrap_ImGuiIO_GetConfigInputTextCursorBlink(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetConfigInputTextEnterKeepActive(v bool) {
+func (self IO) SetConfigInputTextEnterKeepActive(v bool) {
 	C.wrap_ImGuiIO_SetConfigInputTextEnterKeepActive(self.handle(), C.bool(v))
 }
 
@@ -8571,7 +8571,7 @@ func (self IO) ConfigInputTextEnterKeepActive() bool {
 	return C.wrap_ImGuiIO_GetConfigInputTextEnterKeepActive(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetConfigDragClickToInputText(v bool) {
+func (self IO) SetConfigDragClickToInputText(v bool) {
 	C.wrap_ImGuiIO_SetConfigDragClickToInputText(self.handle(), C.bool(v))
 }
 
@@ -8579,7 +8579,7 @@ func (self IO) ConfigDragClickToInputText() bool {
 	return C.wrap_ImGuiIO_GetConfigDragClickToInputText(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetConfigWindowsResizeFromEdges(v bool) {
+func (self IO) SetConfigWindowsResizeFromEdges(v bool) {
 	C.wrap_ImGuiIO_SetConfigWindowsResizeFromEdges(self.handle(), C.bool(v))
 }
 
@@ -8587,7 +8587,7 @@ func (self IO) ConfigWindowsResizeFromEdges() bool {
 	return C.wrap_ImGuiIO_GetConfigWindowsResizeFromEdges(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetConfigWindowsMoveFromTitleBarOnly(v bool) {
+func (self IO) SetConfigWindowsMoveFromTitleBarOnly(v bool) {
 	C.wrap_ImGuiIO_SetConfigWindowsMoveFromTitleBarOnly(self.handle(), C.bool(v))
 }
 
@@ -8595,7 +8595,7 @@ func (self IO) ConfigWindowsMoveFromTitleBarOnly() bool {
 	return C.wrap_ImGuiIO_GetConfigWindowsMoveFromTitleBarOnly(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetConfigMemoryCompactTimer(v float32) {
+func (self IO) SetConfigMemoryCompactTimer(v float32) {
 	C.wrap_ImGuiIO_SetConfigMemoryCompactTimer(self.handle(), C.float(v))
 }
 
@@ -8603,7 +8603,7 @@ func (self IO) ConfigMemoryCompactTimer() float32 {
 	return float32(C.wrap_ImGuiIO_GetConfigMemoryCompactTimer(self.handle()))
 }
 
-func (self *IO) SetBackendPlatformName(v string) {
+func (self IO) SetBackendPlatformName(v string) {
 	vArg, vFin := wrapString(v)
 	defer vFin()
 
@@ -8614,7 +8614,7 @@ func (self IO) BackendPlatformName() string {
 	return C.GoString(C.wrap_ImGuiIO_GetBackendPlatformName(self.handle()))
 }
 
-func (self *IO) SetBackendRendererName(v string) {
+func (self IO) SetBackendRendererName(v string) {
 	vArg, vFin := wrapString(v)
 	defer vFin()
 
@@ -8625,7 +8625,7 @@ func (self IO) BackendRendererName() string {
 	return C.GoString(C.wrap_ImGuiIO_GetBackendRendererName(self.handle()))
 }
 
-func (self *IO) SetBackendPlatformUserData(v unsafe.Pointer) {
+func (self IO) SetBackendPlatformUserData(v unsafe.Pointer) {
 	C.wrap_ImGuiIO_SetBackendPlatformUserData(self.handle(), (v))
 }
 
@@ -8633,7 +8633,7 @@ func (self IO) BackendPlatformUserData() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImGuiIO_GetBackendPlatformUserData(self.handle()))
 }
 
-func (self *IO) SetBackendRendererUserData(v unsafe.Pointer) {
+func (self IO) SetBackendRendererUserData(v unsafe.Pointer) {
 	C.wrap_ImGuiIO_SetBackendRendererUserData(self.handle(), (v))
 }
 
@@ -8641,7 +8641,7 @@ func (self IO) BackendRendererUserData() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImGuiIO_GetBackendRendererUserData(self.handle()))
 }
 
-func (self *IO) SetBackendLanguageUserData(v unsafe.Pointer) {
+func (self IO) SetBackendLanguageUserData(v unsafe.Pointer) {
 	C.wrap_ImGuiIO_SetBackendLanguageUserData(self.handle(), (v))
 }
 
@@ -8649,7 +8649,7 @@ func (self IO) BackendLanguageUserData() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImGuiIO_GetBackendLanguageUserData(self.handle()))
 }
 
-func (self *IO) SetClipboardUserData(v unsafe.Pointer) {
+func (self IO) SetClipboardUserData(v unsafe.Pointer) {
 	C.wrap_ImGuiIO_SetClipboardUserData(self.handle(), (v))
 }
 
@@ -8657,7 +8657,7 @@ func (self IO) ClipboardUserData() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImGuiIO_GetClipboardUserData(self.handle()))
 }
 
-func (self *IO) SetUnusedPadding(v unsafe.Pointer) {
+func (self IO) SetUnusedPadding(v unsafe.Pointer) {
 	C.wrap_ImGuiIO_Set_UnusedPadding(self.handle(), (v))
 }
 
@@ -8665,7 +8665,7 @@ func (self IO) UnusedPadding() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImGuiIO_Get_UnusedPadding(self.handle()))
 }
 
-func (self *IO) SetWantCaptureMouse(v bool) {
+func (self IO) SetWantCaptureMouse(v bool) {
 	C.wrap_ImGuiIO_SetWantCaptureMouse(self.handle(), C.bool(v))
 }
 
@@ -8673,7 +8673,7 @@ func (self IO) WantCaptureMouse() bool {
 	return C.wrap_ImGuiIO_GetWantCaptureMouse(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetWantCaptureKeyboard(v bool) {
+func (self IO) SetWantCaptureKeyboard(v bool) {
 	C.wrap_ImGuiIO_SetWantCaptureKeyboard(self.handle(), C.bool(v))
 }
 
@@ -8681,7 +8681,7 @@ func (self IO) WantCaptureKeyboard() bool {
 	return C.wrap_ImGuiIO_GetWantCaptureKeyboard(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetWantTextInput(v bool) {
+func (self IO) SetWantTextInput(v bool) {
 	C.wrap_ImGuiIO_SetWantTextInput(self.handle(), C.bool(v))
 }
 
@@ -8689,7 +8689,7 @@ func (self IO) WantTextInput() bool {
 	return C.wrap_ImGuiIO_GetWantTextInput(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetWantSetMousePos(v bool) {
+func (self IO) SetWantSetMousePos(v bool) {
 	C.wrap_ImGuiIO_SetWantSetMousePos(self.handle(), C.bool(v))
 }
 
@@ -8697,7 +8697,7 @@ func (self IO) WantSetMousePos() bool {
 	return C.wrap_ImGuiIO_GetWantSetMousePos(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetWantSaveIniSettings(v bool) {
+func (self IO) SetWantSaveIniSettings(v bool) {
 	C.wrap_ImGuiIO_SetWantSaveIniSettings(self.handle(), C.bool(v))
 }
 
@@ -8705,7 +8705,7 @@ func (self IO) WantSaveIniSettings() bool {
 	return C.wrap_ImGuiIO_GetWantSaveIniSettings(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetNavActive(v bool) {
+func (self IO) SetNavActive(v bool) {
 	C.wrap_ImGuiIO_SetNavActive(self.handle(), C.bool(v))
 }
 
@@ -8713,7 +8713,7 @@ func (self IO) NavActive() bool {
 	return C.wrap_ImGuiIO_GetNavActive(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetNavVisible(v bool) {
+func (self IO) SetNavVisible(v bool) {
 	C.wrap_ImGuiIO_SetNavVisible(self.handle(), C.bool(v))
 }
 
@@ -8721,7 +8721,7 @@ func (self IO) NavVisible() bool {
 	return C.wrap_ImGuiIO_GetNavVisible(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetFramerate(v float32) {
+func (self IO) SetFramerate(v float32) {
 	C.wrap_ImGuiIO_SetFramerate(self.handle(), C.float(v))
 }
 
@@ -8729,7 +8729,7 @@ func (self IO) Framerate() float32 {
 	return float32(C.wrap_ImGuiIO_GetFramerate(self.handle()))
 }
 
-func (self *IO) SetMetricsRenderVertices(v int32) {
+func (self IO) SetMetricsRenderVertices(v int32) {
 	C.wrap_ImGuiIO_SetMetricsRenderVertices(self.handle(), C.int(v))
 }
 
@@ -8737,7 +8737,7 @@ func (self IO) MetricsRenderVertices() int {
 	return int(C.wrap_ImGuiIO_GetMetricsRenderVertices(self.handle()))
 }
 
-func (self *IO) SetMetricsRenderIndices(v int32) {
+func (self IO) SetMetricsRenderIndices(v int32) {
 	C.wrap_ImGuiIO_SetMetricsRenderIndices(self.handle(), C.int(v))
 }
 
@@ -8745,7 +8745,7 @@ func (self IO) MetricsRenderIndices() int {
 	return int(C.wrap_ImGuiIO_GetMetricsRenderIndices(self.handle()))
 }
 
-func (self *IO) SetMetricsRenderWindows(v int32) {
+func (self IO) SetMetricsRenderWindows(v int32) {
 	C.wrap_ImGuiIO_SetMetricsRenderWindows(self.handle(), C.int(v))
 }
 
@@ -8753,7 +8753,7 @@ func (self IO) MetricsRenderWindows() int {
 	return int(C.wrap_ImGuiIO_GetMetricsRenderWindows(self.handle()))
 }
 
-func (self *IO) SetMetricsActiveWindows(v int32) {
+func (self IO) SetMetricsActiveWindows(v int32) {
 	C.wrap_ImGuiIO_SetMetricsActiveWindows(self.handle(), C.int(v))
 }
 
@@ -8761,7 +8761,7 @@ func (self IO) MetricsActiveWindows() int {
 	return int(C.wrap_ImGuiIO_GetMetricsActiveWindows(self.handle()))
 }
 
-func (self *IO) SetMetricsActiveAllocations(v int32) {
+func (self IO) SetMetricsActiveAllocations(v int32) {
 	C.wrap_ImGuiIO_SetMetricsActiveAllocations(self.handle(), C.int(v))
 }
 
@@ -8769,7 +8769,7 @@ func (self IO) MetricsActiveAllocations() int {
 	return int(C.wrap_ImGuiIO_GetMetricsActiveAllocations(self.handle()))
 }
 
-func (self *IO) SetMouseDelta(v Vec2) {
+func (self IO) SetMouseDelta(v Vec2) {
 	C.wrap_ImGuiIO_SetMouseDelta(self.handle(), v.toC())
 }
 
@@ -8779,7 +8779,7 @@ func (self IO) MouseDelta() Vec2 {
 	return *out
 }
 
-func (self *IO) SetMousePos(v Vec2) {
+func (self IO) SetMousePos(v Vec2) {
 	C.wrap_ImGuiIO_SetMousePos(self.handle(), v.toC())
 }
 
@@ -8789,7 +8789,7 @@ func (self IO) MousePos() Vec2 {
 	return *out
 }
 
-func (self *IO) SetMouseWheel(v float32) {
+func (self IO) SetMouseWheel(v float32) {
 	C.wrap_ImGuiIO_SetMouseWheel(self.handle(), C.float(v))
 }
 
@@ -8797,7 +8797,7 @@ func (self IO) MouseWheel() float32 {
 	return float32(C.wrap_ImGuiIO_GetMouseWheel(self.handle()))
 }
 
-func (self *IO) SetMouseWheelH(v float32) {
+func (self IO) SetMouseWheelH(v float32) {
 	C.wrap_ImGuiIO_SetMouseWheelH(self.handle(), C.float(v))
 }
 
@@ -8805,7 +8805,7 @@ func (self IO) MouseWheelH() float32 {
 	return float32(C.wrap_ImGuiIO_GetMouseWheelH(self.handle()))
 }
 
-func (self *IO) SetMouseHoveredViewport(v ID) {
+func (self IO) SetMouseHoveredViewport(v ID) {
 	C.wrap_ImGuiIO_SetMouseHoveredViewport(self.handle(), C.ImGuiID(v))
 }
 
@@ -8813,7 +8813,7 @@ func (self IO) MouseHoveredViewport() ID {
 	return ID(C.wrap_ImGuiIO_GetMouseHoveredViewport(self.handle()))
 }
 
-func (self *IO) SetKeyCtrl(v bool) {
+func (self IO) SetKeyCtrl(v bool) {
 	C.wrap_ImGuiIO_SetKeyCtrl(self.handle(), C.bool(v))
 }
 
@@ -8821,7 +8821,7 @@ func (self IO) KeyCtrl() bool {
 	return C.wrap_ImGuiIO_GetKeyCtrl(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetKeyShift(v bool) {
+func (self IO) SetKeyShift(v bool) {
 	C.wrap_ImGuiIO_SetKeyShift(self.handle(), C.bool(v))
 }
 
@@ -8829,7 +8829,7 @@ func (self IO) KeyShift() bool {
 	return C.wrap_ImGuiIO_GetKeyShift(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetKeyAlt(v bool) {
+func (self IO) SetKeyAlt(v bool) {
 	C.wrap_ImGuiIO_SetKeyAlt(self.handle(), C.bool(v))
 }
 
@@ -8837,7 +8837,7 @@ func (self IO) KeyAlt() bool {
 	return C.wrap_ImGuiIO_GetKeyAlt(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetKeySuper(v bool) {
+func (self IO) SetKeySuper(v bool) {
 	C.wrap_ImGuiIO_SetKeySuper(self.handle(), C.bool(v))
 }
 
@@ -8845,7 +8845,7 @@ func (self IO) KeySuper() bool {
 	return C.wrap_ImGuiIO_GetKeySuper(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetKeyMods(v ModFlags) {
+func (self IO) SetKeyMods(v ModFlags) {
 	C.wrap_ImGuiIO_SetKeyMods(self.handle(), C.ImGuiModFlags(v))
 }
 
@@ -8853,7 +8853,7 @@ func (self IO) KeyMods() ModFlags {
 	return ModFlags(C.wrap_ImGuiIO_GetKeyMods(self.handle()))
 }
 
-func (self *IO) SetWantCaptureMouseUnlessPopupClose(v bool) {
+func (self IO) SetWantCaptureMouseUnlessPopupClose(v bool) {
 	C.wrap_ImGuiIO_SetWantCaptureMouseUnlessPopupClose(self.handle(), C.bool(v))
 }
 
@@ -8861,7 +8861,7 @@ func (self IO) WantCaptureMouseUnlessPopupClose() bool {
 	return C.wrap_ImGuiIO_GetWantCaptureMouseUnlessPopupClose(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetMousePosPrev(v Vec2) {
+func (self IO) SetMousePosPrev(v Vec2) {
 	C.wrap_ImGuiIO_SetMousePosPrev(self.handle(), v.toC())
 }
 
@@ -8871,7 +8871,7 @@ func (self IO) MousePosPrev() Vec2 {
 	return *out
 }
 
-func (self *IO) SetPenPressure(v float32) {
+func (self IO) SetPenPressure(v float32) {
 	C.wrap_ImGuiIO_SetPenPressure(self.handle(), C.float(v))
 }
 
@@ -8879,7 +8879,7 @@ func (self IO) PenPressure() float32 {
 	return float32(C.wrap_ImGuiIO_GetPenPressure(self.handle()))
 }
 
-func (self *IO) SetAppFocusLost(v bool) {
+func (self IO) SetAppFocusLost(v bool) {
 	C.wrap_ImGuiIO_SetAppFocusLost(self.handle(), C.bool(v))
 }
 
@@ -8887,7 +8887,7 @@ func (self IO) AppFocusLost() bool {
 	return C.wrap_ImGuiIO_GetAppFocusLost(self.handle()) == C.bool(true)
 }
 
-func (self *IO) SetBackendUsingLegacyKeyArrays(v int) {
+func (self IO) SetBackendUsingLegacyKeyArrays(v int) {
 	C.wrap_ImGuiIO_SetBackendUsingLegacyKeyArrays(self.handle(), C.ImS8(v))
 }
 
@@ -8895,7 +8895,7 @@ func (self IO) BackendUsingLegacyKeyArrays() int {
 	return int(C.wrap_ImGuiIO_GetBackendUsingLegacyKeyArrays(self.handle()))
 }
 
-func (self *IO) SetBackendUsingLegacyNavInputArray(v bool) {
+func (self IO) SetBackendUsingLegacyNavInputArray(v bool) {
 	C.wrap_ImGuiIO_SetBackendUsingLegacyNavInputArray(self.handle(), C.bool(v))
 }
 
@@ -8903,7 +8903,7 @@ func (self IO) BackendUsingLegacyNavInputArray() bool {
 	return C.wrap_ImGuiIO_GetBackendUsingLegacyNavInputArray(self.handle()) == C.bool(true)
 }
 
-func (self *InputEvent) SetType(v InputEventType) {
+func (self InputEvent) SetType(v InputEventType) {
 	C.wrap_ImGuiInputEvent_SetType(self.handle(), C.ImGuiInputEventType(v))
 }
 
@@ -8911,7 +8911,7 @@ func (self InputEvent) Type() InputEventType {
 	return InputEventType(C.wrap_ImGuiInputEvent_GetType(self.handle()))
 }
 
-func (self *InputEvent) SetSource(v InputSource) {
+func (self InputEvent) SetSource(v InputSource) {
 	C.wrap_ImGuiInputEvent_SetSource(self.handle(), C.ImGuiInputSource(v))
 }
 
@@ -8919,7 +8919,7 @@ func (self InputEvent) Source() InputSource {
 	return InputSource(C.wrap_ImGuiInputEvent_GetSource(self.handle()))
 }
 
-func (self *InputEvent) SetIgnoredAsSame(v bool) {
+func (self InputEvent) SetIgnoredAsSame(v bool) {
 	C.wrap_ImGuiInputEvent_SetIgnoredAsSame(self.handle(), C.bool(v))
 }
 
@@ -8927,7 +8927,7 @@ func (self InputEvent) IgnoredAsSame() bool {
 	return C.wrap_ImGuiInputEvent_GetIgnoredAsSame(self.handle()) == C.bool(true)
 }
 
-func (self *InputEvent) SetAddedByTestEngine(v bool) {
+func (self InputEvent) SetAddedByTestEngine(v bool) {
 	C.wrap_ImGuiInputEvent_SetAddedByTestEngine(self.handle(), C.bool(v))
 }
 
@@ -8935,7 +8935,7 @@ func (self InputEvent) AddedByTestEngine() bool {
 	return C.wrap_ImGuiInputEvent_GetAddedByTestEngine(self.handle()) == C.bool(true)
 }
 
-func (self *InputEventAppFocused) SetFocused(v bool) {
+func (self InputEventAppFocused) SetFocused(v bool) {
 	C.wrap_ImGuiInputEventAppFocused_SetFocused(self.handle(), C.bool(v))
 }
 
@@ -8943,7 +8943,7 @@ func (self InputEventAppFocused) Focused() bool {
 	return C.wrap_ImGuiInputEventAppFocused_GetFocused(self.handle()) == C.bool(true)
 }
 
-func (self *InputEventKey) SetKey(v Key) {
+func (self InputEventKey) SetKey(v Key) {
 	C.wrap_ImGuiInputEventKey_SetKey(self.handle(), C.ImGuiKey(v))
 }
 
@@ -8951,7 +8951,7 @@ func (self InputEventKey) Key() Key {
 	return Key(C.wrap_ImGuiInputEventKey_GetKey(self.handle()))
 }
 
-func (self *InputEventKey) SetDown(v bool) {
+func (self InputEventKey) SetDown(v bool) {
 	C.wrap_ImGuiInputEventKey_SetDown(self.handle(), C.bool(v))
 }
 
@@ -8959,7 +8959,7 @@ func (self InputEventKey) Down() bool {
 	return C.wrap_ImGuiInputEventKey_GetDown(self.handle()) == C.bool(true)
 }
 
-func (self *InputEventKey) SetAnalogValue(v float32) {
+func (self InputEventKey) SetAnalogValue(v float32) {
 	C.wrap_ImGuiInputEventKey_SetAnalogValue(self.handle(), C.float(v))
 }
 
@@ -8967,7 +8967,7 @@ func (self InputEventKey) AnalogValue() float32 {
 	return float32(C.wrap_ImGuiInputEventKey_GetAnalogValue(self.handle()))
 }
 
-func (self *InputEventMouseButton) SetButton(v int32) {
+func (self InputEventMouseButton) SetButton(v int32) {
 	C.wrap_ImGuiInputEventMouseButton_SetButton(self.handle(), C.int(v))
 }
 
@@ -8975,7 +8975,7 @@ func (self InputEventMouseButton) Button() int {
 	return int(C.wrap_ImGuiInputEventMouseButton_GetButton(self.handle()))
 }
 
-func (self *InputEventMouseButton) SetDown(v bool) {
+func (self InputEventMouseButton) SetDown(v bool) {
 	C.wrap_ImGuiInputEventMouseButton_SetDown(self.handle(), C.bool(v))
 }
 
@@ -8983,7 +8983,7 @@ func (self InputEventMouseButton) Down() bool {
 	return C.wrap_ImGuiInputEventMouseButton_GetDown(self.handle()) == C.bool(true)
 }
 
-func (self *InputEventMousePos) SetPosX(v float32) {
+func (self InputEventMousePos) SetPosX(v float32) {
 	C.wrap_ImGuiInputEventMousePos_SetPosX(self.handle(), C.float(v))
 }
 
@@ -8991,7 +8991,7 @@ func (self InputEventMousePos) PosX() float32 {
 	return float32(C.wrap_ImGuiInputEventMousePos_GetPosX(self.handle()))
 }
 
-func (self *InputEventMousePos) SetPosY(v float32) {
+func (self InputEventMousePos) SetPosY(v float32) {
 	C.wrap_ImGuiInputEventMousePos_SetPosY(self.handle(), C.float(v))
 }
 
@@ -8999,7 +8999,7 @@ func (self InputEventMousePos) PosY() float32 {
 	return float32(C.wrap_ImGuiInputEventMousePos_GetPosY(self.handle()))
 }
 
-func (self *InputEventMouseViewport) SetHoveredViewportID(v ID) {
+func (self InputEventMouseViewport) SetHoveredViewportID(v ID) {
 	C.wrap_ImGuiInputEventMouseViewport_SetHoveredViewportID(self.handle(), C.ImGuiID(v))
 }
 
@@ -9007,7 +9007,7 @@ func (self InputEventMouseViewport) HoveredViewportID() ID {
 	return ID(C.wrap_ImGuiInputEventMouseViewport_GetHoveredViewportID(self.handle()))
 }
 
-func (self *InputEventMouseWheel) SetWheelX(v float32) {
+func (self InputEventMouseWheel) SetWheelX(v float32) {
 	C.wrap_ImGuiInputEventMouseWheel_SetWheelX(self.handle(), C.float(v))
 }
 
@@ -9015,7 +9015,7 @@ func (self InputEventMouseWheel) WheelX() float32 {
 	return float32(C.wrap_ImGuiInputEventMouseWheel_GetWheelX(self.handle()))
 }
 
-func (self *InputEventMouseWheel) SetWheelY(v float32) {
+func (self InputEventMouseWheel) SetWheelY(v float32) {
 	C.wrap_ImGuiInputEventMouseWheel_SetWheelY(self.handle(), C.float(v))
 }
 
@@ -9023,7 +9023,7 @@ func (self InputEventMouseWheel) WheelY() float32 {
 	return float32(C.wrap_ImGuiInputEventMouseWheel_GetWheelY(self.handle()))
 }
 
-func (self *InputEventText) SetChar(v uint32) {
+func (self InputEventText) SetChar(v uint32) {
 	C.wrap_ImGuiInputEventText_SetChar(self.handle(), C.uint(v))
 }
 
@@ -9031,7 +9031,7 @@ func (self InputEventText) Char() uint32 {
 	return uint32(C.wrap_ImGuiInputEventText_GetChar(self.handle()))
 }
 
-func (self *InputTextCallbackData) SetEventFlag(v InputTextFlags) {
+func (self InputTextCallbackData) SetEventFlag(v InputTextFlags) {
 	C.wrap_ImGuiInputTextCallbackData_SetEventFlag(self.handle(), C.ImGuiInputTextFlags(v))
 }
 
@@ -9039,7 +9039,7 @@ func (self InputTextCallbackData) EventFlag() InputTextFlags {
 	return InputTextFlags(C.wrap_ImGuiInputTextCallbackData_GetEventFlag(self.handle()))
 }
 
-func (self *InputTextCallbackData) SetFlags(v InputTextFlags) {
+func (self InputTextCallbackData) SetFlags(v InputTextFlags) {
 	C.wrap_ImGuiInputTextCallbackData_SetFlags(self.handle(), C.ImGuiInputTextFlags(v))
 }
 
@@ -9047,7 +9047,7 @@ func (self InputTextCallbackData) Flags() InputTextFlags {
 	return InputTextFlags(C.wrap_ImGuiInputTextCallbackData_GetFlags(self.handle()))
 }
 
-func (self *InputTextCallbackData) SetUserData(v unsafe.Pointer) {
+func (self InputTextCallbackData) SetUserData(v unsafe.Pointer) {
 	C.wrap_ImGuiInputTextCallbackData_SetUserData(self.handle(), (v))
 }
 
@@ -9055,7 +9055,7 @@ func (self InputTextCallbackData) UserData() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImGuiInputTextCallbackData_GetUserData(self.handle()))
 }
 
-func (self *InputTextCallbackData) SetEventChar(v Wchar) {
+func (self InputTextCallbackData) SetEventChar(v Wchar) {
 	C.wrap_ImGuiInputTextCallbackData_SetEventChar(self.handle(), C.ImWchar(v))
 }
 
@@ -9063,7 +9063,7 @@ func (self InputTextCallbackData) EventChar() Wchar {
 	return Wchar(C.wrap_ImGuiInputTextCallbackData_GetEventChar(self.handle()))
 }
 
-func (self *InputTextCallbackData) SetEventKey(v Key) {
+func (self InputTextCallbackData) SetEventKey(v Key) {
 	C.wrap_ImGuiInputTextCallbackData_SetEventKey(self.handle(), C.ImGuiKey(v))
 }
 
@@ -9071,7 +9071,7 @@ func (self InputTextCallbackData) EventKey() Key {
 	return Key(C.wrap_ImGuiInputTextCallbackData_GetEventKey(self.handle()))
 }
 
-func (self *InputTextCallbackData) SetBuf(v string) {
+func (self InputTextCallbackData) SetBuf(v string) {
 	vArg, vFin := wrapString(v)
 	defer vFin()
 
@@ -9082,7 +9082,7 @@ func (self InputTextCallbackData) Buf() string {
 	return C.GoString(C.wrap_ImGuiInputTextCallbackData_GetBuf(self.handle()))
 }
 
-func (self *InputTextCallbackData) SetBufTextLen(v int32) {
+func (self InputTextCallbackData) SetBufTextLen(v int32) {
 	C.wrap_ImGuiInputTextCallbackData_SetBufTextLen(self.handle(), C.int(v))
 }
 
@@ -9090,7 +9090,7 @@ func (self InputTextCallbackData) BufTextLen() int {
 	return int(C.wrap_ImGuiInputTextCallbackData_GetBufTextLen(self.handle()))
 }
 
-func (self *InputTextCallbackData) SetBufSize(v int32) {
+func (self InputTextCallbackData) SetBufSize(v int32) {
 	C.wrap_ImGuiInputTextCallbackData_SetBufSize(self.handle(), C.int(v))
 }
 
@@ -9098,7 +9098,7 @@ func (self InputTextCallbackData) BufSize() int {
 	return int(C.wrap_ImGuiInputTextCallbackData_GetBufSize(self.handle()))
 }
 
-func (self *InputTextCallbackData) SetBufDirty(v bool) {
+func (self InputTextCallbackData) SetBufDirty(v bool) {
 	C.wrap_ImGuiInputTextCallbackData_SetBufDirty(self.handle(), C.bool(v))
 }
 
@@ -9106,7 +9106,7 @@ func (self InputTextCallbackData) BufDirty() bool {
 	return C.wrap_ImGuiInputTextCallbackData_GetBufDirty(self.handle()) == C.bool(true)
 }
 
-func (self *InputTextCallbackData) SetCursorPos(v int32) {
+func (self InputTextCallbackData) SetCursorPos(v int32) {
 	C.wrap_ImGuiInputTextCallbackData_SetCursorPos(self.handle(), C.int(v))
 }
 
@@ -9114,7 +9114,7 @@ func (self InputTextCallbackData) CursorPos() int {
 	return int(C.wrap_ImGuiInputTextCallbackData_GetCursorPos(self.handle()))
 }
 
-func (self *InputTextCallbackData) SetSelectionStart(v int32) {
+func (self InputTextCallbackData) SetSelectionStart(v int32) {
 	C.wrap_ImGuiInputTextCallbackData_SetSelectionStart(self.handle(), C.int(v))
 }
 
@@ -9122,7 +9122,7 @@ func (self InputTextCallbackData) SelectionStart() int {
 	return int(C.wrap_ImGuiInputTextCallbackData_GetSelectionStart(self.handle()))
 }
 
-func (self *InputTextCallbackData) SetSelectionEnd(v int32) {
+func (self InputTextCallbackData) SetSelectionEnd(v int32) {
 	C.wrap_ImGuiInputTextCallbackData_SetSelectionEnd(self.handle(), C.int(v))
 }
 
@@ -9130,7 +9130,7 @@ func (self InputTextCallbackData) SelectionEnd() int {
 	return int(C.wrap_ImGuiInputTextCallbackData_GetSelectionEnd(self.handle()))
 }
 
-func (self *InputTextState) SetID(v ID) {
+func (self InputTextState) SetID(v ID) {
 	C.wrap_ImGuiInputTextState_SetID(self.handle(), C.ImGuiID(v))
 }
 
@@ -9138,7 +9138,7 @@ func (self InputTextState) ID() ID {
 	return ID(C.wrap_ImGuiInputTextState_GetID(self.handle()))
 }
 
-func (self *InputTextState) SetCurLenW(v int32) {
+func (self InputTextState) SetCurLenW(v int32) {
 	C.wrap_ImGuiInputTextState_SetCurLenW(self.handle(), C.int(v))
 }
 
@@ -9146,7 +9146,7 @@ func (self InputTextState) CurLenW() int {
 	return int(C.wrap_ImGuiInputTextState_GetCurLenW(self.handle()))
 }
 
-func (self *InputTextState) SetCurLenA(v int32) {
+func (self InputTextState) SetCurLenA(v int32) {
 	C.wrap_ImGuiInputTextState_SetCurLenA(self.handle(), C.int(v))
 }
 
@@ -9154,7 +9154,7 @@ func (self InputTextState) CurLenA() int {
 	return int(C.wrap_ImGuiInputTextState_GetCurLenA(self.handle()))
 }
 
-func (self *InputTextState) SetTextAIsValid(v bool) {
+func (self InputTextState) SetTextAIsValid(v bool) {
 	C.wrap_ImGuiInputTextState_SetTextAIsValid(self.handle(), C.bool(v))
 }
 
@@ -9162,7 +9162,7 @@ func (self InputTextState) TextAIsValid() bool {
 	return C.wrap_ImGuiInputTextState_GetTextAIsValid(self.handle()) == C.bool(true)
 }
 
-func (self *InputTextState) SetBufCapacityA(v int32) {
+func (self InputTextState) SetBufCapacityA(v int32) {
 	C.wrap_ImGuiInputTextState_SetBufCapacityA(self.handle(), C.int(v))
 }
 
@@ -9170,7 +9170,7 @@ func (self InputTextState) BufCapacityA() int {
 	return int(C.wrap_ImGuiInputTextState_GetBufCapacityA(self.handle()))
 }
 
-func (self *InputTextState) SetScrollX(v float32) {
+func (self InputTextState) SetScrollX(v float32) {
 	C.wrap_ImGuiInputTextState_SetScrollX(self.handle(), C.float(v))
 }
 
@@ -9178,7 +9178,7 @@ func (self InputTextState) ScrollX() float32 {
 	return float32(C.wrap_ImGuiInputTextState_GetScrollX(self.handle()))
 }
 
-func (self *InputTextState) SetCursorAnim(v float32) {
+func (self InputTextState) SetCursorAnim(v float32) {
 	C.wrap_ImGuiInputTextState_SetCursorAnim(self.handle(), C.float(v))
 }
 
@@ -9186,7 +9186,7 @@ func (self InputTextState) CursorAnim() float32 {
 	return float32(C.wrap_ImGuiInputTextState_GetCursorAnim(self.handle()))
 }
 
-func (self *InputTextState) SetCursorFollow(v bool) {
+func (self InputTextState) SetCursorFollow(v bool) {
 	C.wrap_ImGuiInputTextState_SetCursorFollow(self.handle(), C.bool(v))
 }
 
@@ -9194,7 +9194,7 @@ func (self InputTextState) CursorFollow() bool {
 	return C.wrap_ImGuiInputTextState_GetCursorFollow(self.handle()) == C.bool(true)
 }
 
-func (self *InputTextState) SetSelectedAllMouseLock(v bool) {
+func (self InputTextState) SetSelectedAllMouseLock(v bool) {
 	C.wrap_ImGuiInputTextState_SetSelectedAllMouseLock(self.handle(), C.bool(v))
 }
 
@@ -9202,7 +9202,7 @@ func (self InputTextState) SelectedAllMouseLock() bool {
 	return C.wrap_ImGuiInputTextState_GetSelectedAllMouseLock(self.handle()) == C.bool(true)
 }
 
-func (self *InputTextState) SetEdited(v bool) {
+func (self InputTextState) SetEdited(v bool) {
 	C.wrap_ImGuiInputTextState_SetEdited(self.handle(), C.bool(v))
 }
 
@@ -9210,7 +9210,7 @@ func (self InputTextState) Edited() bool {
 	return C.wrap_ImGuiInputTextState_GetEdited(self.handle()) == C.bool(true)
 }
 
-func (self *InputTextState) SetFlags(v InputTextFlags) {
+func (self InputTextState) SetFlags(v InputTextFlags) {
 	C.wrap_ImGuiInputTextState_SetFlags(self.handle(), C.ImGuiInputTextFlags(v))
 }
 
@@ -9218,7 +9218,7 @@ func (self InputTextState) Flags() InputTextFlags {
 	return InputTextFlags(C.wrap_ImGuiInputTextState_GetFlags(self.handle()))
 }
 
-func (self *KeyData) SetDown(v bool) {
+func (self KeyData) SetDown(v bool) {
 	C.wrap_ImGuiKeyData_SetDown(self.handle(), C.bool(v))
 }
 
@@ -9226,7 +9226,7 @@ func (self KeyData) Down() bool {
 	return C.wrap_ImGuiKeyData_GetDown(self.handle()) == C.bool(true)
 }
 
-func (self *KeyData) SetDownDuration(v float32) {
+func (self KeyData) SetDownDuration(v float32) {
 	C.wrap_ImGuiKeyData_SetDownDuration(self.handle(), C.float(v))
 }
 
@@ -9234,7 +9234,7 @@ func (self KeyData) DownDuration() float32 {
 	return float32(C.wrap_ImGuiKeyData_GetDownDuration(self.handle()))
 }
 
-func (self *KeyData) SetDownDurationPrev(v float32) {
+func (self KeyData) SetDownDurationPrev(v float32) {
 	C.wrap_ImGuiKeyData_SetDownDurationPrev(self.handle(), C.float(v))
 }
 
@@ -9242,7 +9242,7 @@ func (self KeyData) DownDurationPrev() float32 {
 	return float32(C.wrap_ImGuiKeyData_GetDownDurationPrev(self.handle()))
 }
 
-func (self *KeyData) SetAnalogValue(v float32) {
+func (self KeyData) SetAnalogValue(v float32) {
 	C.wrap_ImGuiKeyData_SetAnalogValue(self.handle(), C.float(v))
 }
 
@@ -9250,7 +9250,7 @@ func (self KeyData) AnalogValue() float32 {
 	return float32(C.wrap_ImGuiKeyData_GetAnalogValue(self.handle()))
 }
 
-func (self *LastItemData) SetID(v ID) {
+func (self LastItemData) SetID(v ID) {
 	C.wrap_ImGuiLastItemData_SetID(self.handle(), C.ImGuiID(v))
 }
 
@@ -9258,7 +9258,7 @@ func (self LastItemData) ID() ID {
 	return ID(C.wrap_ImGuiLastItemData_GetID(self.handle()))
 }
 
-func (self *LastItemData) SetInFlags(v ItemFlags) {
+func (self LastItemData) SetInFlags(v ItemFlags) {
 	C.wrap_ImGuiLastItemData_SetInFlags(self.handle(), C.ImGuiItemFlags(v))
 }
 
@@ -9266,7 +9266,7 @@ func (self LastItemData) InFlags() ItemFlags {
 	return ItemFlags(C.wrap_ImGuiLastItemData_GetInFlags(self.handle()))
 }
 
-func (self *LastItemData) SetStatusFlags(v ItemStatusFlags) {
+func (self LastItemData) SetStatusFlags(v ItemStatusFlags) {
 	C.wrap_ImGuiLastItemData_SetStatusFlags(self.handle(), C.ImGuiItemStatusFlags(v))
 }
 
@@ -9274,7 +9274,7 @@ func (self LastItemData) StatusFlags() ItemStatusFlags {
 	return ItemStatusFlags(C.wrap_ImGuiLastItemData_GetStatusFlags(self.handle()))
 }
 
-func (self *LastItemData) SetRect(v Rect) {
+func (self LastItemData) SetRect(v Rect) {
 	C.wrap_ImGuiLastItemData_SetRect(self.handle(), v.toC())
 }
 
@@ -9284,7 +9284,7 @@ func (self LastItemData) Rect() Rect {
 	return *out
 }
 
-func (self *LastItemData) SetNavRect(v Rect) {
+func (self LastItemData) SetNavRect(v Rect) {
 	C.wrap_ImGuiLastItemData_SetNavRect(self.handle(), v.toC())
 }
 
@@ -9294,7 +9294,7 @@ func (self LastItemData) NavRect() Rect {
 	return *out
 }
 
-func (self *LastItemData) SetDisplayRect(v Rect) {
+func (self LastItemData) SetDisplayRect(v Rect) {
 	C.wrap_ImGuiLastItemData_SetDisplayRect(self.handle(), v.toC())
 }
 
@@ -9304,7 +9304,7 @@ func (self LastItemData) DisplayRect() Rect {
 	return *out
 }
 
-func (self *ListClipper) SetDisplayStart(v int32) {
+func (self ListClipper) SetDisplayStart(v int32) {
 	C.wrap_ImGuiListClipper_SetDisplayStart(self.handle(), C.int(v))
 }
 
@@ -9312,7 +9312,7 @@ func (self ListClipper) DisplayStart() int {
 	return int(C.wrap_ImGuiListClipper_GetDisplayStart(self.handle()))
 }
 
-func (self *ListClipper) SetDisplayEnd(v int32) {
+func (self ListClipper) SetDisplayEnd(v int32) {
 	C.wrap_ImGuiListClipper_SetDisplayEnd(self.handle(), C.int(v))
 }
 
@@ -9320,7 +9320,7 @@ func (self ListClipper) DisplayEnd() int {
 	return int(C.wrap_ImGuiListClipper_GetDisplayEnd(self.handle()))
 }
 
-func (self *ListClipper) SetItemsCount(v int32) {
+func (self ListClipper) SetItemsCount(v int32) {
 	C.wrap_ImGuiListClipper_SetItemsCount(self.handle(), C.int(v))
 }
 
@@ -9328,7 +9328,7 @@ func (self ListClipper) ItemsCount() int {
 	return int(C.wrap_ImGuiListClipper_GetItemsCount(self.handle()))
 }
 
-func (self *ListClipper) SetItemsHeight(v float32) {
+func (self ListClipper) SetItemsHeight(v float32) {
 	C.wrap_ImGuiListClipper_SetItemsHeight(self.handle(), C.float(v))
 }
 
@@ -9336,7 +9336,7 @@ func (self ListClipper) ItemsHeight() float32 {
 	return float32(C.wrap_ImGuiListClipper_GetItemsHeight(self.handle()))
 }
 
-func (self *ListClipper) SetStartPosY(v float32) {
+func (self ListClipper) SetStartPosY(v float32) {
 	C.wrap_ImGuiListClipper_SetStartPosY(self.handle(), C.float(v))
 }
 
@@ -9344,7 +9344,7 @@ func (self ListClipper) StartPosY() float32 {
 	return float32(C.wrap_ImGuiListClipper_GetStartPosY(self.handle()))
 }
 
-func (self *ListClipper) SetTempData(v unsafe.Pointer) {
+func (self ListClipper) SetTempData(v unsafe.Pointer) {
 	C.wrap_ImGuiListClipper_SetTempData(self.handle(), (v))
 }
 
@@ -9352,7 +9352,7 @@ func (self ListClipper) TempData() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImGuiListClipper_GetTempData(self.handle()))
 }
 
-func (self *ListClipperData) SetListClipper(v ListClipper) {
+func (self ListClipperData) SetListClipper(v ListClipper) {
 	C.wrap_ImGuiListClipperData_SetListClipper(self.handle(), v.handle())
 }
 
@@ -9360,7 +9360,7 @@ func (self ListClipperData) ListClipper() ListClipper {
 	return (ListClipper)(unsafe.Pointer(C.wrap_ImGuiListClipperData_GetListClipper(self.handle())))
 }
 
-func (self *ListClipperData) SetLossynessOffset(v float32) {
+func (self ListClipperData) SetLossynessOffset(v float32) {
 	C.wrap_ImGuiListClipperData_SetLossynessOffset(self.handle(), C.float(v))
 }
 
@@ -9368,7 +9368,7 @@ func (self ListClipperData) LossynessOffset() float32 {
 	return float32(C.wrap_ImGuiListClipperData_GetLossynessOffset(self.handle()))
 }
 
-func (self *ListClipperData) SetStepNo(v int32) {
+func (self ListClipperData) SetStepNo(v int32) {
 	C.wrap_ImGuiListClipperData_SetStepNo(self.handle(), C.int(v))
 }
 
@@ -9376,7 +9376,7 @@ func (self ListClipperData) StepNo() int {
 	return int(C.wrap_ImGuiListClipperData_GetStepNo(self.handle()))
 }
 
-func (self *ListClipperData) SetItemsFrozen(v int32) {
+func (self ListClipperData) SetItemsFrozen(v int32) {
 	C.wrap_ImGuiListClipperData_SetItemsFrozen(self.handle(), C.int(v))
 }
 
@@ -9384,7 +9384,7 @@ func (self ListClipperData) ItemsFrozen() int {
 	return int(C.wrap_ImGuiListClipperData_GetItemsFrozen(self.handle()))
 }
 
-func (self *ListClipperRange) SetMin(v int32) {
+func (self ListClipperRange) SetMin(v int32) {
 	C.wrap_ImGuiListClipperRange_SetMin(self.handle(), C.int(v))
 }
 
@@ -9392,7 +9392,7 @@ func (self ListClipperRange) Min() int {
 	return int(C.wrap_ImGuiListClipperRange_GetMin(self.handle()))
 }
 
-func (self *ListClipperRange) SetMax(v int32) {
+func (self ListClipperRange) SetMax(v int32) {
 	C.wrap_ImGuiListClipperRange_SetMax(self.handle(), C.int(v))
 }
 
@@ -9400,7 +9400,7 @@ func (self ListClipperRange) Max() int {
 	return int(C.wrap_ImGuiListClipperRange_GetMax(self.handle()))
 }
 
-func (self *ListClipperRange) SetPosToIndexConvert(v bool) {
+func (self ListClipperRange) SetPosToIndexConvert(v bool) {
 	C.wrap_ImGuiListClipperRange_SetPosToIndexConvert(self.handle(), C.bool(v))
 }
 
@@ -9408,7 +9408,7 @@ func (self ListClipperRange) PosToIndexConvert() bool {
 	return C.wrap_ImGuiListClipperRange_GetPosToIndexConvert(self.handle()) == C.bool(true)
 }
 
-func (self *ListClipperRange) SetPosToIndexOffsetMin(v int) {
+func (self ListClipperRange) SetPosToIndexOffsetMin(v int) {
 	C.wrap_ImGuiListClipperRange_SetPosToIndexOffsetMin(self.handle(), C.ImS8(v))
 }
 
@@ -9416,7 +9416,7 @@ func (self ListClipperRange) PosToIndexOffsetMin() int {
 	return int(C.wrap_ImGuiListClipperRange_GetPosToIndexOffsetMin(self.handle()))
 }
 
-func (self *ListClipperRange) SetPosToIndexOffsetMax(v int) {
+func (self ListClipperRange) SetPosToIndexOffsetMax(v int) {
 	C.wrap_ImGuiListClipperRange_SetPosToIndexOffsetMax(self.handle(), C.ImS8(v))
 }
 
@@ -9424,7 +9424,7 @@ func (self ListClipperRange) PosToIndexOffsetMax() int {
 	return int(C.wrap_ImGuiListClipperRange_GetPosToIndexOffsetMax(self.handle()))
 }
 
-func (self *MenuColumns) SetTotalWidth(v uint32) {
+func (self MenuColumns) SetTotalWidth(v uint32) {
 	C.wrap_ImGuiMenuColumns_SetTotalWidth(self.handle(), C.ImU32(v))
 }
 
@@ -9432,7 +9432,7 @@ func (self MenuColumns) TotalWidth() uint32 {
 	return uint32(C.wrap_ImGuiMenuColumns_GetTotalWidth(self.handle()))
 }
 
-func (self *MenuColumns) SetNextTotalWidth(v uint32) {
+func (self MenuColumns) SetNextTotalWidth(v uint32) {
 	C.wrap_ImGuiMenuColumns_SetNextTotalWidth(self.handle(), C.ImU32(v))
 }
 
@@ -9440,7 +9440,7 @@ func (self MenuColumns) NextTotalWidth() uint32 {
 	return uint32(C.wrap_ImGuiMenuColumns_GetNextTotalWidth(self.handle()))
 }
 
-func (self *MenuColumns) SetSpacing(v uint) {
+func (self MenuColumns) SetSpacing(v uint) {
 	C.wrap_ImGuiMenuColumns_SetSpacing(self.handle(), C.ImU16(v))
 }
 
@@ -9448,7 +9448,7 @@ func (self MenuColumns) Spacing() uint32 {
 	return uint32(C.wrap_ImGuiMenuColumns_GetSpacing(self.handle()))
 }
 
-func (self *MenuColumns) SetOffsetIcon(v uint) {
+func (self MenuColumns) SetOffsetIcon(v uint) {
 	C.wrap_ImGuiMenuColumns_SetOffsetIcon(self.handle(), C.ImU16(v))
 }
 
@@ -9456,7 +9456,7 @@ func (self MenuColumns) OffsetIcon() uint32 {
 	return uint32(C.wrap_ImGuiMenuColumns_GetOffsetIcon(self.handle()))
 }
 
-func (self *MenuColumns) SetOffsetLabel(v uint) {
+func (self MenuColumns) SetOffsetLabel(v uint) {
 	C.wrap_ImGuiMenuColumns_SetOffsetLabel(self.handle(), C.ImU16(v))
 }
 
@@ -9464,7 +9464,7 @@ func (self MenuColumns) OffsetLabel() uint32 {
 	return uint32(C.wrap_ImGuiMenuColumns_GetOffsetLabel(self.handle()))
 }
 
-func (self *MenuColumns) SetOffsetShortcut(v uint) {
+func (self MenuColumns) SetOffsetShortcut(v uint) {
 	C.wrap_ImGuiMenuColumns_SetOffsetShortcut(self.handle(), C.ImU16(v))
 }
 
@@ -9472,7 +9472,7 @@ func (self MenuColumns) OffsetShortcut() uint32 {
 	return uint32(C.wrap_ImGuiMenuColumns_GetOffsetShortcut(self.handle()))
 }
 
-func (self *MenuColumns) SetOffsetMark(v uint) {
+func (self MenuColumns) SetOffsetMark(v uint) {
 	C.wrap_ImGuiMenuColumns_SetOffsetMark(self.handle(), C.ImU16(v))
 }
 
@@ -9480,7 +9480,7 @@ func (self MenuColumns) OffsetMark() uint32 {
 	return uint32(C.wrap_ImGuiMenuColumns_GetOffsetMark(self.handle()))
 }
 
-func (self *MetricsConfig) SetShowDebugLog(v bool) {
+func (self MetricsConfig) SetShowDebugLog(v bool) {
 	C.wrap_ImGuiMetricsConfig_SetShowDebugLog(self.handle(), C.bool(v))
 }
 
@@ -9488,7 +9488,7 @@ func (self MetricsConfig) ShowDebugLog() bool {
 	return C.wrap_ImGuiMetricsConfig_GetShowDebugLog(self.handle()) == C.bool(true)
 }
 
-func (self *MetricsConfig) SetShowStackTool(v bool) {
+func (self MetricsConfig) SetShowStackTool(v bool) {
 	C.wrap_ImGuiMetricsConfig_SetShowStackTool(self.handle(), C.bool(v))
 }
 
@@ -9496,7 +9496,7 @@ func (self MetricsConfig) ShowStackTool() bool {
 	return C.wrap_ImGuiMetricsConfig_GetShowStackTool(self.handle()) == C.bool(true)
 }
 
-func (self *MetricsConfig) SetShowWindowsRects(v bool) {
+func (self MetricsConfig) SetShowWindowsRects(v bool) {
 	C.wrap_ImGuiMetricsConfig_SetShowWindowsRects(self.handle(), C.bool(v))
 }
 
@@ -9504,7 +9504,7 @@ func (self MetricsConfig) ShowWindowsRects() bool {
 	return C.wrap_ImGuiMetricsConfig_GetShowWindowsRects(self.handle()) == C.bool(true)
 }
 
-func (self *MetricsConfig) SetShowWindowsBeginOrder(v bool) {
+func (self MetricsConfig) SetShowWindowsBeginOrder(v bool) {
 	C.wrap_ImGuiMetricsConfig_SetShowWindowsBeginOrder(self.handle(), C.bool(v))
 }
 
@@ -9512,7 +9512,7 @@ func (self MetricsConfig) ShowWindowsBeginOrder() bool {
 	return C.wrap_ImGuiMetricsConfig_GetShowWindowsBeginOrder(self.handle()) == C.bool(true)
 }
 
-func (self *MetricsConfig) SetShowTablesRects(v bool) {
+func (self MetricsConfig) SetShowTablesRects(v bool) {
 	C.wrap_ImGuiMetricsConfig_SetShowTablesRects(self.handle(), C.bool(v))
 }
 
@@ -9520,7 +9520,7 @@ func (self MetricsConfig) ShowTablesRects() bool {
 	return C.wrap_ImGuiMetricsConfig_GetShowTablesRects(self.handle()) == C.bool(true)
 }
 
-func (self *MetricsConfig) SetShowDrawCmdMesh(v bool) {
+func (self MetricsConfig) SetShowDrawCmdMesh(v bool) {
 	C.wrap_ImGuiMetricsConfig_SetShowDrawCmdMesh(self.handle(), C.bool(v))
 }
 
@@ -9528,7 +9528,7 @@ func (self MetricsConfig) ShowDrawCmdMesh() bool {
 	return C.wrap_ImGuiMetricsConfig_GetShowDrawCmdMesh(self.handle()) == C.bool(true)
 }
 
-func (self *MetricsConfig) SetShowDrawCmdBoundingBoxes(v bool) {
+func (self MetricsConfig) SetShowDrawCmdBoundingBoxes(v bool) {
 	C.wrap_ImGuiMetricsConfig_SetShowDrawCmdBoundingBoxes(self.handle(), C.bool(v))
 }
 
@@ -9536,7 +9536,7 @@ func (self MetricsConfig) ShowDrawCmdBoundingBoxes() bool {
 	return C.wrap_ImGuiMetricsConfig_GetShowDrawCmdBoundingBoxes(self.handle()) == C.bool(true)
 }
 
-func (self *MetricsConfig) SetShowDockingNodes(v bool) {
+func (self MetricsConfig) SetShowDockingNodes(v bool) {
 	C.wrap_ImGuiMetricsConfig_SetShowDockingNodes(self.handle(), C.bool(v))
 }
 
@@ -9544,7 +9544,7 @@ func (self MetricsConfig) ShowDockingNodes() bool {
 	return C.wrap_ImGuiMetricsConfig_GetShowDockingNodes(self.handle()) == C.bool(true)
 }
 
-func (self *MetricsConfig) SetShowWindowsRectsType(v int32) {
+func (self MetricsConfig) SetShowWindowsRectsType(v int32) {
 	C.wrap_ImGuiMetricsConfig_SetShowWindowsRectsType(self.handle(), C.int(v))
 }
 
@@ -9552,7 +9552,7 @@ func (self MetricsConfig) ShowWindowsRectsType() int {
 	return int(C.wrap_ImGuiMetricsConfig_GetShowWindowsRectsType(self.handle()))
 }
 
-func (self *MetricsConfig) SetShowTablesRectsType(v int32) {
+func (self MetricsConfig) SetShowTablesRectsType(v int32) {
 	C.wrap_ImGuiMetricsConfig_SetShowTablesRectsType(self.handle(), C.int(v))
 }
 
@@ -9560,7 +9560,7 @@ func (self MetricsConfig) ShowTablesRectsType() int {
 	return int(C.wrap_ImGuiMetricsConfig_GetShowTablesRectsType(self.handle()))
 }
 
-func (self *NavItemData) SetWindow(v Window) {
+func (self NavItemData) SetWindow(v Window) {
 	C.wrap_ImGuiNavItemData_SetWindow(self.handle(), v.handle())
 }
 
@@ -9568,7 +9568,7 @@ func (self NavItemData) Window() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiNavItemData_GetWindow(self.handle())))
 }
 
-func (self *NavItemData) SetID(v ID) {
+func (self NavItemData) SetID(v ID) {
 	C.wrap_ImGuiNavItemData_SetID(self.handle(), C.ImGuiID(v))
 }
 
@@ -9576,7 +9576,7 @@ func (self NavItemData) ID() ID {
 	return ID(C.wrap_ImGuiNavItemData_GetID(self.handle()))
 }
 
-func (self *NavItemData) SetFocusScopeId(v ID) {
+func (self NavItemData) SetFocusScopeId(v ID) {
 	C.wrap_ImGuiNavItemData_SetFocusScopeId(self.handle(), C.ImGuiID(v))
 }
 
@@ -9584,7 +9584,7 @@ func (self NavItemData) FocusScopeId() ID {
 	return ID(C.wrap_ImGuiNavItemData_GetFocusScopeId(self.handle()))
 }
 
-func (self *NavItemData) SetRectRel(v Rect) {
+func (self NavItemData) SetRectRel(v Rect) {
 	C.wrap_ImGuiNavItemData_SetRectRel(self.handle(), v.toC())
 }
 
@@ -9594,7 +9594,7 @@ func (self NavItemData) RectRel() Rect {
 	return *out
 }
 
-func (self *NavItemData) SetInFlags(v ItemFlags) {
+func (self NavItemData) SetInFlags(v ItemFlags) {
 	C.wrap_ImGuiNavItemData_SetInFlags(self.handle(), C.ImGuiItemFlags(v))
 }
 
@@ -9602,7 +9602,7 @@ func (self NavItemData) InFlags() ItemFlags {
 	return ItemFlags(C.wrap_ImGuiNavItemData_GetInFlags(self.handle()))
 }
 
-func (self *NavItemData) SetDistBox(v float32) {
+func (self NavItemData) SetDistBox(v float32) {
 	C.wrap_ImGuiNavItemData_SetDistBox(self.handle(), C.float(v))
 }
 
@@ -9610,7 +9610,7 @@ func (self NavItemData) DistBox() float32 {
 	return float32(C.wrap_ImGuiNavItemData_GetDistBox(self.handle()))
 }
 
-func (self *NavItemData) SetDistCenter(v float32) {
+func (self NavItemData) SetDistCenter(v float32) {
 	C.wrap_ImGuiNavItemData_SetDistCenter(self.handle(), C.float(v))
 }
 
@@ -9618,7 +9618,7 @@ func (self NavItemData) DistCenter() float32 {
 	return float32(C.wrap_ImGuiNavItemData_GetDistCenter(self.handle()))
 }
 
-func (self *NavItemData) SetDistAxial(v float32) {
+func (self NavItemData) SetDistAxial(v float32) {
 	C.wrap_ImGuiNavItemData_SetDistAxial(self.handle(), C.float(v))
 }
 
@@ -9626,7 +9626,7 @@ func (self NavItemData) DistAxial() float32 {
 	return float32(C.wrap_ImGuiNavItemData_GetDistAxial(self.handle()))
 }
 
-func (self *NextItemData) SetFlags(v NextItemDataFlags) {
+func (self NextItemData) SetFlags(v NextItemDataFlags) {
 	C.wrap_ImGuiNextItemData_SetFlags(self.handle(), C.ImGuiNextItemDataFlags(v))
 }
 
@@ -9634,7 +9634,7 @@ func (self NextItemData) Flags() NextItemDataFlags {
 	return NextItemDataFlags(C.wrap_ImGuiNextItemData_GetFlags(self.handle()))
 }
 
-func (self *NextItemData) SetWidth(v float32) {
+func (self NextItemData) SetWidth(v float32) {
 	C.wrap_ImGuiNextItemData_SetWidth(self.handle(), C.float(v))
 }
 
@@ -9642,7 +9642,7 @@ func (self NextItemData) Width() float32 {
 	return float32(C.wrap_ImGuiNextItemData_GetWidth(self.handle()))
 }
 
-func (self *NextItemData) SetFocusScopeId(v ID) {
+func (self NextItemData) SetFocusScopeId(v ID) {
 	C.wrap_ImGuiNextItemData_SetFocusScopeId(self.handle(), C.ImGuiID(v))
 }
 
@@ -9650,7 +9650,7 @@ func (self NextItemData) FocusScopeId() ID {
 	return ID(C.wrap_ImGuiNextItemData_GetFocusScopeId(self.handle()))
 }
 
-func (self *NextItemData) SetOpenCond(v Cond) {
+func (self NextItemData) SetOpenCond(v Cond) {
 	C.wrap_ImGuiNextItemData_SetOpenCond(self.handle(), C.ImGuiCond(v))
 }
 
@@ -9658,7 +9658,7 @@ func (self NextItemData) OpenCond() Cond {
 	return Cond(C.wrap_ImGuiNextItemData_GetOpenCond(self.handle()))
 }
 
-func (self *NextItemData) SetOpenVal(v bool) {
+func (self NextItemData) SetOpenVal(v bool) {
 	C.wrap_ImGuiNextItemData_SetOpenVal(self.handle(), C.bool(v))
 }
 
@@ -9666,7 +9666,7 @@ func (self NextItemData) OpenVal() bool {
 	return C.wrap_ImGuiNextItemData_GetOpenVal(self.handle()) == C.bool(true)
 }
 
-func (self *NextWindowData) SetFlags(v NextWindowDataFlags) {
+func (self NextWindowData) SetFlags(v NextWindowDataFlags) {
 	C.wrap_ImGuiNextWindowData_SetFlags(self.handle(), C.ImGuiNextWindowDataFlags(v))
 }
 
@@ -9674,7 +9674,7 @@ func (self NextWindowData) Flags() NextWindowDataFlags {
 	return NextWindowDataFlags(C.wrap_ImGuiNextWindowData_GetFlags(self.handle()))
 }
 
-func (self *NextWindowData) SetPosCond(v Cond) {
+func (self NextWindowData) SetPosCond(v Cond) {
 	C.wrap_ImGuiNextWindowData_SetPosCond(self.handle(), C.ImGuiCond(v))
 }
 
@@ -9682,7 +9682,7 @@ func (self NextWindowData) PosCond() Cond {
 	return Cond(C.wrap_ImGuiNextWindowData_GetPosCond(self.handle()))
 }
 
-func (self *NextWindowData) SetSizeCond(v Cond) {
+func (self NextWindowData) SetSizeCond(v Cond) {
 	C.wrap_ImGuiNextWindowData_SetSizeCond(self.handle(), C.ImGuiCond(v))
 }
 
@@ -9690,7 +9690,7 @@ func (self NextWindowData) SizeCond() Cond {
 	return Cond(C.wrap_ImGuiNextWindowData_GetSizeCond(self.handle()))
 }
 
-func (self *NextWindowData) SetCollapsedCond(v Cond) {
+func (self NextWindowData) SetCollapsedCond(v Cond) {
 	C.wrap_ImGuiNextWindowData_SetCollapsedCond(self.handle(), C.ImGuiCond(v))
 }
 
@@ -9698,7 +9698,7 @@ func (self NextWindowData) CollapsedCond() Cond {
 	return Cond(C.wrap_ImGuiNextWindowData_GetCollapsedCond(self.handle()))
 }
 
-func (self *NextWindowData) SetDockCond(v Cond) {
+func (self NextWindowData) SetDockCond(v Cond) {
 	C.wrap_ImGuiNextWindowData_SetDockCond(self.handle(), C.ImGuiCond(v))
 }
 
@@ -9706,7 +9706,7 @@ func (self NextWindowData) DockCond() Cond {
 	return Cond(C.wrap_ImGuiNextWindowData_GetDockCond(self.handle()))
 }
 
-func (self *NextWindowData) SetPosVal(v Vec2) {
+func (self NextWindowData) SetPosVal(v Vec2) {
 	C.wrap_ImGuiNextWindowData_SetPosVal(self.handle(), v.toC())
 }
 
@@ -9716,7 +9716,7 @@ func (self NextWindowData) PosVal() Vec2 {
 	return *out
 }
 
-func (self *NextWindowData) SetPosPivotVal(v Vec2) {
+func (self NextWindowData) SetPosPivotVal(v Vec2) {
 	C.wrap_ImGuiNextWindowData_SetPosPivotVal(self.handle(), v.toC())
 }
 
@@ -9726,7 +9726,7 @@ func (self NextWindowData) PosPivotVal() Vec2 {
 	return *out
 }
 
-func (self *NextWindowData) SetSizeVal(v Vec2) {
+func (self NextWindowData) SetSizeVal(v Vec2) {
 	C.wrap_ImGuiNextWindowData_SetSizeVal(self.handle(), v.toC())
 }
 
@@ -9736,7 +9736,7 @@ func (self NextWindowData) SizeVal() Vec2 {
 	return *out
 }
 
-func (self *NextWindowData) SetContentSizeVal(v Vec2) {
+func (self NextWindowData) SetContentSizeVal(v Vec2) {
 	C.wrap_ImGuiNextWindowData_SetContentSizeVal(self.handle(), v.toC())
 }
 
@@ -9746,7 +9746,7 @@ func (self NextWindowData) ContentSizeVal() Vec2 {
 	return *out
 }
 
-func (self *NextWindowData) SetScrollVal(v Vec2) {
+func (self NextWindowData) SetScrollVal(v Vec2) {
 	C.wrap_ImGuiNextWindowData_SetScrollVal(self.handle(), v.toC())
 }
 
@@ -9756,7 +9756,7 @@ func (self NextWindowData) ScrollVal() Vec2 {
 	return *out
 }
 
-func (self *NextWindowData) SetPosUndock(v bool) {
+func (self NextWindowData) SetPosUndock(v bool) {
 	C.wrap_ImGuiNextWindowData_SetPosUndock(self.handle(), C.bool(v))
 }
 
@@ -9764,7 +9764,7 @@ func (self NextWindowData) PosUndock() bool {
 	return C.wrap_ImGuiNextWindowData_GetPosUndock(self.handle()) == C.bool(true)
 }
 
-func (self *NextWindowData) SetCollapsedVal(v bool) {
+func (self NextWindowData) SetCollapsedVal(v bool) {
 	C.wrap_ImGuiNextWindowData_SetCollapsedVal(self.handle(), C.bool(v))
 }
 
@@ -9772,7 +9772,7 @@ func (self NextWindowData) CollapsedVal() bool {
 	return C.wrap_ImGuiNextWindowData_GetCollapsedVal(self.handle()) == C.bool(true)
 }
 
-func (self *NextWindowData) SetSizeConstraintRect(v Rect) {
+func (self NextWindowData) SetSizeConstraintRect(v Rect) {
 	C.wrap_ImGuiNextWindowData_SetSizeConstraintRect(self.handle(), v.toC())
 }
 
@@ -9782,7 +9782,7 @@ func (self NextWindowData) SizeConstraintRect() Rect {
 	return *out
 }
 
-func (self *NextWindowData) SetSizeCallbackUserData(v unsafe.Pointer) {
+func (self NextWindowData) SetSizeCallbackUserData(v unsafe.Pointer) {
 	C.wrap_ImGuiNextWindowData_SetSizeCallbackUserData(self.handle(), (v))
 }
 
@@ -9790,7 +9790,7 @@ func (self NextWindowData) SizeCallbackUserData() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImGuiNextWindowData_GetSizeCallbackUserData(self.handle()))
 }
 
-func (self *NextWindowData) SetBgAlphaVal(v float32) {
+func (self NextWindowData) SetBgAlphaVal(v float32) {
 	C.wrap_ImGuiNextWindowData_SetBgAlphaVal(self.handle(), C.float(v))
 }
 
@@ -9798,7 +9798,7 @@ func (self NextWindowData) BgAlphaVal() float32 {
 	return float32(C.wrap_ImGuiNextWindowData_GetBgAlphaVal(self.handle()))
 }
 
-func (self *NextWindowData) SetViewportId(v ID) {
+func (self NextWindowData) SetViewportId(v ID) {
 	C.wrap_ImGuiNextWindowData_SetViewportId(self.handle(), C.ImGuiID(v))
 }
 
@@ -9806,7 +9806,7 @@ func (self NextWindowData) ViewportId() ID {
 	return ID(C.wrap_ImGuiNextWindowData_GetViewportId(self.handle()))
 }
 
-func (self *NextWindowData) SetDockId(v ID) {
+func (self NextWindowData) SetDockId(v ID) {
 	C.wrap_ImGuiNextWindowData_SetDockId(self.handle(), C.ImGuiID(v))
 }
 
@@ -9818,7 +9818,7 @@ func (self NextWindowData) WindowClass() WindowClass {
 	return newWindowClassFromC(C.wrap_ImGuiNextWindowData_GetWindowClass(self.handle()))
 }
 
-func (self *NextWindowData) SetMenuBarOffsetMinVal(v Vec2) {
+func (self NextWindowData) SetMenuBarOffsetMinVal(v Vec2) {
 	C.wrap_ImGuiNextWindowData_SetMenuBarOffsetMinVal(self.handle(), v.toC())
 }
 
@@ -9828,7 +9828,7 @@ func (self NextWindowData) MenuBarOffsetMinVal() Vec2 {
 	return *out
 }
 
-func (self *OldColumnData) SetOffsetNorm(v float32) {
+func (self OldColumnData) SetOffsetNorm(v float32) {
 	C.wrap_ImGuiOldColumnData_SetOffsetNorm(self.handle(), C.float(v))
 }
 
@@ -9836,7 +9836,7 @@ func (self OldColumnData) OffsetNorm() float32 {
 	return float32(C.wrap_ImGuiOldColumnData_GetOffsetNorm(self.handle()))
 }
 
-func (self *OldColumnData) SetOffsetNormBeforeResize(v float32) {
+func (self OldColumnData) SetOffsetNormBeforeResize(v float32) {
 	C.wrap_ImGuiOldColumnData_SetOffsetNormBeforeResize(self.handle(), C.float(v))
 }
 
@@ -9844,7 +9844,7 @@ func (self OldColumnData) OffsetNormBeforeResize() float32 {
 	return float32(C.wrap_ImGuiOldColumnData_GetOffsetNormBeforeResize(self.handle()))
 }
 
-func (self *OldColumnData) SetFlags(v OldColumnFlags) {
+func (self OldColumnData) SetFlags(v OldColumnFlags) {
 	C.wrap_ImGuiOldColumnData_SetFlags(self.handle(), C.ImGuiOldColumnFlags(v))
 }
 
@@ -9852,7 +9852,7 @@ func (self OldColumnData) Flags() OldColumnFlags {
 	return OldColumnFlags(C.wrap_ImGuiOldColumnData_GetFlags(self.handle()))
 }
 
-func (self *OldColumnData) SetClipRect(v Rect) {
+func (self OldColumnData) SetClipRect(v Rect) {
 	C.wrap_ImGuiOldColumnData_SetClipRect(self.handle(), v.toC())
 }
 
@@ -9862,7 +9862,7 @@ func (self OldColumnData) ClipRect() Rect {
 	return *out
 }
 
-func (self *OldColumns) SetID(v ID) {
+func (self OldColumns) SetID(v ID) {
 	C.wrap_ImGuiOldColumns_SetID(self.handle(), C.ImGuiID(v))
 }
 
@@ -9870,7 +9870,7 @@ func (self OldColumns) ID() ID {
 	return ID(C.wrap_ImGuiOldColumns_GetID(self.handle()))
 }
 
-func (self *OldColumns) SetFlags(v OldColumnFlags) {
+func (self OldColumns) SetFlags(v OldColumnFlags) {
 	C.wrap_ImGuiOldColumns_SetFlags(self.handle(), C.ImGuiOldColumnFlags(v))
 }
 
@@ -9878,7 +9878,7 @@ func (self OldColumns) Flags() OldColumnFlags {
 	return OldColumnFlags(C.wrap_ImGuiOldColumns_GetFlags(self.handle()))
 }
 
-func (self *OldColumns) SetIsFirstFrame(v bool) {
+func (self OldColumns) SetIsFirstFrame(v bool) {
 	C.wrap_ImGuiOldColumns_SetIsFirstFrame(self.handle(), C.bool(v))
 }
 
@@ -9886,7 +9886,7 @@ func (self OldColumns) IsFirstFrame() bool {
 	return C.wrap_ImGuiOldColumns_GetIsFirstFrame(self.handle()) == C.bool(true)
 }
 
-func (self *OldColumns) SetIsBeingResized(v bool) {
+func (self OldColumns) SetIsBeingResized(v bool) {
 	C.wrap_ImGuiOldColumns_SetIsBeingResized(self.handle(), C.bool(v))
 }
 
@@ -9894,7 +9894,7 @@ func (self OldColumns) IsBeingResized() bool {
 	return C.wrap_ImGuiOldColumns_GetIsBeingResized(self.handle()) == C.bool(true)
 }
 
-func (self *OldColumns) SetCurrent(v int32) {
+func (self OldColumns) SetCurrent(v int32) {
 	C.wrap_ImGuiOldColumns_SetCurrent(self.handle(), C.int(v))
 }
 
@@ -9902,7 +9902,7 @@ func (self OldColumns) Current() int {
 	return int(C.wrap_ImGuiOldColumns_GetCurrent(self.handle()))
 }
 
-func (self *OldColumns) SetCount(v int32) {
+func (self OldColumns) SetCount(v int32) {
 	C.wrap_ImGuiOldColumns_SetCount(self.handle(), C.int(v))
 }
 
@@ -9910,7 +9910,7 @@ func (self OldColumns) Count() int {
 	return int(C.wrap_ImGuiOldColumns_GetCount(self.handle()))
 }
 
-func (self *OldColumns) SetOffMinX(v float32) {
+func (self OldColumns) SetOffMinX(v float32) {
 	C.wrap_ImGuiOldColumns_SetOffMinX(self.handle(), C.float(v))
 }
 
@@ -9918,7 +9918,7 @@ func (self OldColumns) OffMinX() float32 {
 	return float32(C.wrap_ImGuiOldColumns_GetOffMinX(self.handle()))
 }
 
-func (self *OldColumns) SetOffMaxX(v float32) {
+func (self OldColumns) SetOffMaxX(v float32) {
 	C.wrap_ImGuiOldColumns_SetOffMaxX(self.handle(), C.float(v))
 }
 
@@ -9926,7 +9926,7 @@ func (self OldColumns) OffMaxX() float32 {
 	return float32(C.wrap_ImGuiOldColumns_GetOffMaxX(self.handle()))
 }
 
-func (self *OldColumns) SetLineMinY(v float32) {
+func (self OldColumns) SetLineMinY(v float32) {
 	C.wrap_ImGuiOldColumns_SetLineMinY(self.handle(), C.float(v))
 }
 
@@ -9934,7 +9934,7 @@ func (self OldColumns) LineMinY() float32 {
 	return float32(C.wrap_ImGuiOldColumns_GetLineMinY(self.handle()))
 }
 
-func (self *OldColumns) SetLineMaxY(v float32) {
+func (self OldColumns) SetLineMaxY(v float32) {
 	C.wrap_ImGuiOldColumns_SetLineMaxY(self.handle(), C.float(v))
 }
 
@@ -9942,7 +9942,7 @@ func (self OldColumns) LineMaxY() float32 {
 	return float32(C.wrap_ImGuiOldColumns_GetLineMaxY(self.handle()))
 }
 
-func (self *OldColumns) SetHostCursorPosY(v float32) {
+func (self OldColumns) SetHostCursorPosY(v float32) {
 	C.wrap_ImGuiOldColumns_SetHostCursorPosY(self.handle(), C.float(v))
 }
 
@@ -9950,7 +9950,7 @@ func (self OldColumns) HostCursorPosY() float32 {
 	return float32(C.wrap_ImGuiOldColumns_GetHostCursorPosY(self.handle()))
 }
 
-func (self *OldColumns) SetHostCursorMaxPosX(v float32) {
+func (self OldColumns) SetHostCursorMaxPosX(v float32) {
 	C.wrap_ImGuiOldColumns_SetHostCursorMaxPosX(self.handle(), C.float(v))
 }
 
@@ -9958,7 +9958,7 @@ func (self OldColumns) HostCursorMaxPosX() float32 {
 	return float32(C.wrap_ImGuiOldColumns_GetHostCursorMaxPosX(self.handle()))
 }
 
-func (self *OldColumns) SetHostInitialClipRect(v Rect) {
+func (self OldColumns) SetHostInitialClipRect(v Rect) {
 	C.wrap_ImGuiOldColumns_SetHostInitialClipRect(self.handle(), v.toC())
 }
 
@@ -9968,7 +9968,7 @@ func (self OldColumns) HostInitialClipRect() Rect {
 	return *out
 }
 
-func (self *OldColumns) SetHostBackupClipRect(v Rect) {
+func (self OldColumns) SetHostBackupClipRect(v Rect) {
 	C.wrap_ImGuiOldColumns_SetHostBackupClipRect(self.handle(), v.toC())
 }
 
@@ -9978,7 +9978,7 @@ func (self OldColumns) HostBackupClipRect() Rect {
 	return *out
 }
 
-func (self *OldColumns) SetHostBackupParentWorkRect(v Rect) {
+func (self OldColumns) SetHostBackupParentWorkRect(v Rect) {
 	C.wrap_ImGuiOldColumns_SetHostBackupParentWorkRect(self.handle(), v.toC())
 }
 
@@ -9992,7 +9992,7 @@ func (self OldColumns) Splitter() DrawListSplitter {
 	return newDrawListSplitterFromC(C.wrap_ImGuiOldColumns_GetSplitter(self.handle()))
 }
 
-func (self *OnceUponAFrame) SetRefFrame(v int32) {
+func (self OnceUponAFrame) SetRefFrame(v int32) {
 	C.wrap_ImGuiOnceUponAFrame_SetRefFrame(self.handle(), C.int(v))
 }
 
@@ -10000,7 +10000,7 @@ func (self OnceUponAFrame) RefFrame() int {
 	return int(C.wrap_ImGuiOnceUponAFrame_GetRefFrame(self.handle()))
 }
 
-func (self *Payload) SetData(v unsafe.Pointer) {
+func (self Payload) SetData(v unsafe.Pointer) {
 	C.wrap_ImGuiPayload_SetData(self.handle(), (v))
 }
 
@@ -10008,7 +10008,7 @@ func (self Payload) Data() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImGuiPayload_GetData(self.handle()))
 }
 
-func (self *Payload) SetDataSize(v int32) {
+func (self Payload) SetDataSize(v int32) {
 	C.wrap_ImGuiPayload_SetDataSize(self.handle(), C.int(v))
 }
 
@@ -10016,7 +10016,7 @@ func (self Payload) DataSize() int {
 	return int(C.wrap_ImGuiPayload_GetDataSize(self.handle()))
 }
 
-func (self *Payload) SetSourceId(v ID) {
+func (self Payload) SetSourceId(v ID) {
 	C.wrap_ImGuiPayload_SetSourceId(self.handle(), C.ImGuiID(v))
 }
 
@@ -10024,7 +10024,7 @@ func (self Payload) SourceId() ID {
 	return ID(C.wrap_ImGuiPayload_GetSourceId(self.handle()))
 }
 
-func (self *Payload) SetSourceParentId(v ID) {
+func (self Payload) SetSourceParentId(v ID) {
 	C.wrap_ImGuiPayload_SetSourceParentId(self.handle(), C.ImGuiID(v))
 }
 
@@ -10032,7 +10032,7 @@ func (self Payload) SourceParentId() ID {
 	return ID(C.wrap_ImGuiPayload_GetSourceParentId(self.handle()))
 }
 
-func (self *Payload) SetDataFrameCount(v int32) {
+func (self Payload) SetDataFrameCount(v int32) {
 	C.wrap_ImGuiPayload_SetDataFrameCount(self.handle(), C.int(v))
 }
 
@@ -10040,7 +10040,7 @@ func (self Payload) DataFrameCount() int {
 	return int(C.wrap_ImGuiPayload_GetDataFrameCount(self.handle()))
 }
 
-func (self *Payload) SetPreview(v bool) {
+func (self Payload) SetPreview(v bool) {
 	C.wrap_ImGuiPayload_SetPreview(self.handle(), C.bool(v))
 }
 
@@ -10048,7 +10048,7 @@ func (self Payload) Preview() bool {
 	return C.wrap_ImGuiPayload_GetPreview(self.handle()) == C.bool(true)
 }
 
-func (self *Payload) SetDelivery(v bool) {
+func (self Payload) SetDelivery(v bool) {
 	C.wrap_ImGuiPayload_SetDelivery(self.handle(), C.bool(v))
 }
 
@@ -10056,7 +10056,7 @@ func (self Payload) Delivery() bool {
 	return C.wrap_ImGuiPayload_GetDelivery(self.handle()) == C.bool(true)
 }
 
-func (self *PlatformImeData) SetWantVisible(v bool) {
+func (self PlatformImeData) SetWantVisible(v bool) {
 	C.wrap_ImGuiPlatformImeData_SetWantVisible(self.handle(), C.bool(v))
 }
 
@@ -10064,7 +10064,7 @@ func (self PlatformImeData) WantVisible() bool {
 	return C.wrap_ImGuiPlatformImeData_GetWantVisible(self.handle()) == C.bool(true)
 }
 
-func (self *PlatformImeData) SetInputPos(v Vec2) {
+func (self PlatformImeData) SetInputPos(v Vec2) {
 	C.wrap_ImGuiPlatformImeData_SetInputPos(self.handle(), v.toC())
 }
 
@@ -10074,7 +10074,7 @@ func (self PlatformImeData) InputPos() Vec2 {
 	return *out
 }
 
-func (self *PlatformImeData) SetInputLineHeight(v float32) {
+func (self PlatformImeData) SetInputLineHeight(v float32) {
 	C.wrap_ImGuiPlatformImeData_SetInputLineHeight(self.handle(), C.float(v))
 }
 
@@ -10082,7 +10082,7 @@ func (self PlatformImeData) InputLineHeight() float32 {
 	return float32(C.wrap_ImGuiPlatformImeData_GetInputLineHeight(self.handle()))
 }
 
-func (self *PlatformMonitor) SetMainPos(v Vec2) {
+func (self PlatformMonitor) SetMainPos(v Vec2) {
 	C.wrap_ImGuiPlatformMonitor_SetMainPos(self.handle(), v.toC())
 }
 
@@ -10092,7 +10092,7 @@ func (self PlatformMonitor) MainPos() Vec2 {
 	return *out
 }
 
-func (self *PlatformMonitor) SetMainSize(v Vec2) {
+func (self PlatformMonitor) SetMainSize(v Vec2) {
 	C.wrap_ImGuiPlatformMonitor_SetMainSize(self.handle(), v.toC())
 }
 
@@ -10102,7 +10102,7 @@ func (self PlatformMonitor) MainSize() Vec2 {
 	return *out
 }
 
-func (self *PlatformMonitor) SetWorkPos(v Vec2) {
+func (self PlatformMonitor) SetWorkPos(v Vec2) {
 	C.wrap_ImGuiPlatformMonitor_SetWorkPos(self.handle(), v.toC())
 }
 
@@ -10112,7 +10112,7 @@ func (self PlatformMonitor) WorkPos() Vec2 {
 	return *out
 }
 
-func (self *PlatformMonitor) SetWorkSize(v Vec2) {
+func (self PlatformMonitor) SetWorkSize(v Vec2) {
 	C.wrap_ImGuiPlatformMonitor_SetWorkSize(self.handle(), v.toC())
 }
 
@@ -10122,7 +10122,7 @@ func (self PlatformMonitor) WorkSize() Vec2 {
 	return *out
 }
 
-func (self *PlatformMonitor) SetDpiScale(v float32) {
+func (self PlatformMonitor) SetDpiScale(v float32) {
 	C.wrap_ImGuiPlatformMonitor_SetDpiScale(self.handle(), C.float(v))
 }
 
@@ -10130,7 +10130,7 @@ func (self PlatformMonitor) DpiScale() float32 {
 	return float32(C.wrap_ImGuiPlatformMonitor_GetDpiScale(self.handle()))
 }
 
-func (self *PopupData) SetPopupId(v ID) {
+func (self PopupData) SetPopupId(v ID) {
 	C.wrap_ImGuiPopupData_SetPopupId(self.handle(), C.ImGuiID(v))
 }
 
@@ -10138,7 +10138,7 @@ func (self PopupData) PopupId() ID {
 	return ID(C.wrap_ImGuiPopupData_GetPopupId(self.handle()))
 }
 
-func (self *PopupData) SetWindow(v Window) {
+func (self PopupData) SetWindow(v Window) {
 	C.wrap_ImGuiPopupData_SetWindow(self.handle(), v.handle())
 }
 
@@ -10146,7 +10146,7 @@ func (self PopupData) Window() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiPopupData_GetWindow(self.handle())))
 }
 
-func (self *PopupData) SetSourceWindow(v Window) {
+func (self PopupData) SetSourceWindow(v Window) {
 	C.wrap_ImGuiPopupData_SetSourceWindow(self.handle(), v.handle())
 }
 
@@ -10154,7 +10154,7 @@ func (self PopupData) SourceWindow() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiPopupData_GetSourceWindow(self.handle())))
 }
 
-func (self *PopupData) SetParentNavLayer(v int32) {
+func (self PopupData) SetParentNavLayer(v int32) {
 	C.wrap_ImGuiPopupData_SetParentNavLayer(self.handle(), C.int(v))
 }
 
@@ -10162,7 +10162,7 @@ func (self PopupData) ParentNavLayer() int {
 	return int(C.wrap_ImGuiPopupData_GetParentNavLayer(self.handle()))
 }
 
-func (self *PopupData) SetOpenFrameCount(v int32) {
+func (self PopupData) SetOpenFrameCount(v int32) {
 	C.wrap_ImGuiPopupData_SetOpenFrameCount(self.handle(), C.int(v))
 }
 
@@ -10170,7 +10170,7 @@ func (self PopupData) OpenFrameCount() int {
 	return int(C.wrap_ImGuiPopupData_GetOpenFrameCount(self.handle()))
 }
 
-func (self *PopupData) SetOpenParentId(v ID) {
+func (self PopupData) SetOpenParentId(v ID) {
 	C.wrap_ImGuiPopupData_SetOpenParentId(self.handle(), C.ImGuiID(v))
 }
 
@@ -10178,7 +10178,7 @@ func (self PopupData) OpenParentId() ID {
 	return ID(C.wrap_ImGuiPopupData_GetOpenParentId(self.handle()))
 }
 
-func (self *PopupData) SetOpenPopupPos(v Vec2) {
+func (self PopupData) SetOpenPopupPos(v Vec2) {
 	C.wrap_ImGuiPopupData_SetOpenPopupPos(self.handle(), v.toC())
 }
 
@@ -10188,7 +10188,7 @@ func (self PopupData) OpenPopupPos() Vec2 {
 	return *out
 }
 
-func (self *PopupData) SetOpenMousePos(v Vec2) {
+func (self PopupData) SetOpenMousePos(v Vec2) {
 	C.wrap_ImGuiPopupData_SetOpenMousePos(self.handle(), v.toC())
 }
 
@@ -10198,7 +10198,7 @@ func (self PopupData) OpenMousePos() Vec2 {
 	return *out
 }
 
-func (self *PtrOrIndex) SetPtr(v unsafe.Pointer) {
+func (self PtrOrIndex) SetPtr(v unsafe.Pointer) {
 	C.wrap_ImGuiPtrOrIndex_SetPtr(self.handle(), (v))
 }
 
@@ -10206,7 +10206,7 @@ func (self PtrOrIndex) Ptr() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImGuiPtrOrIndex_GetPtr(self.handle()))
 }
 
-func (self *PtrOrIndex) SetIndex(v int32) {
+func (self PtrOrIndex) SetIndex(v int32) {
 	C.wrap_ImGuiPtrOrIndex_SetIndex(self.handle(), C.int(v))
 }
 
@@ -10214,7 +10214,7 @@ func (self PtrOrIndex) Index() int {
 	return int(C.wrap_ImGuiPtrOrIndex_GetIndex(self.handle()))
 }
 
-func (self *SettingsHandler) SetTypeName(v string) {
+func (self SettingsHandler) SetTypeName(v string) {
 	vArg, vFin := wrapString(v)
 	defer vFin()
 
@@ -10225,7 +10225,7 @@ func (self SettingsHandler) TypeName() string {
 	return C.GoString(C.wrap_ImGuiSettingsHandler_GetTypeName(self.handle()))
 }
 
-func (self *SettingsHandler) SetTypeHash(v ID) {
+func (self SettingsHandler) SetTypeHash(v ID) {
 	C.wrap_ImGuiSettingsHandler_SetTypeHash(self.handle(), C.ImGuiID(v))
 }
 
@@ -10233,7 +10233,7 @@ func (self SettingsHandler) TypeHash() ID {
 	return ID(C.wrap_ImGuiSettingsHandler_GetTypeHash(self.handle()))
 }
 
-func (self *SettingsHandler) SetUserData(v unsafe.Pointer) {
+func (self SettingsHandler) SetUserData(v unsafe.Pointer) {
 	C.wrap_ImGuiSettingsHandler_SetUserData(self.handle(), (v))
 }
 
@@ -10241,7 +10241,7 @@ func (self SettingsHandler) UserData() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImGuiSettingsHandler_GetUserData(self.handle()))
 }
 
-func (self *ShrinkWidthItem) SetIndex(v int32) {
+func (self ShrinkWidthItem) SetIndex(v int32) {
 	C.wrap_ImGuiShrinkWidthItem_SetIndex(self.handle(), C.int(v))
 }
 
@@ -10249,7 +10249,7 @@ func (self ShrinkWidthItem) Index() int {
 	return int(C.wrap_ImGuiShrinkWidthItem_GetIndex(self.handle()))
 }
 
-func (self *ShrinkWidthItem) SetWidth(v float32) {
+func (self ShrinkWidthItem) SetWidth(v float32) {
 	C.wrap_ImGuiShrinkWidthItem_SetWidth(self.handle(), C.float(v))
 }
 
@@ -10257,7 +10257,7 @@ func (self ShrinkWidthItem) Width() float32 {
 	return float32(C.wrap_ImGuiShrinkWidthItem_GetWidth(self.handle()))
 }
 
-func (self *ShrinkWidthItem) SetInitialWidth(v float32) {
+func (self ShrinkWidthItem) SetInitialWidth(v float32) {
 	C.wrap_ImGuiShrinkWidthItem_SetInitialWidth(self.handle(), C.float(v))
 }
 
@@ -10265,7 +10265,7 @@ func (self ShrinkWidthItem) InitialWidth() float32 {
 	return float32(C.wrap_ImGuiShrinkWidthItem_GetInitialWidth(self.handle()))
 }
 
-func (self *SizeCallbackData) SetUserData(v unsafe.Pointer) {
+func (self SizeCallbackData) SetUserData(v unsafe.Pointer) {
 	C.wrap_ImGuiSizeCallbackData_SetUserData(self.handle(), (v))
 }
 
@@ -10273,7 +10273,7 @@ func (self SizeCallbackData) UserData() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImGuiSizeCallbackData_GetUserData(self.handle()))
 }
 
-func (self *SizeCallbackData) SetPos(v Vec2) {
+func (self SizeCallbackData) SetPos(v Vec2) {
 	C.wrap_ImGuiSizeCallbackData_SetPos(self.handle(), v.toC())
 }
 
@@ -10283,7 +10283,7 @@ func (self SizeCallbackData) Pos() Vec2 {
 	return *out
 }
 
-func (self *SizeCallbackData) SetCurrentSize(v Vec2) {
+func (self SizeCallbackData) SetCurrentSize(v Vec2) {
 	C.wrap_ImGuiSizeCallbackData_SetCurrentSize(self.handle(), v.toC())
 }
 
@@ -10293,7 +10293,7 @@ func (self SizeCallbackData) CurrentSize() Vec2 {
 	return *out
 }
 
-func (self *SizeCallbackData) SetDesiredSize(v Vec2) {
+func (self SizeCallbackData) SetDesiredSize(v Vec2) {
 	C.wrap_ImGuiSizeCallbackData_SetDesiredSize(self.handle(), v.toC())
 }
 
@@ -10303,7 +10303,7 @@ func (self SizeCallbackData) DesiredSize() Vec2 {
 	return *out
 }
 
-func (self *StackLevelInfo) SetID(v ID) {
+func (self StackLevelInfo) SetID(v ID) {
 	C.wrap_ImGuiStackLevelInfo_SetID(self.handle(), C.ImGuiID(v))
 }
 
@@ -10311,7 +10311,7 @@ func (self StackLevelInfo) ID() ID {
 	return ID(C.wrap_ImGuiStackLevelInfo_GetID(self.handle()))
 }
 
-func (self *StackLevelInfo) SetQueryFrameCount(v int) {
+func (self StackLevelInfo) SetQueryFrameCount(v int) {
 	C.wrap_ImGuiStackLevelInfo_SetQueryFrameCount(self.handle(), C.ImS8(v))
 }
 
@@ -10319,7 +10319,7 @@ func (self StackLevelInfo) QueryFrameCount() int {
 	return int(C.wrap_ImGuiStackLevelInfo_GetQueryFrameCount(self.handle()))
 }
 
-func (self *StackLevelInfo) SetQuerySuccess(v bool) {
+func (self StackLevelInfo) SetQuerySuccess(v bool) {
 	C.wrap_ImGuiStackLevelInfo_SetQuerySuccess(self.handle(), C.bool(v))
 }
 
@@ -10327,7 +10327,7 @@ func (self StackLevelInfo) QuerySuccess() bool {
 	return C.wrap_ImGuiStackLevelInfo_GetQuerySuccess(self.handle()) == C.bool(true)
 }
 
-func (self *StackLevelInfo) SetDataType(v DataType) {
+func (self StackLevelInfo) SetDataType(v DataType) {
 	C.wrap_ImGuiStackLevelInfo_SetDataType(self.handle(), C.ImGuiDataType(v))
 }
 
@@ -10335,7 +10335,7 @@ func (self StackLevelInfo) DataType() DataType {
 	return DataType(C.wrap_ImGuiStackLevelInfo_GetDataType(self.handle()))
 }
 
-func (self *StackSizes) SetSizeOfIDStack(v int) {
+func (self StackSizes) SetSizeOfIDStack(v int) {
 	C.wrap_ImGuiStackSizes_SetSizeOfIDStack(self.handle(), C.short(v))
 }
 
@@ -10343,7 +10343,7 @@ func (self StackSizes) SizeOfIDStack() int {
 	return int(C.wrap_ImGuiStackSizes_GetSizeOfIDStack(self.handle()))
 }
 
-func (self *StackSizes) SetSizeOfColorStack(v int) {
+func (self StackSizes) SetSizeOfColorStack(v int) {
 	C.wrap_ImGuiStackSizes_SetSizeOfColorStack(self.handle(), C.short(v))
 }
 
@@ -10351,7 +10351,7 @@ func (self StackSizes) SizeOfColorStack() int {
 	return int(C.wrap_ImGuiStackSizes_GetSizeOfColorStack(self.handle()))
 }
 
-func (self *StackSizes) SetSizeOfStyleVarStack(v int) {
+func (self StackSizes) SetSizeOfStyleVarStack(v int) {
 	C.wrap_ImGuiStackSizes_SetSizeOfStyleVarStack(self.handle(), C.short(v))
 }
 
@@ -10359,7 +10359,7 @@ func (self StackSizes) SizeOfStyleVarStack() int {
 	return int(C.wrap_ImGuiStackSizes_GetSizeOfStyleVarStack(self.handle()))
 }
 
-func (self *StackSizes) SetSizeOfFontStack(v int) {
+func (self StackSizes) SetSizeOfFontStack(v int) {
 	C.wrap_ImGuiStackSizes_SetSizeOfFontStack(self.handle(), C.short(v))
 }
 
@@ -10367,7 +10367,7 @@ func (self StackSizes) SizeOfFontStack() int {
 	return int(C.wrap_ImGuiStackSizes_GetSizeOfFontStack(self.handle()))
 }
 
-func (self *StackSizes) SetSizeOfFocusScopeStack(v int) {
+func (self StackSizes) SetSizeOfFocusScopeStack(v int) {
 	C.wrap_ImGuiStackSizes_SetSizeOfFocusScopeStack(self.handle(), C.short(v))
 }
 
@@ -10375,7 +10375,7 @@ func (self StackSizes) SizeOfFocusScopeStack() int {
 	return int(C.wrap_ImGuiStackSizes_GetSizeOfFocusScopeStack(self.handle()))
 }
 
-func (self *StackSizes) SetSizeOfGroupStack(v int) {
+func (self StackSizes) SetSizeOfGroupStack(v int) {
 	C.wrap_ImGuiStackSizes_SetSizeOfGroupStack(self.handle(), C.short(v))
 }
 
@@ -10383,7 +10383,7 @@ func (self StackSizes) SizeOfGroupStack() int {
 	return int(C.wrap_ImGuiStackSizes_GetSizeOfGroupStack(self.handle()))
 }
 
-func (self *StackSizes) SetSizeOfItemFlagsStack(v int) {
+func (self StackSizes) SetSizeOfItemFlagsStack(v int) {
 	C.wrap_ImGuiStackSizes_SetSizeOfItemFlagsStack(self.handle(), C.short(v))
 }
 
@@ -10391,7 +10391,7 @@ func (self StackSizes) SizeOfItemFlagsStack() int {
 	return int(C.wrap_ImGuiStackSizes_GetSizeOfItemFlagsStack(self.handle()))
 }
 
-func (self *StackSizes) SetSizeOfBeginPopupStack(v int) {
+func (self StackSizes) SetSizeOfBeginPopupStack(v int) {
 	C.wrap_ImGuiStackSizes_SetSizeOfBeginPopupStack(self.handle(), C.short(v))
 }
 
@@ -10399,7 +10399,7 @@ func (self StackSizes) SizeOfBeginPopupStack() int {
 	return int(C.wrap_ImGuiStackSizes_GetSizeOfBeginPopupStack(self.handle()))
 }
 
-func (self *StackSizes) SetSizeOfDisabledStack(v int) {
+func (self StackSizes) SetSizeOfDisabledStack(v int) {
 	C.wrap_ImGuiStackSizes_SetSizeOfDisabledStack(self.handle(), C.short(v))
 }
 
@@ -10407,7 +10407,7 @@ func (self StackSizes) SizeOfDisabledStack() int {
 	return int(C.wrap_ImGuiStackSizes_GetSizeOfDisabledStack(self.handle()))
 }
 
-func (self *StackTool) SetLastActiveFrame(v int32) {
+func (self StackTool) SetLastActiveFrame(v int32) {
 	C.wrap_ImGuiStackTool_SetLastActiveFrame(self.handle(), C.int(v))
 }
 
@@ -10415,7 +10415,7 @@ func (self StackTool) LastActiveFrame() int {
 	return int(C.wrap_ImGuiStackTool_GetLastActiveFrame(self.handle()))
 }
 
-func (self *StackTool) SetStackLevel(v int32) {
+func (self StackTool) SetStackLevel(v int32) {
 	C.wrap_ImGuiStackTool_SetStackLevel(self.handle(), C.int(v))
 }
 
@@ -10423,7 +10423,7 @@ func (self StackTool) StackLevel() int {
 	return int(C.wrap_ImGuiStackTool_GetStackLevel(self.handle()))
 }
 
-func (self *StackTool) SetQueryId(v ID) {
+func (self StackTool) SetQueryId(v ID) {
 	C.wrap_ImGuiStackTool_SetQueryId(self.handle(), C.ImGuiID(v))
 }
 
@@ -10431,7 +10431,7 @@ func (self StackTool) QueryId() ID {
 	return ID(C.wrap_ImGuiStackTool_GetQueryId(self.handle()))
 }
 
-func (self *StackTool) SetCopyToClipboardOnCtrlC(v bool) {
+func (self StackTool) SetCopyToClipboardOnCtrlC(v bool) {
 	C.wrap_ImGuiStackTool_SetCopyToClipboardOnCtrlC(self.handle(), C.bool(v))
 }
 
@@ -10439,7 +10439,7 @@ func (self StackTool) CopyToClipboardOnCtrlC() bool {
 	return C.wrap_ImGuiStackTool_GetCopyToClipboardOnCtrlC(self.handle()) == C.bool(true)
 }
 
-func (self *StackTool) SetCopyToClipboardLastTime(v float32) {
+func (self StackTool) SetCopyToClipboardLastTime(v float32) {
 	C.wrap_ImGuiStackTool_SetCopyToClipboardLastTime(self.handle(), C.float(v))
 }
 
@@ -10447,7 +10447,7 @@ func (self StackTool) CopyToClipboardLastTime() float32 {
 	return float32(C.wrap_ImGuiStackTool_GetCopyToClipboardLastTime(self.handle()))
 }
 
-func (self *StoragePair) Setkey(v ID) {
+func (self StoragePair) Setkey(v ID) {
 	C.wrap_ImGuiStoragePair_Setkey(self.handle(), C.ImGuiID(v))
 }
 
@@ -10455,7 +10455,7 @@ func (self StoragePair) key() ID {
 	return ID(C.wrap_ImGuiStoragePair_Getkey(self.handle()))
 }
 
-func (self *Style) SetAlpha(v float32) {
+func (self Style) SetAlpha(v float32) {
 	C.wrap_ImGuiStyle_SetAlpha(self.handle(), C.float(v))
 }
 
@@ -10463,7 +10463,7 @@ func (self Style) Alpha() float32 {
 	return float32(C.wrap_ImGuiStyle_GetAlpha(self.handle()))
 }
 
-func (self *Style) SetDisabledAlpha(v float32) {
+func (self Style) SetDisabledAlpha(v float32) {
 	C.wrap_ImGuiStyle_SetDisabledAlpha(self.handle(), C.float(v))
 }
 
@@ -10471,7 +10471,7 @@ func (self Style) DisabledAlpha() float32 {
 	return float32(C.wrap_ImGuiStyle_GetDisabledAlpha(self.handle()))
 }
 
-func (self *Style) SetWindowPadding(v Vec2) {
+func (self Style) SetWindowPadding(v Vec2) {
 	C.wrap_ImGuiStyle_SetWindowPadding(self.handle(), v.toC())
 }
 
@@ -10481,7 +10481,7 @@ func (self Style) WindowPadding() Vec2 {
 	return *out
 }
 
-func (self *Style) SetWindowRounding(v float32) {
+func (self Style) SetWindowRounding(v float32) {
 	C.wrap_ImGuiStyle_SetWindowRounding(self.handle(), C.float(v))
 }
 
@@ -10489,7 +10489,7 @@ func (self Style) WindowRounding() float32 {
 	return float32(C.wrap_ImGuiStyle_GetWindowRounding(self.handle()))
 }
 
-func (self *Style) SetWindowBorderSize(v float32) {
+func (self Style) SetWindowBorderSize(v float32) {
 	C.wrap_ImGuiStyle_SetWindowBorderSize(self.handle(), C.float(v))
 }
 
@@ -10497,7 +10497,7 @@ func (self Style) WindowBorderSize() float32 {
 	return float32(C.wrap_ImGuiStyle_GetWindowBorderSize(self.handle()))
 }
 
-func (self *Style) SetWindowMinSize(v Vec2) {
+func (self Style) SetWindowMinSize(v Vec2) {
 	C.wrap_ImGuiStyle_SetWindowMinSize(self.handle(), v.toC())
 }
 
@@ -10507,7 +10507,7 @@ func (self Style) WindowMinSize() Vec2 {
 	return *out
 }
 
-func (self *Style) SetWindowTitleAlign(v Vec2) {
+func (self Style) SetWindowTitleAlign(v Vec2) {
 	C.wrap_ImGuiStyle_SetWindowTitleAlign(self.handle(), v.toC())
 }
 
@@ -10517,7 +10517,7 @@ func (self Style) WindowTitleAlign() Vec2 {
 	return *out
 }
 
-func (self *Style) SetWindowMenuButtonPosition(v Dir) {
+func (self Style) SetWindowMenuButtonPosition(v Dir) {
 	C.wrap_ImGuiStyle_SetWindowMenuButtonPosition(self.handle(), C.ImGuiDir(v))
 }
 
@@ -10525,7 +10525,7 @@ func (self Style) WindowMenuButtonPosition() Dir {
 	return Dir(C.wrap_ImGuiStyle_GetWindowMenuButtonPosition(self.handle()))
 }
 
-func (self *Style) SetChildRounding(v float32) {
+func (self Style) SetChildRounding(v float32) {
 	C.wrap_ImGuiStyle_SetChildRounding(self.handle(), C.float(v))
 }
 
@@ -10533,7 +10533,7 @@ func (self Style) ChildRounding() float32 {
 	return float32(C.wrap_ImGuiStyle_GetChildRounding(self.handle()))
 }
 
-func (self *Style) SetChildBorderSize(v float32) {
+func (self Style) SetChildBorderSize(v float32) {
 	C.wrap_ImGuiStyle_SetChildBorderSize(self.handle(), C.float(v))
 }
 
@@ -10541,7 +10541,7 @@ func (self Style) ChildBorderSize() float32 {
 	return float32(C.wrap_ImGuiStyle_GetChildBorderSize(self.handle()))
 }
 
-func (self *Style) SetPopupRounding(v float32) {
+func (self Style) SetPopupRounding(v float32) {
 	C.wrap_ImGuiStyle_SetPopupRounding(self.handle(), C.float(v))
 }
 
@@ -10549,7 +10549,7 @@ func (self Style) PopupRounding() float32 {
 	return float32(C.wrap_ImGuiStyle_GetPopupRounding(self.handle()))
 }
 
-func (self *Style) SetPopupBorderSize(v float32) {
+func (self Style) SetPopupBorderSize(v float32) {
 	C.wrap_ImGuiStyle_SetPopupBorderSize(self.handle(), C.float(v))
 }
 
@@ -10557,7 +10557,7 @@ func (self Style) PopupBorderSize() float32 {
 	return float32(C.wrap_ImGuiStyle_GetPopupBorderSize(self.handle()))
 }
 
-func (self *Style) SetFramePadding(v Vec2) {
+func (self Style) SetFramePadding(v Vec2) {
 	C.wrap_ImGuiStyle_SetFramePadding(self.handle(), v.toC())
 }
 
@@ -10567,7 +10567,7 @@ func (self Style) FramePadding() Vec2 {
 	return *out
 }
 
-func (self *Style) SetFrameRounding(v float32) {
+func (self Style) SetFrameRounding(v float32) {
 	C.wrap_ImGuiStyle_SetFrameRounding(self.handle(), C.float(v))
 }
 
@@ -10575,7 +10575,7 @@ func (self Style) FrameRounding() float32 {
 	return float32(C.wrap_ImGuiStyle_GetFrameRounding(self.handle()))
 }
 
-func (self *Style) SetFrameBorderSize(v float32) {
+func (self Style) SetFrameBorderSize(v float32) {
 	C.wrap_ImGuiStyle_SetFrameBorderSize(self.handle(), C.float(v))
 }
 
@@ -10583,7 +10583,7 @@ func (self Style) FrameBorderSize() float32 {
 	return float32(C.wrap_ImGuiStyle_GetFrameBorderSize(self.handle()))
 }
 
-func (self *Style) SetItemSpacing(v Vec2) {
+func (self Style) SetItemSpacing(v Vec2) {
 	C.wrap_ImGuiStyle_SetItemSpacing(self.handle(), v.toC())
 }
 
@@ -10593,7 +10593,7 @@ func (self Style) ItemSpacing() Vec2 {
 	return *out
 }
 
-func (self *Style) SetItemInnerSpacing(v Vec2) {
+func (self Style) SetItemInnerSpacing(v Vec2) {
 	C.wrap_ImGuiStyle_SetItemInnerSpacing(self.handle(), v.toC())
 }
 
@@ -10603,7 +10603,7 @@ func (self Style) ItemInnerSpacing() Vec2 {
 	return *out
 }
 
-func (self *Style) SetCellPadding(v Vec2) {
+func (self Style) SetCellPadding(v Vec2) {
 	C.wrap_ImGuiStyle_SetCellPadding(self.handle(), v.toC())
 }
 
@@ -10613,7 +10613,7 @@ func (self Style) CellPadding() Vec2 {
 	return *out
 }
 
-func (self *Style) SetTouchExtraPadding(v Vec2) {
+func (self Style) SetTouchExtraPadding(v Vec2) {
 	C.wrap_ImGuiStyle_SetTouchExtraPadding(self.handle(), v.toC())
 }
 
@@ -10623,7 +10623,7 @@ func (self Style) TouchExtraPadding() Vec2 {
 	return *out
 }
 
-func (self *Style) SetIndentSpacing(v float32) {
+func (self Style) SetIndentSpacing(v float32) {
 	C.wrap_ImGuiStyle_SetIndentSpacing(self.handle(), C.float(v))
 }
 
@@ -10631,7 +10631,7 @@ func (self Style) IndentSpacing() float32 {
 	return float32(C.wrap_ImGuiStyle_GetIndentSpacing(self.handle()))
 }
 
-func (self *Style) SetColumnsMinSpacing(v float32) {
+func (self Style) SetColumnsMinSpacing(v float32) {
 	C.wrap_ImGuiStyle_SetColumnsMinSpacing(self.handle(), C.float(v))
 }
 
@@ -10639,7 +10639,7 @@ func (self Style) ColumnsMinSpacing() float32 {
 	return float32(C.wrap_ImGuiStyle_GetColumnsMinSpacing(self.handle()))
 }
 
-func (self *Style) SetScrollbarSize(v float32) {
+func (self Style) SetScrollbarSize(v float32) {
 	C.wrap_ImGuiStyle_SetScrollbarSize(self.handle(), C.float(v))
 }
 
@@ -10647,7 +10647,7 @@ func (self Style) ScrollbarSize() float32 {
 	return float32(C.wrap_ImGuiStyle_GetScrollbarSize(self.handle()))
 }
 
-func (self *Style) SetScrollbarRounding(v float32) {
+func (self Style) SetScrollbarRounding(v float32) {
 	C.wrap_ImGuiStyle_SetScrollbarRounding(self.handle(), C.float(v))
 }
 
@@ -10655,7 +10655,7 @@ func (self Style) ScrollbarRounding() float32 {
 	return float32(C.wrap_ImGuiStyle_GetScrollbarRounding(self.handle()))
 }
 
-func (self *Style) SetGrabMinSize(v float32) {
+func (self Style) SetGrabMinSize(v float32) {
 	C.wrap_ImGuiStyle_SetGrabMinSize(self.handle(), C.float(v))
 }
 
@@ -10663,7 +10663,7 @@ func (self Style) GrabMinSize() float32 {
 	return float32(C.wrap_ImGuiStyle_GetGrabMinSize(self.handle()))
 }
 
-func (self *Style) SetGrabRounding(v float32) {
+func (self Style) SetGrabRounding(v float32) {
 	C.wrap_ImGuiStyle_SetGrabRounding(self.handle(), C.float(v))
 }
 
@@ -10671,7 +10671,7 @@ func (self Style) GrabRounding() float32 {
 	return float32(C.wrap_ImGuiStyle_GetGrabRounding(self.handle()))
 }
 
-func (self *Style) SetLogSliderDeadzone(v float32) {
+func (self Style) SetLogSliderDeadzone(v float32) {
 	C.wrap_ImGuiStyle_SetLogSliderDeadzone(self.handle(), C.float(v))
 }
 
@@ -10679,7 +10679,7 @@ func (self Style) LogSliderDeadzone() float32 {
 	return float32(C.wrap_ImGuiStyle_GetLogSliderDeadzone(self.handle()))
 }
 
-func (self *Style) SetTabRounding(v float32) {
+func (self Style) SetTabRounding(v float32) {
 	C.wrap_ImGuiStyle_SetTabRounding(self.handle(), C.float(v))
 }
 
@@ -10687,7 +10687,7 @@ func (self Style) TabRounding() float32 {
 	return float32(C.wrap_ImGuiStyle_GetTabRounding(self.handle()))
 }
 
-func (self *Style) SetTabBorderSize(v float32) {
+func (self Style) SetTabBorderSize(v float32) {
 	C.wrap_ImGuiStyle_SetTabBorderSize(self.handle(), C.float(v))
 }
 
@@ -10695,7 +10695,7 @@ func (self Style) TabBorderSize() float32 {
 	return float32(C.wrap_ImGuiStyle_GetTabBorderSize(self.handle()))
 }
 
-func (self *Style) SetTabMinWidthForCloseButton(v float32) {
+func (self Style) SetTabMinWidthForCloseButton(v float32) {
 	C.wrap_ImGuiStyle_SetTabMinWidthForCloseButton(self.handle(), C.float(v))
 }
 
@@ -10703,7 +10703,7 @@ func (self Style) TabMinWidthForCloseButton() float32 {
 	return float32(C.wrap_ImGuiStyle_GetTabMinWidthForCloseButton(self.handle()))
 }
 
-func (self *Style) SetColorButtonPosition(v Dir) {
+func (self Style) SetColorButtonPosition(v Dir) {
 	C.wrap_ImGuiStyle_SetColorButtonPosition(self.handle(), C.ImGuiDir(v))
 }
 
@@ -10711,7 +10711,7 @@ func (self Style) ColorButtonPosition() Dir {
 	return Dir(C.wrap_ImGuiStyle_GetColorButtonPosition(self.handle()))
 }
 
-func (self *Style) SetButtonTextAlign(v Vec2) {
+func (self Style) SetButtonTextAlign(v Vec2) {
 	C.wrap_ImGuiStyle_SetButtonTextAlign(self.handle(), v.toC())
 }
 
@@ -10721,7 +10721,7 @@ func (self Style) ButtonTextAlign() Vec2 {
 	return *out
 }
 
-func (self *Style) SetSelectableTextAlign(v Vec2) {
+func (self Style) SetSelectableTextAlign(v Vec2) {
 	C.wrap_ImGuiStyle_SetSelectableTextAlign(self.handle(), v.toC())
 }
 
@@ -10731,7 +10731,7 @@ func (self Style) SelectableTextAlign() Vec2 {
 	return *out
 }
 
-func (self *Style) SetDisplayWindowPadding(v Vec2) {
+func (self Style) SetDisplayWindowPadding(v Vec2) {
 	C.wrap_ImGuiStyle_SetDisplayWindowPadding(self.handle(), v.toC())
 }
 
@@ -10741,7 +10741,7 @@ func (self Style) DisplayWindowPadding() Vec2 {
 	return *out
 }
 
-func (self *Style) SetDisplaySafeAreaPadding(v Vec2) {
+func (self Style) SetDisplaySafeAreaPadding(v Vec2) {
 	C.wrap_ImGuiStyle_SetDisplaySafeAreaPadding(self.handle(), v.toC())
 }
 
@@ -10751,7 +10751,7 @@ func (self Style) DisplaySafeAreaPadding() Vec2 {
 	return *out
 }
 
-func (self *Style) SetMouseCursorScale(v float32) {
+func (self Style) SetMouseCursorScale(v float32) {
 	C.wrap_ImGuiStyle_SetMouseCursorScale(self.handle(), C.float(v))
 }
 
@@ -10759,7 +10759,7 @@ func (self Style) MouseCursorScale() float32 {
 	return float32(C.wrap_ImGuiStyle_GetMouseCursorScale(self.handle()))
 }
 
-func (self *Style) SetAntiAliasedLines(v bool) {
+func (self Style) SetAntiAliasedLines(v bool) {
 	C.wrap_ImGuiStyle_SetAntiAliasedLines(self.handle(), C.bool(v))
 }
 
@@ -10767,7 +10767,7 @@ func (self Style) AntiAliasedLines() bool {
 	return C.wrap_ImGuiStyle_GetAntiAliasedLines(self.handle()) == C.bool(true)
 }
 
-func (self *Style) SetAntiAliasedLinesUseTex(v bool) {
+func (self Style) SetAntiAliasedLinesUseTex(v bool) {
 	C.wrap_ImGuiStyle_SetAntiAliasedLinesUseTex(self.handle(), C.bool(v))
 }
 
@@ -10775,7 +10775,7 @@ func (self Style) AntiAliasedLinesUseTex() bool {
 	return C.wrap_ImGuiStyle_GetAntiAliasedLinesUseTex(self.handle()) == C.bool(true)
 }
 
-func (self *Style) SetAntiAliasedFill(v bool) {
+func (self Style) SetAntiAliasedFill(v bool) {
 	C.wrap_ImGuiStyle_SetAntiAliasedFill(self.handle(), C.bool(v))
 }
 
@@ -10783,7 +10783,7 @@ func (self Style) AntiAliasedFill() bool {
 	return C.wrap_ImGuiStyle_GetAntiAliasedFill(self.handle()) == C.bool(true)
 }
 
-func (self *Style) SetCurveTessellationTol(v float32) {
+func (self Style) SetCurveTessellationTol(v float32) {
 	C.wrap_ImGuiStyle_SetCurveTessellationTol(self.handle(), C.float(v))
 }
 
@@ -10791,7 +10791,7 @@ func (self Style) CurveTessellationTol() float32 {
 	return float32(C.wrap_ImGuiStyle_GetCurveTessellationTol(self.handle()))
 }
 
-func (self *Style) SetCircleTessellationMaxError(v float32) {
+func (self Style) SetCircleTessellationMaxError(v float32) {
 	C.wrap_ImGuiStyle_SetCircleTessellationMaxError(self.handle(), C.float(v))
 }
 
@@ -10799,7 +10799,7 @@ func (self Style) CircleTessellationMaxError() float32 {
 	return float32(C.wrap_ImGuiStyle_GetCircleTessellationMaxError(self.handle()))
 }
 
-func (self *StyleMod) SetVarIdx(v StyleVar) {
+func (self StyleMod) SetVarIdx(v StyleVar) {
 	C.wrap_ImGuiStyleMod_SetVarIdx(self.handle(), C.ImGuiStyleVar(v))
 }
 
@@ -10807,7 +10807,7 @@ func (self StyleMod) VarIdx() StyleVar {
 	return StyleVar(C.wrap_ImGuiStyleMod_GetVarIdx(self.handle()))
 }
 
-func (self *TabBar) SetFlags(v TabBarFlags) {
+func (self TabBar) SetFlags(v TabBarFlags) {
 	C.wrap_ImGuiTabBar_SetFlags(self.handle(), C.ImGuiTabBarFlags(v))
 }
 
@@ -10815,7 +10815,7 @@ func (self TabBar) Flags() TabBarFlags {
 	return TabBarFlags(C.wrap_ImGuiTabBar_GetFlags(self.handle()))
 }
 
-func (self *TabBar) SetID(v ID) {
+func (self TabBar) SetID(v ID) {
 	C.wrap_ImGuiTabBar_SetID(self.handle(), C.ImGuiID(v))
 }
 
@@ -10823,7 +10823,7 @@ func (self TabBar) ID() ID {
 	return ID(C.wrap_ImGuiTabBar_GetID(self.handle()))
 }
 
-func (self *TabBar) SetSelectedTabId(v ID) {
+func (self TabBar) SetSelectedTabId(v ID) {
 	C.wrap_ImGuiTabBar_SetSelectedTabId(self.handle(), C.ImGuiID(v))
 }
 
@@ -10831,7 +10831,7 @@ func (self TabBar) SelectedTabId() ID {
 	return ID(C.wrap_ImGuiTabBar_GetSelectedTabId(self.handle()))
 }
 
-func (self *TabBar) SetNextSelectedTabId(v ID) {
+func (self TabBar) SetNextSelectedTabId(v ID) {
 	C.wrap_ImGuiTabBar_SetNextSelectedTabId(self.handle(), C.ImGuiID(v))
 }
 
@@ -10839,7 +10839,7 @@ func (self TabBar) NextSelectedTabId() ID {
 	return ID(C.wrap_ImGuiTabBar_GetNextSelectedTabId(self.handle()))
 }
 
-func (self *TabBar) SetVisibleTabId(v ID) {
+func (self TabBar) SetVisibleTabId(v ID) {
 	C.wrap_ImGuiTabBar_SetVisibleTabId(self.handle(), C.ImGuiID(v))
 }
 
@@ -10847,7 +10847,7 @@ func (self TabBar) VisibleTabId() ID {
 	return ID(C.wrap_ImGuiTabBar_GetVisibleTabId(self.handle()))
 }
 
-func (self *TabBar) SetCurrFrameVisible(v int32) {
+func (self TabBar) SetCurrFrameVisible(v int32) {
 	C.wrap_ImGuiTabBar_SetCurrFrameVisible(self.handle(), C.int(v))
 }
 
@@ -10855,7 +10855,7 @@ func (self TabBar) CurrFrameVisible() int {
 	return int(C.wrap_ImGuiTabBar_GetCurrFrameVisible(self.handle()))
 }
 
-func (self *TabBar) SetPrevFrameVisible(v int32) {
+func (self TabBar) SetPrevFrameVisible(v int32) {
 	C.wrap_ImGuiTabBar_SetPrevFrameVisible(self.handle(), C.int(v))
 }
 
@@ -10863,7 +10863,7 @@ func (self TabBar) PrevFrameVisible() int {
 	return int(C.wrap_ImGuiTabBar_GetPrevFrameVisible(self.handle()))
 }
 
-func (self *TabBar) SetBarRect(v Rect) {
+func (self TabBar) SetBarRect(v Rect) {
 	C.wrap_ImGuiTabBar_SetBarRect(self.handle(), v.toC())
 }
 
@@ -10873,7 +10873,7 @@ func (self TabBar) BarRect() Rect {
 	return *out
 }
 
-func (self *TabBar) SetCurrTabsContentsHeight(v float32) {
+func (self TabBar) SetCurrTabsContentsHeight(v float32) {
 	C.wrap_ImGuiTabBar_SetCurrTabsContentsHeight(self.handle(), C.float(v))
 }
 
@@ -10881,7 +10881,7 @@ func (self TabBar) CurrTabsContentsHeight() float32 {
 	return float32(C.wrap_ImGuiTabBar_GetCurrTabsContentsHeight(self.handle()))
 }
 
-func (self *TabBar) SetPrevTabsContentsHeight(v float32) {
+func (self TabBar) SetPrevTabsContentsHeight(v float32) {
 	C.wrap_ImGuiTabBar_SetPrevTabsContentsHeight(self.handle(), C.float(v))
 }
 
@@ -10889,7 +10889,7 @@ func (self TabBar) PrevTabsContentsHeight() float32 {
 	return float32(C.wrap_ImGuiTabBar_GetPrevTabsContentsHeight(self.handle()))
 }
 
-func (self *TabBar) SetWidthAllTabs(v float32) {
+func (self TabBar) SetWidthAllTabs(v float32) {
 	C.wrap_ImGuiTabBar_SetWidthAllTabs(self.handle(), C.float(v))
 }
 
@@ -10897,7 +10897,7 @@ func (self TabBar) WidthAllTabs() float32 {
 	return float32(C.wrap_ImGuiTabBar_GetWidthAllTabs(self.handle()))
 }
 
-func (self *TabBar) SetWidthAllTabsIdeal(v float32) {
+func (self TabBar) SetWidthAllTabsIdeal(v float32) {
 	C.wrap_ImGuiTabBar_SetWidthAllTabsIdeal(self.handle(), C.float(v))
 }
 
@@ -10905,7 +10905,7 @@ func (self TabBar) WidthAllTabsIdeal() float32 {
 	return float32(C.wrap_ImGuiTabBar_GetWidthAllTabsIdeal(self.handle()))
 }
 
-func (self *TabBar) SetScrollingAnim(v float32) {
+func (self TabBar) SetScrollingAnim(v float32) {
 	C.wrap_ImGuiTabBar_SetScrollingAnim(self.handle(), C.float(v))
 }
 
@@ -10913,7 +10913,7 @@ func (self TabBar) ScrollingAnim() float32 {
 	return float32(C.wrap_ImGuiTabBar_GetScrollingAnim(self.handle()))
 }
 
-func (self *TabBar) SetScrollingTarget(v float32) {
+func (self TabBar) SetScrollingTarget(v float32) {
 	C.wrap_ImGuiTabBar_SetScrollingTarget(self.handle(), C.float(v))
 }
 
@@ -10921,7 +10921,7 @@ func (self TabBar) ScrollingTarget() float32 {
 	return float32(C.wrap_ImGuiTabBar_GetScrollingTarget(self.handle()))
 }
 
-func (self *TabBar) SetScrollingTargetDistToVisibility(v float32) {
+func (self TabBar) SetScrollingTargetDistToVisibility(v float32) {
 	C.wrap_ImGuiTabBar_SetScrollingTargetDistToVisibility(self.handle(), C.float(v))
 }
 
@@ -10929,7 +10929,7 @@ func (self TabBar) ScrollingTargetDistToVisibility() float32 {
 	return float32(C.wrap_ImGuiTabBar_GetScrollingTargetDistToVisibility(self.handle()))
 }
 
-func (self *TabBar) SetScrollingSpeed(v float32) {
+func (self TabBar) SetScrollingSpeed(v float32) {
 	C.wrap_ImGuiTabBar_SetScrollingSpeed(self.handle(), C.float(v))
 }
 
@@ -10937,7 +10937,7 @@ func (self TabBar) ScrollingSpeed() float32 {
 	return float32(C.wrap_ImGuiTabBar_GetScrollingSpeed(self.handle()))
 }
 
-func (self *TabBar) SetScrollingRectMinX(v float32) {
+func (self TabBar) SetScrollingRectMinX(v float32) {
 	C.wrap_ImGuiTabBar_SetScrollingRectMinX(self.handle(), C.float(v))
 }
 
@@ -10945,7 +10945,7 @@ func (self TabBar) ScrollingRectMinX() float32 {
 	return float32(C.wrap_ImGuiTabBar_GetScrollingRectMinX(self.handle()))
 }
 
-func (self *TabBar) SetScrollingRectMaxX(v float32) {
+func (self TabBar) SetScrollingRectMaxX(v float32) {
 	C.wrap_ImGuiTabBar_SetScrollingRectMaxX(self.handle(), C.float(v))
 }
 
@@ -10953,7 +10953,7 @@ func (self TabBar) ScrollingRectMaxX() float32 {
 	return float32(C.wrap_ImGuiTabBar_GetScrollingRectMaxX(self.handle()))
 }
 
-func (self *TabBar) SetReorderRequestTabId(v ID) {
+func (self TabBar) SetReorderRequestTabId(v ID) {
 	C.wrap_ImGuiTabBar_SetReorderRequestTabId(self.handle(), C.ImGuiID(v))
 }
 
@@ -10961,7 +10961,7 @@ func (self TabBar) ReorderRequestTabId() ID {
 	return ID(C.wrap_ImGuiTabBar_GetReorderRequestTabId(self.handle()))
 }
 
-func (self *TabBar) SetReorderRequestOffset(v int) {
+func (self TabBar) SetReorderRequestOffset(v int) {
 	C.wrap_ImGuiTabBar_SetReorderRequestOffset(self.handle(), C.ImS16(v))
 }
 
@@ -10969,7 +10969,7 @@ func (self TabBar) ReorderRequestOffset() int {
 	return int(C.wrap_ImGuiTabBar_GetReorderRequestOffset(self.handle()))
 }
 
-func (self *TabBar) SetBeginCount(v int) {
+func (self TabBar) SetBeginCount(v int) {
 	C.wrap_ImGuiTabBar_SetBeginCount(self.handle(), C.ImS8(v))
 }
 
@@ -10977,7 +10977,7 @@ func (self TabBar) BeginCount() int {
 	return int(C.wrap_ImGuiTabBar_GetBeginCount(self.handle()))
 }
 
-func (self *TabBar) SetWantLayout(v bool) {
+func (self TabBar) SetWantLayout(v bool) {
 	C.wrap_ImGuiTabBar_SetWantLayout(self.handle(), C.bool(v))
 }
 
@@ -10985,7 +10985,7 @@ func (self TabBar) WantLayout() bool {
 	return C.wrap_ImGuiTabBar_GetWantLayout(self.handle()) == C.bool(true)
 }
 
-func (self *TabBar) SetVisibleTabWasSubmitted(v bool) {
+func (self TabBar) SetVisibleTabWasSubmitted(v bool) {
 	C.wrap_ImGuiTabBar_SetVisibleTabWasSubmitted(self.handle(), C.bool(v))
 }
 
@@ -10993,7 +10993,7 @@ func (self TabBar) VisibleTabWasSubmitted() bool {
 	return C.wrap_ImGuiTabBar_GetVisibleTabWasSubmitted(self.handle()) == C.bool(true)
 }
 
-func (self *TabBar) SetTabsAddedNew(v bool) {
+func (self TabBar) SetTabsAddedNew(v bool) {
 	C.wrap_ImGuiTabBar_SetTabsAddedNew(self.handle(), C.bool(v))
 }
 
@@ -11001,7 +11001,7 @@ func (self TabBar) TabsAddedNew() bool {
 	return C.wrap_ImGuiTabBar_GetTabsAddedNew(self.handle()) == C.bool(true)
 }
 
-func (self *TabBar) SetTabsActiveCount(v int) {
+func (self TabBar) SetTabsActiveCount(v int) {
 	C.wrap_ImGuiTabBar_SetTabsActiveCount(self.handle(), C.ImS16(v))
 }
 
@@ -11009,7 +11009,7 @@ func (self TabBar) TabsActiveCount() int {
 	return int(C.wrap_ImGuiTabBar_GetTabsActiveCount(self.handle()))
 }
 
-func (self *TabBar) SetLastTabItemIdx(v int) {
+func (self TabBar) SetLastTabItemIdx(v int) {
 	C.wrap_ImGuiTabBar_SetLastTabItemIdx(self.handle(), C.ImS16(v))
 }
 
@@ -11017,7 +11017,7 @@ func (self TabBar) LastTabItemIdx() int {
 	return int(C.wrap_ImGuiTabBar_GetLastTabItemIdx(self.handle()))
 }
 
-func (self *TabBar) SetItemSpacingY(v float32) {
+func (self TabBar) SetItemSpacingY(v float32) {
 	C.wrap_ImGuiTabBar_SetItemSpacingY(self.handle(), C.float(v))
 }
 
@@ -11025,7 +11025,7 @@ func (self TabBar) ItemSpacingY() float32 {
 	return float32(C.wrap_ImGuiTabBar_GetItemSpacingY(self.handle()))
 }
 
-func (self *TabBar) SetFramePadding(v Vec2) {
+func (self TabBar) SetFramePadding(v Vec2) {
 	C.wrap_ImGuiTabBar_SetFramePadding(self.handle(), v.toC())
 }
 
@@ -11035,7 +11035,7 @@ func (self TabBar) FramePadding() Vec2 {
 	return *out
 }
 
-func (self *TabBar) SetBackupCursorPos(v Vec2) {
+func (self TabBar) SetBackupCursorPos(v Vec2) {
 	C.wrap_ImGuiTabBar_SetBackupCursorPos(self.handle(), v.toC())
 }
 
@@ -11049,7 +11049,7 @@ func (self TabBar) TabsNames() TextBuffer {
 	return newTextBufferFromC(C.wrap_ImGuiTabBar_GetTabsNames(self.handle()))
 }
 
-func (self *TabItem) SetID(v ID) {
+func (self TabItem) SetID(v ID) {
 	C.wrap_ImGuiTabItem_SetID(self.handle(), C.ImGuiID(v))
 }
 
@@ -11057,7 +11057,7 @@ func (self TabItem) ID() ID {
 	return ID(C.wrap_ImGuiTabItem_GetID(self.handle()))
 }
 
-func (self *TabItem) SetFlags(v TabItemFlags) {
+func (self TabItem) SetFlags(v TabItemFlags) {
 	C.wrap_ImGuiTabItem_SetFlags(self.handle(), C.ImGuiTabItemFlags(v))
 }
 
@@ -11065,7 +11065,7 @@ func (self TabItem) Flags() TabItemFlags {
 	return TabItemFlags(C.wrap_ImGuiTabItem_GetFlags(self.handle()))
 }
 
-func (self *TabItem) SetWindow(v Window) {
+func (self TabItem) SetWindow(v Window) {
 	C.wrap_ImGuiTabItem_SetWindow(self.handle(), v.handle())
 }
 
@@ -11073,7 +11073,7 @@ func (self TabItem) Window() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiTabItem_GetWindow(self.handle())))
 }
 
-func (self *TabItem) SetLastFrameVisible(v int32) {
+func (self TabItem) SetLastFrameVisible(v int32) {
 	C.wrap_ImGuiTabItem_SetLastFrameVisible(self.handle(), C.int(v))
 }
 
@@ -11081,7 +11081,7 @@ func (self TabItem) LastFrameVisible() int {
 	return int(C.wrap_ImGuiTabItem_GetLastFrameVisible(self.handle()))
 }
 
-func (self *TabItem) SetLastFrameSelected(v int32) {
+func (self TabItem) SetLastFrameSelected(v int32) {
 	C.wrap_ImGuiTabItem_SetLastFrameSelected(self.handle(), C.int(v))
 }
 
@@ -11089,7 +11089,7 @@ func (self TabItem) LastFrameSelected() int {
 	return int(C.wrap_ImGuiTabItem_GetLastFrameSelected(self.handle()))
 }
 
-func (self *TabItem) SetOffset(v float32) {
+func (self TabItem) SetOffset(v float32) {
 	C.wrap_ImGuiTabItem_SetOffset(self.handle(), C.float(v))
 }
 
@@ -11097,7 +11097,7 @@ func (self TabItem) Offset() float32 {
 	return float32(C.wrap_ImGuiTabItem_GetOffset(self.handle()))
 }
 
-func (self *TabItem) SetWidth(v float32) {
+func (self TabItem) SetWidth(v float32) {
 	C.wrap_ImGuiTabItem_SetWidth(self.handle(), C.float(v))
 }
 
@@ -11105,7 +11105,7 @@ func (self TabItem) Width() float32 {
 	return float32(C.wrap_ImGuiTabItem_GetWidth(self.handle()))
 }
 
-func (self *TabItem) SetContentWidth(v float32) {
+func (self TabItem) SetContentWidth(v float32) {
 	C.wrap_ImGuiTabItem_SetContentWidth(self.handle(), C.float(v))
 }
 
@@ -11113,7 +11113,7 @@ func (self TabItem) ContentWidth() float32 {
 	return float32(C.wrap_ImGuiTabItem_GetContentWidth(self.handle()))
 }
 
-func (self *TabItem) SetRequestedWidth(v float32) {
+func (self TabItem) SetRequestedWidth(v float32) {
 	C.wrap_ImGuiTabItem_SetRequestedWidth(self.handle(), C.float(v))
 }
 
@@ -11121,7 +11121,7 @@ func (self TabItem) RequestedWidth() float32 {
 	return float32(C.wrap_ImGuiTabItem_GetRequestedWidth(self.handle()))
 }
 
-func (self *TabItem) SetNameOffset(v int) {
+func (self TabItem) SetNameOffset(v int) {
 	C.wrap_ImGuiTabItem_SetNameOffset(self.handle(), C.ImS32(v))
 }
 
@@ -11129,7 +11129,7 @@ func (self TabItem) NameOffset() int {
 	return int(C.wrap_ImGuiTabItem_GetNameOffset(self.handle()))
 }
 
-func (self *TabItem) SetBeginOrder(v int) {
+func (self TabItem) SetBeginOrder(v int) {
 	C.wrap_ImGuiTabItem_SetBeginOrder(self.handle(), C.ImS16(v))
 }
 
@@ -11137,7 +11137,7 @@ func (self TabItem) BeginOrder() int {
 	return int(C.wrap_ImGuiTabItem_GetBeginOrder(self.handle()))
 }
 
-func (self *TabItem) SetIndexDuringLayout(v int) {
+func (self TabItem) SetIndexDuringLayout(v int) {
 	C.wrap_ImGuiTabItem_SetIndexDuringLayout(self.handle(), C.ImS16(v))
 }
 
@@ -11145,7 +11145,7 @@ func (self TabItem) IndexDuringLayout() int {
 	return int(C.wrap_ImGuiTabItem_GetIndexDuringLayout(self.handle()))
 }
 
-func (self *TabItem) SetWantClose(v bool) {
+func (self TabItem) SetWantClose(v bool) {
 	C.wrap_ImGuiTabItem_SetWantClose(self.handle(), C.bool(v))
 }
 
@@ -11153,7 +11153,7 @@ func (self TabItem) WantClose() bool {
 	return C.wrap_ImGuiTabItem_GetWantClose(self.handle()) == C.bool(true)
 }
 
-func (self *Table) SetID(v ID) {
+func (self Table) SetID(v ID) {
 	C.wrap_ImGuiTable_SetID(self.handle(), C.ImGuiID(v))
 }
 
@@ -11161,7 +11161,7 @@ func (self Table) ID() ID {
 	return ID(C.wrap_ImGuiTable_GetID(self.handle()))
 }
 
-func (self *Table) SetFlags(v TableFlags) {
+func (self Table) SetFlags(v TableFlags) {
 	C.wrap_ImGuiTable_SetFlags(self.handle(), C.ImGuiTableFlags(v))
 }
 
@@ -11169,7 +11169,7 @@ func (self Table) Flags() TableFlags {
 	return TableFlags(C.wrap_ImGuiTable_GetFlags(self.handle()))
 }
 
-func (self *Table) SetRawData(v unsafe.Pointer) {
+func (self Table) SetRawData(v unsafe.Pointer) {
 	C.wrap_ImGuiTable_SetRawData(self.handle(), (v))
 }
 
@@ -11177,7 +11177,7 @@ func (self Table) RawData() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImGuiTable_GetRawData(self.handle()))
 }
 
-func (self *Table) SetTempData(v TableTempData) {
+func (self Table) SetTempData(v TableTempData) {
 	C.wrap_ImGuiTable_SetTempData(self.handle(), v.handle())
 }
 
@@ -11185,7 +11185,7 @@ func (self Table) TempData() TableTempData {
 	return (TableTempData)(unsafe.Pointer(C.wrap_ImGuiTable_GetTempData(self.handle())))
 }
 
-func (self *Table) SetEnabledMaskByDisplayOrder(v uint64) {
+func (self Table) SetEnabledMaskByDisplayOrder(v uint64) {
 	C.wrap_ImGuiTable_SetEnabledMaskByDisplayOrder(self.handle(), C.ImU64(v))
 }
 
@@ -11193,7 +11193,7 @@ func (self Table) EnabledMaskByDisplayOrder() uint64 {
 	return uint64(C.wrap_ImGuiTable_GetEnabledMaskByDisplayOrder(self.handle()))
 }
 
-func (self *Table) SetEnabledMaskByIndex(v uint64) {
+func (self Table) SetEnabledMaskByIndex(v uint64) {
 	C.wrap_ImGuiTable_SetEnabledMaskByIndex(self.handle(), C.ImU64(v))
 }
 
@@ -11201,7 +11201,7 @@ func (self Table) EnabledMaskByIndex() uint64 {
 	return uint64(C.wrap_ImGuiTable_GetEnabledMaskByIndex(self.handle()))
 }
 
-func (self *Table) SetVisibleMaskByIndex(v uint64) {
+func (self Table) SetVisibleMaskByIndex(v uint64) {
 	C.wrap_ImGuiTable_SetVisibleMaskByIndex(self.handle(), C.ImU64(v))
 }
 
@@ -11209,7 +11209,7 @@ func (self Table) VisibleMaskByIndex() uint64 {
 	return uint64(C.wrap_ImGuiTable_GetVisibleMaskByIndex(self.handle()))
 }
 
-func (self *Table) SetRequestOutputMaskByIndex(v uint64) {
+func (self Table) SetRequestOutputMaskByIndex(v uint64) {
 	C.wrap_ImGuiTable_SetRequestOutputMaskByIndex(self.handle(), C.ImU64(v))
 }
 
@@ -11217,7 +11217,7 @@ func (self Table) RequestOutputMaskByIndex() uint64 {
 	return uint64(C.wrap_ImGuiTable_GetRequestOutputMaskByIndex(self.handle()))
 }
 
-func (self *Table) SetSettingsLoadedFlags(v TableFlags) {
+func (self Table) SetSettingsLoadedFlags(v TableFlags) {
 	C.wrap_ImGuiTable_SetSettingsLoadedFlags(self.handle(), C.ImGuiTableFlags(v))
 }
 
@@ -11225,7 +11225,7 @@ func (self Table) SettingsLoadedFlags() TableFlags {
 	return TableFlags(C.wrap_ImGuiTable_GetSettingsLoadedFlags(self.handle()))
 }
 
-func (self *Table) SetSettingsOffset(v int32) {
+func (self Table) SetSettingsOffset(v int32) {
 	C.wrap_ImGuiTable_SetSettingsOffset(self.handle(), C.int(v))
 }
 
@@ -11233,7 +11233,7 @@ func (self Table) SettingsOffset() int {
 	return int(C.wrap_ImGuiTable_GetSettingsOffset(self.handle()))
 }
 
-func (self *Table) SetLastFrameActive(v int32) {
+func (self Table) SetLastFrameActive(v int32) {
 	C.wrap_ImGuiTable_SetLastFrameActive(self.handle(), C.int(v))
 }
 
@@ -11241,7 +11241,7 @@ func (self Table) LastFrameActive() int {
 	return int(C.wrap_ImGuiTable_GetLastFrameActive(self.handle()))
 }
 
-func (self *Table) SetColumnsCount(v int32) {
+func (self Table) SetColumnsCount(v int32) {
 	C.wrap_ImGuiTable_SetColumnsCount(self.handle(), C.int(v))
 }
 
@@ -11249,7 +11249,7 @@ func (self Table) ColumnsCount() int {
 	return int(C.wrap_ImGuiTable_GetColumnsCount(self.handle()))
 }
 
-func (self *Table) SetCurrentRow(v int32) {
+func (self Table) SetCurrentRow(v int32) {
 	C.wrap_ImGuiTable_SetCurrentRow(self.handle(), C.int(v))
 }
 
@@ -11257,7 +11257,7 @@ func (self Table) CurrentRow() int {
 	return int(C.wrap_ImGuiTable_GetCurrentRow(self.handle()))
 }
 
-func (self *Table) SetCurrentColumn(v int32) {
+func (self Table) SetCurrentColumn(v int32) {
 	C.wrap_ImGuiTable_SetCurrentColumn(self.handle(), C.int(v))
 }
 
@@ -11265,7 +11265,7 @@ func (self Table) CurrentColumn() int {
 	return int(C.wrap_ImGuiTable_GetCurrentColumn(self.handle()))
 }
 
-func (self *Table) SetInstanceCurrent(v int) {
+func (self Table) SetInstanceCurrent(v int) {
 	C.wrap_ImGuiTable_SetInstanceCurrent(self.handle(), C.ImS16(v))
 }
 
@@ -11273,7 +11273,7 @@ func (self Table) InstanceCurrent() int {
 	return int(C.wrap_ImGuiTable_GetInstanceCurrent(self.handle()))
 }
 
-func (self *Table) SetInstanceInteracted(v int) {
+func (self Table) SetInstanceInteracted(v int) {
 	C.wrap_ImGuiTable_SetInstanceInteracted(self.handle(), C.ImS16(v))
 }
 
@@ -11281,7 +11281,7 @@ func (self Table) InstanceInteracted() int {
 	return int(C.wrap_ImGuiTable_GetInstanceInteracted(self.handle()))
 }
 
-func (self *Table) SetRowPosY1(v float32) {
+func (self Table) SetRowPosY1(v float32) {
 	C.wrap_ImGuiTable_SetRowPosY1(self.handle(), C.float(v))
 }
 
@@ -11289,7 +11289,7 @@ func (self Table) RowPosY1() float32 {
 	return float32(C.wrap_ImGuiTable_GetRowPosY1(self.handle()))
 }
 
-func (self *Table) SetRowPosY2(v float32) {
+func (self Table) SetRowPosY2(v float32) {
 	C.wrap_ImGuiTable_SetRowPosY2(self.handle(), C.float(v))
 }
 
@@ -11297,7 +11297,7 @@ func (self Table) RowPosY2() float32 {
 	return float32(C.wrap_ImGuiTable_GetRowPosY2(self.handle()))
 }
 
-func (self *Table) SetRowMinHeight(v float32) {
+func (self Table) SetRowMinHeight(v float32) {
 	C.wrap_ImGuiTable_SetRowMinHeight(self.handle(), C.float(v))
 }
 
@@ -11305,7 +11305,7 @@ func (self Table) RowMinHeight() float32 {
 	return float32(C.wrap_ImGuiTable_GetRowMinHeight(self.handle()))
 }
 
-func (self *Table) SetRowTextBaseline(v float32) {
+func (self Table) SetRowTextBaseline(v float32) {
 	C.wrap_ImGuiTable_SetRowTextBaseline(self.handle(), C.float(v))
 }
 
@@ -11313,7 +11313,7 @@ func (self Table) RowTextBaseline() float32 {
 	return float32(C.wrap_ImGuiTable_GetRowTextBaseline(self.handle()))
 }
 
-func (self *Table) SetRowIndentOffsetX(v float32) {
+func (self Table) SetRowIndentOffsetX(v float32) {
 	C.wrap_ImGuiTable_SetRowIndentOffsetX(self.handle(), C.float(v))
 }
 
@@ -11321,7 +11321,7 @@ func (self Table) RowIndentOffsetX() float32 {
 	return float32(C.wrap_ImGuiTable_GetRowIndentOffsetX(self.handle()))
 }
 
-func (self *Table) SetRowFlags(v TableRowFlags) {
+func (self Table) SetRowFlags(v TableRowFlags) {
 	C.wrap_ImGuiTable_SetRowFlags(self.handle(), C.ImGuiTableRowFlags(v))
 }
 
@@ -11329,7 +11329,7 @@ func (self Table) RowFlags() TableRowFlags {
 	return TableRowFlags(C.wrap_ImGuiTable_GetRowFlags(self.handle()))
 }
 
-func (self *Table) SetLastRowFlags(v TableRowFlags) {
+func (self Table) SetLastRowFlags(v TableRowFlags) {
 	C.wrap_ImGuiTable_SetLastRowFlags(self.handle(), C.ImGuiTableRowFlags(v))
 }
 
@@ -11337,7 +11337,7 @@ func (self Table) LastRowFlags() TableRowFlags {
 	return TableRowFlags(C.wrap_ImGuiTable_GetLastRowFlags(self.handle()))
 }
 
-func (self *Table) SetRowBgColorCounter(v int32) {
+func (self Table) SetRowBgColorCounter(v int32) {
 	C.wrap_ImGuiTable_SetRowBgColorCounter(self.handle(), C.int(v))
 }
 
@@ -11345,7 +11345,7 @@ func (self Table) RowBgColorCounter() int {
 	return int(C.wrap_ImGuiTable_GetRowBgColorCounter(self.handle()))
 }
 
-func (self *Table) SetBorderColorStrong(v uint32) {
+func (self Table) SetBorderColorStrong(v uint32) {
 	C.wrap_ImGuiTable_SetBorderColorStrong(self.handle(), C.ImU32(v))
 }
 
@@ -11353,7 +11353,7 @@ func (self Table) BorderColorStrong() uint32 {
 	return uint32(C.wrap_ImGuiTable_GetBorderColorStrong(self.handle()))
 }
 
-func (self *Table) SetBorderColorLight(v uint32) {
+func (self Table) SetBorderColorLight(v uint32) {
 	C.wrap_ImGuiTable_SetBorderColorLight(self.handle(), C.ImU32(v))
 }
 
@@ -11361,7 +11361,7 @@ func (self Table) BorderColorLight() uint32 {
 	return uint32(C.wrap_ImGuiTable_GetBorderColorLight(self.handle()))
 }
 
-func (self *Table) SetBorderX1(v float32) {
+func (self Table) SetBorderX1(v float32) {
 	C.wrap_ImGuiTable_SetBorderX1(self.handle(), C.float(v))
 }
 
@@ -11369,7 +11369,7 @@ func (self Table) BorderX1() float32 {
 	return float32(C.wrap_ImGuiTable_GetBorderX1(self.handle()))
 }
 
-func (self *Table) SetBorderX2(v float32) {
+func (self Table) SetBorderX2(v float32) {
 	C.wrap_ImGuiTable_SetBorderX2(self.handle(), C.float(v))
 }
 
@@ -11377,7 +11377,7 @@ func (self Table) BorderX2() float32 {
 	return float32(C.wrap_ImGuiTable_GetBorderX2(self.handle()))
 }
 
-func (self *Table) SetHostIndentX(v float32) {
+func (self Table) SetHostIndentX(v float32) {
 	C.wrap_ImGuiTable_SetHostIndentX(self.handle(), C.float(v))
 }
 
@@ -11385,7 +11385,7 @@ func (self Table) HostIndentX() float32 {
 	return float32(C.wrap_ImGuiTable_GetHostIndentX(self.handle()))
 }
 
-func (self *Table) SetMinColumnWidth(v float32) {
+func (self Table) SetMinColumnWidth(v float32) {
 	C.wrap_ImGuiTable_SetMinColumnWidth(self.handle(), C.float(v))
 }
 
@@ -11393,7 +11393,7 @@ func (self Table) MinColumnWidth() float32 {
 	return float32(C.wrap_ImGuiTable_GetMinColumnWidth(self.handle()))
 }
 
-func (self *Table) SetOuterPaddingX(v float32) {
+func (self Table) SetOuterPaddingX(v float32) {
 	C.wrap_ImGuiTable_SetOuterPaddingX(self.handle(), C.float(v))
 }
 
@@ -11401,7 +11401,7 @@ func (self Table) OuterPaddingX() float32 {
 	return float32(C.wrap_ImGuiTable_GetOuterPaddingX(self.handle()))
 }
 
-func (self *Table) SetCellPaddingX(v float32) {
+func (self Table) SetCellPaddingX(v float32) {
 	C.wrap_ImGuiTable_SetCellPaddingX(self.handle(), C.float(v))
 }
 
@@ -11409,7 +11409,7 @@ func (self Table) CellPaddingX() float32 {
 	return float32(C.wrap_ImGuiTable_GetCellPaddingX(self.handle()))
 }
 
-func (self *Table) SetCellPaddingY(v float32) {
+func (self Table) SetCellPaddingY(v float32) {
 	C.wrap_ImGuiTable_SetCellPaddingY(self.handle(), C.float(v))
 }
 
@@ -11417,7 +11417,7 @@ func (self Table) CellPaddingY() float32 {
 	return float32(C.wrap_ImGuiTable_GetCellPaddingY(self.handle()))
 }
 
-func (self *Table) SetCellSpacingX1(v float32) {
+func (self Table) SetCellSpacingX1(v float32) {
 	C.wrap_ImGuiTable_SetCellSpacingX1(self.handle(), C.float(v))
 }
 
@@ -11425,7 +11425,7 @@ func (self Table) CellSpacingX1() float32 {
 	return float32(C.wrap_ImGuiTable_GetCellSpacingX1(self.handle()))
 }
 
-func (self *Table) SetCellSpacingX2(v float32) {
+func (self Table) SetCellSpacingX2(v float32) {
 	C.wrap_ImGuiTable_SetCellSpacingX2(self.handle(), C.float(v))
 }
 
@@ -11433,7 +11433,7 @@ func (self Table) CellSpacingX2() float32 {
 	return float32(C.wrap_ImGuiTable_GetCellSpacingX2(self.handle()))
 }
 
-func (self *Table) SetInnerWidth(v float32) {
+func (self Table) SetInnerWidth(v float32) {
 	C.wrap_ImGuiTable_SetInnerWidth(self.handle(), C.float(v))
 }
 
@@ -11441,7 +11441,7 @@ func (self Table) InnerWidth() float32 {
 	return float32(C.wrap_ImGuiTable_GetInnerWidth(self.handle()))
 }
 
-func (self *Table) SetColumnsGivenWidth(v float32) {
+func (self Table) SetColumnsGivenWidth(v float32) {
 	C.wrap_ImGuiTable_SetColumnsGivenWidth(self.handle(), C.float(v))
 }
 
@@ -11449,7 +11449,7 @@ func (self Table) ColumnsGivenWidth() float32 {
 	return float32(C.wrap_ImGuiTable_GetColumnsGivenWidth(self.handle()))
 }
 
-func (self *Table) SetColumnsAutoFitWidth(v float32) {
+func (self Table) SetColumnsAutoFitWidth(v float32) {
 	C.wrap_ImGuiTable_SetColumnsAutoFitWidth(self.handle(), C.float(v))
 }
 
@@ -11457,7 +11457,7 @@ func (self Table) ColumnsAutoFitWidth() float32 {
 	return float32(C.wrap_ImGuiTable_GetColumnsAutoFitWidth(self.handle()))
 }
 
-func (self *Table) SetColumnsStretchSumWeights(v float32) {
+func (self Table) SetColumnsStretchSumWeights(v float32) {
 	C.wrap_ImGuiTable_SetColumnsStretchSumWeights(self.handle(), C.float(v))
 }
 
@@ -11465,7 +11465,7 @@ func (self Table) ColumnsStretchSumWeights() float32 {
 	return float32(C.wrap_ImGuiTable_GetColumnsStretchSumWeights(self.handle()))
 }
 
-func (self *Table) SetResizedColumnNextWidth(v float32) {
+func (self Table) SetResizedColumnNextWidth(v float32) {
 	C.wrap_ImGuiTable_SetResizedColumnNextWidth(self.handle(), C.float(v))
 }
 
@@ -11473,7 +11473,7 @@ func (self Table) ResizedColumnNextWidth() float32 {
 	return float32(C.wrap_ImGuiTable_GetResizedColumnNextWidth(self.handle()))
 }
 
-func (self *Table) SetResizeLockMinContentsX2(v float32) {
+func (self Table) SetResizeLockMinContentsX2(v float32) {
 	C.wrap_ImGuiTable_SetResizeLockMinContentsX2(self.handle(), C.float(v))
 }
 
@@ -11481,7 +11481,7 @@ func (self Table) ResizeLockMinContentsX2() float32 {
 	return float32(C.wrap_ImGuiTable_GetResizeLockMinContentsX2(self.handle()))
 }
 
-func (self *Table) SetRefScale(v float32) {
+func (self Table) SetRefScale(v float32) {
 	C.wrap_ImGuiTable_SetRefScale(self.handle(), C.float(v))
 }
 
@@ -11489,7 +11489,7 @@ func (self Table) RefScale() float32 {
 	return float32(C.wrap_ImGuiTable_GetRefScale(self.handle()))
 }
 
-func (self *Table) SetOuterRect(v Rect) {
+func (self Table) SetOuterRect(v Rect) {
 	C.wrap_ImGuiTable_SetOuterRect(self.handle(), v.toC())
 }
 
@@ -11499,7 +11499,7 @@ func (self Table) OuterRect() Rect {
 	return *out
 }
 
-func (self *Table) SetInnerRect(v Rect) {
+func (self Table) SetInnerRect(v Rect) {
 	C.wrap_ImGuiTable_SetInnerRect(self.handle(), v.toC())
 }
 
@@ -11509,7 +11509,7 @@ func (self Table) InnerRect() Rect {
 	return *out
 }
 
-func (self *Table) SetWorkRect(v Rect) {
+func (self Table) SetWorkRect(v Rect) {
 	C.wrap_ImGuiTable_SetWorkRect(self.handle(), v.toC())
 }
 
@@ -11519,7 +11519,7 @@ func (self Table) WorkRect() Rect {
 	return *out
 }
 
-func (self *Table) SetInnerClipRect(v Rect) {
+func (self Table) SetInnerClipRect(v Rect) {
 	C.wrap_ImGuiTable_SetInnerClipRect(self.handle(), v.toC())
 }
 
@@ -11529,7 +11529,7 @@ func (self Table) InnerClipRect() Rect {
 	return *out
 }
 
-func (self *Table) SetBgClipRect(v Rect) {
+func (self Table) SetBgClipRect(v Rect) {
 	C.wrap_ImGuiTable_SetBgClipRect(self.handle(), v.toC())
 }
 
@@ -11539,7 +11539,7 @@ func (self Table) BgClipRect() Rect {
 	return *out
 }
 
-func (self *Table) SetBg0ClipRectForDrawCmd(v Rect) {
+func (self Table) SetBg0ClipRectForDrawCmd(v Rect) {
 	C.wrap_ImGuiTable_SetBg0ClipRectForDrawCmd(self.handle(), v.toC())
 }
 
@@ -11549,7 +11549,7 @@ func (self Table) Bg0ClipRectForDrawCmd() Rect {
 	return *out
 }
 
-func (self *Table) SetBg2ClipRectForDrawCmd(v Rect) {
+func (self Table) SetBg2ClipRectForDrawCmd(v Rect) {
 	C.wrap_ImGuiTable_SetBg2ClipRectForDrawCmd(self.handle(), v.toC())
 }
 
@@ -11559,7 +11559,7 @@ func (self Table) Bg2ClipRectForDrawCmd() Rect {
 	return *out
 }
 
-func (self *Table) SetHostClipRect(v Rect) {
+func (self Table) SetHostClipRect(v Rect) {
 	C.wrap_ImGuiTable_SetHostClipRect(self.handle(), v.toC())
 }
 
@@ -11569,7 +11569,7 @@ func (self Table) HostClipRect() Rect {
 	return *out
 }
 
-func (self *Table) SetHostBackupInnerClipRect(v Rect) {
+func (self Table) SetHostBackupInnerClipRect(v Rect) {
 	C.wrap_ImGuiTable_SetHostBackupInnerClipRect(self.handle(), v.toC())
 }
 
@@ -11579,7 +11579,7 @@ func (self Table) HostBackupInnerClipRect() Rect {
 	return *out
 }
 
-func (self *Table) SetOuterWindow(v Window) {
+func (self Table) SetOuterWindow(v Window) {
 	C.wrap_ImGuiTable_SetOuterWindow(self.handle(), v.handle())
 }
 
@@ -11587,7 +11587,7 @@ func (self Table) OuterWindow() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiTable_GetOuterWindow(self.handle())))
 }
 
-func (self *Table) SetInnerWindow(v Window) {
+func (self Table) SetInnerWindow(v Window) {
 	C.wrap_ImGuiTable_SetInnerWindow(self.handle(), v.handle())
 }
 
@@ -11599,7 +11599,7 @@ func (self Table) ColumnsNames() TextBuffer {
 	return newTextBufferFromC(C.wrap_ImGuiTable_GetColumnsNames(self.handle()))
 }
 
-func (self *Table) SetDrawSplitter(v DrawListSplitter) {
+func (self Table) SetDrawSplitter(v DrawListSplitter) {
 	C.wrap_ImGuiTable_SetDrawSplitter(self.handle(), v.handle())
 }
 
@@ -11619,7 +11619,7 @@ func (self Table) SortSpecs() TableSortSpecs {
 	return newTableSortSpecsFromC(C.wrap_ImGuiTable_GetSortSpecs(self.handle()))
 }
 
-func (self *Table) SetSortSpecsCount(v TableColumnIdx) {
+func (self Table) SetSortSpecsCount(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetSortSpecsCount(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11627,7 +11627,7 @@ func (self Table) SortSpecsCount() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetSortSpecsCount(self.handle()))
 }
 
-func (self *Table) SetColumnsEnabledCount(v TableColumnIdx) {
+func (self Table) SetColumnsEnabledCount(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetColumnsEnabledCount(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11635,7 +11635,7 @@ func (self Table) ColumnsEnabledCount() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetColumnsEnabledCount(self.handle()))
 }
 
-func (self *Table) SetColumnsEnabledFixedCount(v TableColumnIdx) {
+func (self Table) SetColumnsEnabledFixedCount(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetColumnsEnabledFixedCount(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11643,7 +11643,7 @@ func (self Table) ColumnsEnabledFixedCount() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetColumnsEnabledFixedCount(self.handle()))
 }
 
-func (self *Table) SetDeclColumnsCount(v TableColumnIdx) {
+func (self Table) SetDeclColumnsCount(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetDeclColumnsCount(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11651,7 +11651,7 @@ func (self Table) DeclColumnsCount() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetDeclColumnsCount(self.handle()))
 }
 
-func (self *Table) SetHoveredColumnBody(v TableColumnIdx) {
+func (self Table) SetHoveredColumnBody(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetHoveredColumnBody(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11659,7 +11659,7 @@ func (self Table) HoveredColumnBody() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetHoveredColumnBody(self.handle()))
 }
 
-func (self *Table) SetHoveredColumnBorder(v TableColumnIdx) {
+func (self Table) SetHoveredColumnBorder(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetHoveredColumnBorder(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11667,7 +11667,7 @@ func (self Table) HoveredColumnBorder() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetHoveredColumnBorder(self.handle()))
 }
 
-func (self *Table) SetAutoFitSingleColumn(v TableColumnIdx) {
+func (self Table) SetAutoFitSingleColumn(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetAutoFitSingleColumn(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11675,7 +11675,7 @@ func (self Table) AutoFitSingleColumn() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetAutoFitSingleColumn(self.handle()))
 }
 
-func (self *Table) SetResizedColumn(v TableColumnIdx) {
+func (self Table) SetResizedColumn(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetResizedColumn(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11683,7 +11683,7 @@ func (self Table) ResizedColumn() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetResizedColumn(self.handle()))
 }
 
-func (self *Table) SetLastResizedColumn(v TableColumnIdx) {
+func (self Table) SetLastResizedColumn(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetLastResizedColumn(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11691,7 +11691,7 @@ func (self Table) LastResizedColumn() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetLastResizedColumn(self.handle()))
 }
 
-func (self *Table) SetHeldHeaderColumn(v TableColumnIdx) {
+func (self Table) SetHeldHeaderColumn(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetHeldHeaderColumn(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11699,7 +11699,7 @@ func (self Table) HeldHeaderColumn() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetHeldHeaderColumn(self.handle()))
 }
 
-func (self *Table) SetReorderColumn(v TableColumnIdx) {
+func (self Table) SetReorderColumn(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetReorderColumn(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11707,7 +11707,7 @@ func (self Table) ReorderColumn() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetReorderColumn(self.handle()))
 }
 
-func (self *Table) SetReorderColumnDir(v TableColumnIdx) {
+func (self Table) SetReorderColumnDir(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetReorderColumnDir(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11715,7 +11715,7 @@ func (self Table) ReorderColumnDir() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetReorderColumnDir(self.handle()))
 }
 
-func (self *Table) SetLeftMostEnabledColumn(v TableColumnIdx) {
+func (self Table) SetLeftMostEnabledColumn(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetLeftMostEnabledColumn(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11723,7 +11723,7 @@ func (self Table) LeftMostEnabledColumn() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetLeftMostEnabledColumn(self.handle()))
 }
 
-func (self *Table) SetRightMostEnabledColumn(v TableColumnIdx) {
+func (self Table) SetRightMostEnabledColumn(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetRightMostEnabledColumn(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11731,7 +11731,7 @@ func (self Table) RightMostEnabledColumn() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetRightMostEnabledColumn(self.handle()))
 }
 
-func (self *Table) SetLeftMostStretchedColumn(v TableColumnIdx) {
+func (self Table) SetLeftMostStretchedColumn(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetLeftMostStretchedColumn(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11739,7 +11739,7 @@ func (self Table) LeftMostStretchedColumn() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetLeftMostStretchedColumn(self.handle()))
 }
 
-func (self *Table) SetRightMostStretchedColumn(v TableColumnIdx) {
+func (self Table) SetRightMostStretchedColumn(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetRightMostStretchedColumn(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11747,7 +11747,7 @@ func (self Table) RightMostStretchedColumn() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetRightMostStretchedColumn(self.handle()))
 }
 
-func (self *Table) SetContextPopupColumn(v TableColumnIdx) {
+func (self Table) SetContextPopupColumn(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetContextPopupColumn(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11755,7 +11755,7 @@ func (self Table) ContextPopupColumn() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetContextPopupColumn(self.handle()))
 }
 
-func (self *Table) SetFreezeRowsRequest(v TableColumnIdx) {
+func (self Table) SetFreezeRowsRequest(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetFreezeRowsRequest(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11763,7 +11763,7 @@ func (self Table) FreezeRowsRequest() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetFreezeRowsRequest(self.handle()))
 }
 
-func (self *Table) SetFreezeRowsCount(v TableColumnIdx) {
+func (self Table) SetFreezeRowsCount(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetFreezeRowsCount(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11771,7 +11771,7 @@ func (self Table) FreezeRowsCount() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetFreezeRowsCount(self.handle()))
 }
 
-func (self *Table) SetFreezeColumnsRequest(v TableColumnIdx) {
+func (self Table) SetFreezeColumnsRequest(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetFreezeColumnsRequest(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11779,7 +11779,7 @@ func (self Table) FreezeColumnsRequest() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetFreezeColumnsRequest(self.handle()))
 }
 
-func (self *Table) SetFreezeColumnsCount(v TableColumnIdx) {
+func (self Table) SetFreezeColumnsCount(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetFreezeColumnsCount(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11787,7 +11787,7 @@ func (self Table) FreezeColumnsCount() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetFreezeColumnsCount(self.handle()))
 }
 
-func (self *Table) SetRowCellDataCurrent(v TableColumnIdx) {
+func (self Table) SetRowCellDataCurrent(v TableColumnIdx) {
 	C.wrap_ImGuiTable_SetRowCellDataCurrent(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11795,7 +11795,7 @@ func (self Table) RowCellDataCurrent() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTable_GetRowCellDataCurrent(self.handle()))
 }
 
-func (self *Table) SetDummyDrawChannel(v TableDrawChannelIdx) {
+func (self Table) SetDummyDrawChannel(v TableDrawChannelIdx) {
 	C.wrap_ImGuiTable_SetDummyDrawChannel(self.handle(), C.ImGuiTableDrawChannelIdx(v))
 }
 
@@ -11803,7 +11803,7 @@ func (self Table) DummyDrawChannel() TableDrawChannelIdx {
 	return TableDrawChannelIdx(C.wrap_ImGuiTable_GetDummyDrawChannel(self.handle()))
 }
 
-func (self *Table) SetBg2DrawChannelCurrent(v TableDrawChannelIdx) {
+func (self Table) SetBg2DrawChannelCurrent(v TableDrawChannelIdx) {
 	C.wrap_ImGuiTable_SetBg2DrawChannelCurrent(self.handle(), C.ImGuiTableDrawChannelIdx(v))
 }
 
@@ -11811,7 +11811,7 @@ func (self Table) Bg2DrawChannelCurrent() TableDrawChannelIdx {
 	return TableDrawChannelIdx(C.wrap_ImGuiTable_GetBg2DrawChannelCurrent(self.handle()))
 }
 
-func (self *Table) SetBg2DrawChannelUnfrozen(v TableDrawChannelIdx) {
+func (self Table) SetBg2DrawChannelUnfrozen(v TableDrawChannelIdx) {
 	C.wrap_ImGuiTable_SetBg2DrawChannelUnfrozen(self.handle(), C.ImGuiTableDrawChannelIdx(v))
 }
 
@@ -11819,7 +11819,7 @@ func (self Table) Bg2DrawChannelUnfrozen() TableDrawChannelIdx {
 	return TableDrawChannelIdx(C.wrap_ImGuiTable_GetBg2DrawChannelUnfrozen(self.handle()))
 }
 
-func (self *Table) SetIsLayoutLocked(v bool) {
+func (self Table) SetIsLayoutLocked(v bool) {
 	C.wrap_ImGuiTable_SetIsLayoutLocked(self.handle(), C.bool(v))
 }
 
@@ -11827,7 +11827,7 @@ func (self Table) IsLayoutLocked() bool {
 	return C.wrap_ImGuiTable_GetIsLayoutLocked(self.handle()) == C.bool(true)
 }
 
-func (self *Table) SetIsInsideRow(v bool) {
+func (self Table) SetIsInsideRow(v bool) {
 	C.wrap_ImGuiTable_SetIsInsideRow(self.handle(), C.bool(v))
 }
 
@@ -11835,7 +11835,7 @@ func (self Table) IsInsideRow() bool {
 	return C.wrap_ImGuiTable_GetIsInsideRow(self.handle()) == C.bool(true)
 }
 
-func (self *Table) SetIsInitializing(v bool) {
+func (self Table) SetIsInitializing(v bool) {
 	C.wrap_ImGuiTable_SetIsInitializing(self.handle(), C.bool(v))
 }
 
@@ -11843,7 +11843,7 @@ func (self Table) IsInitializing() bool {
 	return C.wrap_ImGuiTable_GetIsInitializing(self.handle()) == C.bool(true)
 }
 
-func (self *Table) SetIsSortSpecsDirty(v bool) {
+func (self Table) SetIsSortSpecsDirty(v bool) {
 	C.wrap_ImGuiTable_SetIsSortSpecsDirty(self.handle(), C.bool(v))
 }
 
@@ -11851,7 +11851,7 @@ func (self Table) IsSortSpecsDirty() bool {
 	return C.wrap_ImGuiTable_GetIsSortSpecsDirty(self.handle()) == C.bool(true)
 }
 
-func (self *Table) SetIsUsingHeaders(v bool) {
+func (self Table) SetIsUsingHeaders(v bool) {
 	C.wrap_ImGuiTable_SetIsUsingHeaders(self.handle(), C.bool(v))
 }
 
@@ -11859,7 +11859,7 @@ func (self Table) IsUsingHeaders() bool {
 	return C.wrap_ImGuiTable_GetIsUsingHeaders(self.handle()) == C.bool(true)
 }
 
-func (self *Table) SetIsContextPopupOpen(v bool) {
+func (self Table) SetIsContextPopupOpen(v bool) {
 	C.wrap_ImGuiTable_SetIsContextPopupOpen(self.handle(), C.bool(v))
 }
 
@@ -11867,7 +11867,7 @@ func (self Table) IsContextPopupOpen() bool {
 	return C.wrap_ImGuiTable_GetIsContextPopupOpen(self.handle()) == C.bool(true)
 }
 
-func (self *Table) SetIsSettingsRequestLoad(v bool) {
+func (self Table) SetIsSettingsRequestLoad(v bool) {
 	C.wrap_ImGuiTable_SetIsSettingsRequestLoad(self.handle(), C.bool(v))
 }
 
@@ -11875,7 +11875,7 @@ func (self Table) IsSettingsRequestLoad() bool {
 	return C.wrap_ImGuiTable_GetIsSettingsRequestLoad(self.handle()) == C.bool(true)
 }
 
-func (self *Table) SetIsSettingsDirty(v bool) {
+func (self Table) SetIsSettingsDirty(v bool) {
 	C.wrap_ImGuiTable_SetIsSettingsDirty(self.handle(), C.bool(v))
 }
 
@@ -11883,7 +11883,7 @@ func (self Table) IsSettingsDirty() bool {
 	return C.wrap_ImGuiTable_GetIsSettingsDirty(self.handle()) == C.bool(true)
 }
 
-func (self *Table) SetIsDefaultDisplayOrder(v bool) {
+func (self Table) SetIsDefaultDisplayOrder(v bool) {
 	C.wrap_ImGuiTable_SetIsDefaultDisplayOrder(self.handle(), C.bool(v))
 }
 
@@ -11891,7 +11891,7 @@ func (self Table) IsDefaultDisplayOrder() bool {
 	return C.wrap_ImGuiTable_GetIsDefaultDisplayOrder(self.handle()) == C.bool(true)
 }
 
-func (self *Table) SetIsResetAllRequest(v bool) {
+func (self Table) SetIsResetAllRequest(v bool) {
 	C.wrap_ImGuiTable_SetIsResetAllRequest(self.handle(), C.bool(v))
 }
 
@@ -11899,7 +11899,7 @@ func (self Table) IsResetAllRequest() bool {
 	return C.wrap_ImGuiTable_GetIsResetAllRequest(self.handle()) == C.bool(true)
 }
 
-func (self *Table) SetIsResetDisplayOrderRequest(v bool) {
+func (self Table) SetIsResetDisplayOrderRequest(v bool) {
 	C.wrap_ImGuiTable_SetIsResetDisplayOrderRequest(self.handle(), C.bool(v))
 }
 
@@ -11907,7 +11907,7 @@ func (self Table) IsResetDisplayOrderRequest() bool {
 	return C.wrap_ImGuiTable_GetIsResetDisplayOrderRequest(self.handle()) == C.bool(true)
 }
 
-func (self *Table) SetIsUnfrozenRows(v bool) {
+func (self Table) SetIsUnfrozenRows(v bool) {
 	C.wrap_ImGuiTable_SetIsUnfrozenRows(self.handle(), C.bool(v))
 }
 
@@ -11915,7 +11915,7 @@ func (self Table) IsUnfrozenRows() bool {
 	return C.wrap_ImGuiTable_GetIsUnfrozenRows(self.handle()) == C.bool(true)
 }
 
-func (self *Table) SetIsDefaultSizingPolicy(v bool) {
+func (self Table) SetIsDefaultSizingPolicy(v bool) {
 	C.wrap_ImGuiTable_SetIsDefaultSizingPolicy(self.handle(), C.bool(v))
 }
 
@@ -11923,7 +11923,7 @@ func (self Table) IsDefaultSizingPolicy() bool {
 	return C.wrap_ImGuiTable_GetIsDefaultSizingPolicy(self.handle()) == C.bool(true)
 }
 
-func (self *Table) SetMemoryCompacted(v bool) {
+func (self Table) SetMemoryCompacted(v bool) {
 	C.wrap_ImGuiTable_SetMemoryCompacted(self.handle(), C.bool(v))
 }
 
@@ -11931,7 +11931,7 @@ func (self Table) MemoryCompacted() bool {
 	return C.wrap_ImGuiTable_GetMemoryCompacted(self.handle()) == C.bool(true)
 }
 
-func (self *Table) SetHostSkipItems(v bool) {
+func (self Table) SetHostSkipItems(v bool) {
 	C.wrap_ImGuiTable_SetHostSkipItems(self.handle(), C.bool(v))
 }
 
@@ -11939,7 +11939,7 @@ func (self Table) HostSkipItems() bool {
 	return C.wrap_ImGuiTable_GetHostSkipItems(self.handle()) == C.bool(true)
 }
 
-func (self *TableCellData) SetBgColor(v uint32) {
+func (self TableCellData) SetBgColor(v uint32) {
 	C.wrap_ImGuiTableCellData_SetBgColor(self.handle(), C.ImU32(v))
 }
 
@@ -11947,7 +11947,7 @@ func (self TableCellData) BgColor() uint32 {
 	return uint32(C.wrap_ImGuiTableCellData_GetBgColor(self.handle()))
 }
 
-func (self *TableCellData) SetColumn(v TableColumnIdx) {
+func (self TableCellData) SetColumn(v TableColumnIdx) {
 	C.wrap_ImGuiTableCellData_SetColumn(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -11955,7 +11955,7 @@ func (self TableCellData) Column() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTableCellData_GetColumn(self.handle()))
 }
 
-func (self *TableColumn) SetFlags(v TableColumnFlags) {
+func (self TableColumn) SetFlags(v TableColumnFlags) {
 	C.wrap_ImGuiTableColumn_SetFlags(self.handle(), C.ImGuiTableColumnFlags(v))
 }
 
@@ -11963,7 +11963,7 @@ func (self TableColumn) Flags() TableColumnFlags {
 	return TableColumnFlags(C.wrap_ImGuiTableColumn_GetFlags(self.handle()))
 }
 
-func (self *TableColumn) SetWidthGiven(v float32) {
+func (self TableColumn) SetWidthGiven(v float32) {
 	C.wrap_ImGuiTableColumn_SetWidthGiven(self.handle(), C.float(v))
 }
 
@@ -11971,7 +11971,7 @@ func (self TableColumn) WidthGiven() float32 {
 	return float32(C.wrap_ImGuiTableColumn_GetWidthGiven(self.handle()))
 }
 
-func (self *TableColumn) SetMinX(v float32) {
+func (self TableColumn) SetMinX(v float32) {
 	C.wrap_ImGuiTableColumn_SetMinX(self.handle(), C.float(v))
 }
 
@@ -11979,7 +11979,7 @@ func (self TableColumn) MinX() float32 {
 	return float32(C.wrap_ImGuiTableColumn_GetMinX(self.handle()))
 }
 
-func (self *TableColumn) SetMaxX(v float32) {
+func (self TableColumn) SetMaxX(v float32) {
 	C.wrap_ImGuiTableColumn_SetMaxX(self.handle(), C.float(v))
 }
 
@@ -11987,7 +11987,7 @@ func (self TableColumn) MaxX() float32 {
 	return float32(C.wrap_ImGuiTableColumn_GetMaxX(self.handle()))
 }
 
-func (self *TableColumn) SetWidthRequest(v float32) {
+func (self TableColumn) SetWidthRequest(v float32) {
 	C.wrap_ImGuiTableColumn_SetWidthRequest(self.handle(), C.float(v))
 }
 
@@ -11995,7 +11995,7 @@ func (self TableColumn) WidthRequest() float32 {
 	return float32(C.wrap_ImGuiTableColumn_GetWidthRequest(self.handle()))
 }
 
-func (self *TableColumn) SetWidthAuto(v float32) {
+func (self TableColumn) SetWidthAuto(v float32) {
 	C.wrap_ImGuiTableColumn_SetWidthAuto(self.handle(), C.float(v))
 }
 
@@ -12003,7 +12003,7 @@ func (self TableColumn) WidthAuto() float32 {
 	return float32(C.wrap_ImGuiTableColumn_GetWidthAuto(self.handle()))
 }
 
-func (self *TableColumn) SetStretchWeight(v float32) {
+func (self TableColumn) SetStretchWeight(v float32) {
 	C.wrap_ImGuiTableColumn_SetStretchWeight(self.handle(), C.float(v))
 }
 
@@ -12011,7 +12011,7 @@ func (self TableColumn) StretchWeight() float32 {
 	return float32(C.wrap_ImGuiTableColumn_GetStretchWeight(self.handle()))
 }
 
-func (self *TableColumn) SetInitStretchWeightOrWidth(v float32) {
+func (self TableColumn) SetInitStretchWeightOrWidth(v float32) {
 	C.wrap_ImGuiTableColumn_SetInitStretchWeightOrWidth(self.handle(), C.float(v))
 }
 
@@ -12019,7 +12019,7 @@ func (self TableColumn) InitStretchWeightOrWidth() float32 {
 	return float32(C.wrap_ImGuiTableColumn_GetInitStretchWeightOrWidth(self.handle()))
 }
 
-func (self *TableColumn) SetClipRect(v Rect) {
+func (self TableColumn) SetClipRect(v Rect) {
 	C.wrap_ImGuiTableColumn_SetClipRect(self.handle(), v.toC())
 }
 
@@ -12029,7 +12029,7 @@ func (self TableColumn) ClipRect() Rect {
 	return *out
 }
 
-func (self *TableColumn) SetUserID(v ID) {
+func (self TableColumn) SetUserID(v ID) {
 	C.wrap_ImGuiTableColumn_SetUserID(self.handle(), C.ImGuiID(v))
 }
 
@@ -12037,7 +12037,7 @@ func (self TableColumn) UserID() ID {
 	return ID(C.wrap_ImGuiTableColumn_GetUserID(self.handle()))
 }
 
-func (self *TableColumn) SetWorkMinX(v float32) {
+func (self TableColumn) SetWorkMinX(v float32) {
 	C.wrap_ImGuiTableColumn_SetWorkMinX(self.handle(), C.float(v))
 }
 
@@ -12045,7 +12045,7 @@ func (self TableColumn) WorkMinX() float32 {
 	return float32(C.wrap_ImGuiTableColumn_GetWorkMinX(self.handle()))
 }
 
-func (self *TableColumn) SetWorkMaxX(v float32) {
+func (self TableColumn) SetWorkMaxX(v float32) {
 	C.wrap_ImGuiTableColumn_SetWorkMaxX(self.handle(), C.float(v))
 }
 
@@ -12053,7 +12053,7 @@ func (self TableColumn) WorkMaxX() float32 {
 	return float32(C.wrap_ImGuiTableColumn_GetWorkMaxX(self.handle()))
 }
 
-func (self *TableColumn) SetItemWidth(v float32) {
+func (self TableColumn) SetItemWidth(v float32) {
 	C.wrap_ImGuiTableColumn_SetItemWidth(self.handle(), C.float(v))
 }
 
@@ -12061,7 +12061,7 @@ func (self TableColumn) ItemWidth() float32 {
 	return float32(C.wrap_ImGuiTableColumn_GetItemWidth(self.handle()))
 }
 
-func (self *TableColumn) SetContentMaxXFrozen(v float32) {
+func (self TableColumn) SetContentMaxXFrozen(v float32) {
 	C.wrap_ImGuiTableColumn_SetContentMaxXFrozen(self.handle(), C.float(v))
 }
 
@@ -12069,7 +12069,7 @@ func (self TableColumn) ContentMaxXFrozen() float32 {
 	return float32(C.wrap_ImGuiTableColumn_GetContentMaxXFrozen(self.handle()))
 }
 
-func (self *TableColumn) SetContentMaxXUnfrozen(v float32) {
+func (self TableColumn) SetContentMaxXUnfrozen(v float32) {
 	C.wrap_ImGuiTableColumn_SetContentMaxXUnfrozen(self.handle(), C.float(v))
 }
 
@@ -12077,7 +12077,7 @@ func (self TableColumn) ContentMaxXUnfrozen() float32 {
 	return float32(C.wrap_ImGuiTableColumn_GetContentMaxXUnfrozen(self.handle()))
 }
 
-func (self *TableColumn) SetContentMaxXHeadersUsed(v float32) {
+func (self TableColumn) SetContentMaxXHeadersUsed(v float32) {
 	C.wrap_ImGuiTableColumn_SetContentMaxXHeadersUsed(self.handle(), C.float(v))
 }
 
@@ -12085,7 +12085,7 @@ func (self TableColumn) ContentMaxXHeadersUsed() float32 {
 	return float32(C.wrap_ImGuiTableColumn_GetContentMaxXHeadersUsed(self.handle()))
 }
 
-func (self *TableColumn) SetContentMaxXHeadersIdeal(v float32) {
+func (self TableColumn) SetContentMaxXHeadersIdeal(v float32) {
 	C.wrap_ImGuiTableColumn_SetContentMaxXHeadersIdeal(self.handle(), C.float(v))
 }
 
@@ -12093,7 +12093,7 @@ func (self TableColumn) ContentMaxXHeadersIdeal() float32 {
 	return float32(C.wrap_ImGuiTableColumn_GetContentMaxXHeadersIdeal(self.handle()))
 }
 
-func (self *TableColumn) SetNameOffset(v int) {
+func (self TableColumn) SetNameOffset(v int) {
 	C.wrap_ImGuiTableColumn_SetNameOffset(self.handle(), C.ImS16(v))
 }
 
@@ -12101,7 +12101,7 @@ func (self TableColumn) NameOffset() int {
 	return int(C.wrap_ImGuiTableColumn_GetNameOffset(self.handle()))
 }
 
-func (self *TableColumn) SetDisplayOrder(v TableColumnIdx) {
+func (self TableColumn) SetDisplayOrder(v TableColumnIdx) {
 	C.wrap_ImGuiTableColumn_SetDisplayOrder(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -12109,7 +12109,7 @@ func (self TableColumn) DisplayOrder() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTableColumn_GetDisplayOrder(self.handle()))
 }
 
-func (self *TableColumn) SetIndexWithinEnabledSet(v TableColumnIdx) {
+func (self TableColumn) SetIndexWithinEnabledSet(v TableColumnIdx) {
 	C.wrap_ImGuiTableColumn_SetIndexWithinEnabledSet(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -12117,7 +12117,7 @@ func (self TableColumn) IndexWithinEnabledSet() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTableColumn_GetIndexWithinEnabledSet(self.handle()))
 }
 
-func (self *TableColumn) SetPrevEnabledColumn(v TableColumnIdx) {
+func (self TableColumn) SetPrevEnabledColumn(v TableColumnIdx) {
 	C.wrap_ImGuiTableColumn_SetPrevEnabledColumn(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -12125,7 +12125,7 @@ func (self TableColumn) PrevEnabledColumn() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTableColumn_GetPrevEnabledColumn(self.handle()))
 }
 
-func (self *TableColumn) SetNextEnabledColumn(v TableColumnIdx) {
+func (self TableColumn) SetNextEnabledColumn(v TableColumnIdx) {
 	C.wrap_ImGuiTableColumn_SetNextEnabledColumn(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -12133,7 +12133,7 @@ func (self TableColumn) NextEnabledColumn() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTableColumn_GetNextEnabledColumn(self.handle()))
 }
 
-func (self *TableColumn) SetSortOrder(v TableColumnIdx) {
+func (self TableColumn) SetSortOrder(v TableColumnIdx) {
 	C.wrap_ImGuiTableColumn_SetSortOrder(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -12141,7 +12141,7 @@ func (self TableColumn) SortOrder() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTableColumn_GetSortOrder(self.handle()))
 }
 
-func (self *TableColumn) SetDrawChannelCurrent(v TableDrawChannelIdx) {
+func (self TableColumn) SetDrawChannelCurrent(v TableDrawChannelIdx) {
 	C.wrap_ImGuiTableColumn_SetDrawChannelCurrent(self.handle(), C.ImGuiTableDrawChannelIdx(v))
 }
 
@@ -12149,7 +12149,7 @@ func (self TableColumn) DrawChannelCurrent() TableDrawChannelIdx {
 	return TableDrawChannelIdx(C.wrap_ImGuiTableColumn_GetDrawChannelCurrent(self.handle()))
 }
 
-func (self *TableColumn) SetDrawChannelFrozen(v TableDrawChannelIdx) {
+func (self TableColumn) SetDrawChannelFrozen(v TableDrawChannelIdx) {
 	C.wrap_ImGuiTableColumn_SetDrawChannelFrozen(self.handle(), C.ImGuiTableDrawChannelIdx(v))
 }
 
@@ -12157,7 +12157,7 @@ func (self TableColumn) DrawChannelFrozen() TableDrawChannelIdx {
 	return TableDrawChannelIdx(C.wrap_ImGuiTableColumn_GetDrawChannelFrozen(self.handle()))
 }
 
-func (self *TableColumn) SetDrawChannelUnfrozen(v TableDrawChannelIdx) {
+func (self TableColumn) SetDrawChannelUnfrozen(v TableDrawChannelIdx) {
 	C.wrap_ImGuiTableColumn_SetDrawChannelUnfrozen(self.handle(), C.ImGuiTableDrawChannelIdx(v))
 }
 
@@ -12165,7 +12165,7 @@ func (self TableColumn) DrawChannelUnfrozen() TableDrawChannelIdx {
 	return TableDrawChannelIdx(C.wrap_ImGuiTableColumn_GetDrawChannelUnfrozen(self.handle()))
 }
 
-func (self *TableColumn) SetIsEnabled(v bool) {
+func (self TableColumn) SetIsEnabled(v bool) {
 	C.wrap_ImGuiTableColumn_SetIsEnabled(self.handle(), C.bool(v))
 }
 
@@ -12173,7 +12173,7 @@ func (self TableColumn) IsEnabled() bool {
 	return C.wrap_ImGuiTableColumn_GetIsEnabled(self.handle()) == C.bool(true)
 }
 
-func (self *TableColumn) SetIsUserEnabled(v bool) {
+func (self TableColumn) SetIsUserEnabled(v bool) {
 	C.wrap_ImGuiTableColumn_SetIsUserEnabled(self.handle(), C.bool(v))
 }
 
@@ -12181,7 +12181,7 @@ func (self TableColumn) IsUserEnabled() bool {
 	return C.wrap_ImGuiTableColumn_GetIsUserEnabled(self.handle()) == C.bool(true)
 }
 
-func (self *TableColumn) SetIsUserEnabledNextFrame(v bool) {
+func (self TableColumn) SetIsUserEnabledNextFrame(v bool) {
 	C.wrap_ImGuiTableColumn_SetIsUserEnabledNextFrame(self.handle(), C.bool(v))
 }
 
@@ -12189,7 +12189,7 @@ func (self TableColumn) IsUserEnabledNextFrame() bool {
 	return C.wrap_ImGuiTableColumn_GetIsUserEnabledNextFrame(self.handle()) == C.bool(true)
 }
 
-func (self *TableColumn) SetIsVisibleX(v bool) {
+func (self TableColumn) SetIsVisibleX(v bool) {
 	C.wrap_ImGuiTableColumn_SetIsVisibleX(self.handle(), C.bool(v))
 }
 
@@ -12197,7 +12197,7 @@ func (self TableColumn) IsVisibleX() bool {
 	return C.wrap_ImGuiTableColumn_GetIsVisibleX(self.handle()) == C.bool(true)
 }
 
-func (self *TableColumn) SetIsVisibleY(v bool) {
+func (self TableColumn) SetIsVisibleY(v bool) {
 	C.wrap_ImGuiTableColumn_SetIsVisibleY(self.handle(), C.bool(v))
 }
 
@@ -12205,7 +12205,7 @@ func (self TableColumn) IsVisibleY() bool {
 	return C.wrap_ImGuiTableColumn_GetIsVisibleY(self.handle()) == C.bool(true)
 }
 
-func (self *TableColumn) SetIsRequestOutput(v bool) {
+func (self TableColumn) SetIsRequestOutput(v bool) {
 	C.wrap_ImGuiTableColumn_SetIsRequestOutput(self.handle(), C.bool(v))
 }
 
@@ -12213,7 +12213,7 @@ func (self TableColumn) IsRequestOutput() bool {
 	return C.wrap_ImGuiTableColumn_GetIsRequestOutput(self.handle()) == C.bool(true)
 }
 
-func (self *TableColumn) SetIsSkipItems(v bool) {
+func (self TableColumn) SetIsSkipItems(v bool) {
 	C.wrap_ImGuiTableColumn_SetIsSkipItems(self.handle(), C.bool(v))
 }
 
@@ -12221,7 +12221,7 @@ func (self TableColumn) IsSkipItems() bool {
 	return C.wrap_ImGuiTableColumn_GetIsSkipItems(self.handle()) == C.bool(true)
 }
 
-func (self *TableColumn) SetIsPreserveWidthAuto(v bool) {
+func (self TableColumn) SetIsPreserveWidthAuto(v bool) {
 	C.wrap_ImGuiTableColumn_SetIsPreserveWidthAuto(self.handle(), C.bool(v))
 }
 
@@ -12229,7 +12229,7 @@ func (self TableColumn) IsPreserveWidthAuto() bool {
 	return C.wrap_ImGuiTableColumn_GetIsPreserveWidthAuto(self.handle()) == C.bool(true)
 }
 
-func (self *TableColumn) SetNavLayerCurrent(v int) {
+func (self TableColumn) SetNavLayerCurrent(v int) {
 	C.wrap_ImGuiTableColumn_SetNavLayerCurrent(self.handle(), C.ImS8(v))
 }
 
@@ -12237,7 +12237,7 @@ func (self TableColumn) NavLayerCurrent() int {
 	return int(C.wrap_ImGuiTableColumn_GetNavLayerCurrent(self.handle()))
 }
 
-func (self *TableColumn) SetAutoFitQueue(v uint) {
+func (self TableColumn) SetAutoFitQueue(v uint) {
 	C.wrap_ImGuiTableColumn_SetAutoFitQueue(self.handle(), C.ImU8(v))
 }
 
@@ -12245,7 +12245,7 @@ func (self TableColumn) AutoFitQueue() uint32 {
 	return uint32(C.wrap_ImGuiTableColumn_GetAutoFitQueue(self.handle()))
 }
 
-func (self *TableColumn) SetCannotSkipItemsQueue(v uint) {
+func (self TableColumn) SetCannotSkipItemsQueue(v uint) {
 	C.wrap_ImGuiTableColumn_SetCannotSkipItemsQueue(self.handle(), C.ImU8(v))
 }
 
@@ -12253,7 +12253,7 @@ func (self TableColumn) CannotSkipItemsQueue() uint32 {
 	return uint32(C.wrap_ImGuiTableColumn_GetCannotSkipItemsQueue(self.handle()))
 }
 
-func (self *TableColumn) SetSortDirection(v uint) {
+func (self TableColumn) SetSortDirection(v uint) {
 	C.wrap_ImGuiTableColumn_SetSortDirection(self.handle(), C.ImU8(v))
 }
 
@@ -12261,7 +12261,7 @@ func (self TableColumn) SortDirection() uint32 {
 	return uint32(C.wrap_ImGuiTableColumn_GetSortDirection(self.handle()))
 }
 
-func (self *TableColumn) SetSortDirectionsAvailCount(v uint) {
+func (self TableColumn) SetSortDirectionsAvailCount(v uint) {
 	C.wrap_ImGuiTableColumn_SetSortDirectionsAvailCount(self.handle(), C.ImU8(v))
 }
 
@@ -12269,7 +12269,7 @@ func (self TableColumn) SortDirectionsAvailCount() uint32 {
 	return uint32(C.wrap_ImGuiTableColumn_GetSortDirectionsAvailCount(self.handle()))
 }
 
-func (self *TableColumn) SetSortDirectionsAvailMask(v uint) {
+func (self TableColumn) SetSortDirectionsAvailMask(v uint) {
 	C.wrap_ImGuiTableColumn_SetSortDirectionsAvailMask(self.handle(), C.ImU8(v))
 }
 
@@ -12277,7 +12277,7 @@ func (self TableColumn) SortDirectionsAvailMask() uint32 {
 	return uint32(C.wrap_ImGuiTableColumn_GetSortDirectionsAvailMask(self.handle()))
 }
 
-func (self *TableColumn) SetSortDirectionsAvailList(v uint) {
+func (self TableColumn) SetSortDirectionsAvailList(v uint) {
 	C.wrap_ImGuiTableColumn_SetSortDirectionsAvailList(self.handle(), C.ImU8(v))
 }
 
@@ -12285,7 +12285,7 @@ func (self TableColumn) SortDirectionsAvailList() uint32 {
 	return uint32(C.wrap_ImGuiTableColumn_GetSortDirectionsAvailList(self.handle()))
 }
 
-func (self *TableColumnSettings) SetWidthOrWeight(v float32) {
+func (self TableColumnSettings) SetWidthOrWeight(v float32) {
 	C.wrap_ImGuiTableColumnSettings_SetWidthOrWeight(self.handle(), C.float(v))
 }
 
@@ -12293,7 +12293,7 @@ func (self TableColumnSettings) WidthOrWeight() float32 {
 	return float32(C.wrap_ImGuiTableColumnSettings_GetWidthOrWeight(self.handle()))
 }
 
-func (self *TableColumnSettings) SetUserID(v ID) {
+func (self TableColumnSettings) SetUserID(v ID) {
 	C.wrap_ImGuiTableColumnSettings_SetUserID(self.handle(), C.ImGuiID(v))
 }
 
@@ -12301,7 +12301,7 @@ func (self TableColumnSettings) UserID() ID {
 	return ID(C.wrap_ImGuiTableColumnSettings_GetUserID(self.handle()))
 }
 
-func (self *TableColumnSettings) SetIndex(v TableColumnIdx) {
+func (self TableColumnSettings) SetIndex(v TableColumnIdx) {
 	C.wrap_ImGuiTableColumnSettings_SetIndex(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -12309,7 +12309,7 @@ func (self TableColumnSettings) Index() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTableColumnSettings_GetIndex(self.handle()))
 }
 
-func (self *TableColumnSettings) SetDisplayOrder(v TableColumnIdx) {
+func (self TableColumnSettings) SetDisplayOrder(v TableColumnIdx) {
 	C.wrap_ImGuiTableColumnSettings_SetDisplayOrder(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -12317,7 +12317,7 @@ func (self TableColumnSettings) DisplayOrder() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTableColumnSettings_GetDisplayOrder(self.handle()))
 }
 
-func (self *TableColumnSettings) SetSortOrder(v TableColumnIdx) {
+func (self TableColumnSettings) SetSortOrder(v TableColumnIdx) {
 	C.wrap_ImGuiTableColumnSettings_SetSortOrder(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -12325,7 +12325,7 @@ func (self TableColumnSettings) SortOrder() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTableColumnSettings_GetSortOrder(self.handle()))
 }
 
-func (self *TableColumnSettings) SetSortDirection(v uint) {
+func (self TableColumnSettings) SetSortDirection(v uint) {
 	C.wrap_ImGuiTableColumnSettings_SetSortDirection(self.handle(), C.ImU8(v))
 }
 
@@ -12333,7 +12333,7 @@ func (self TableColumnSettings) SortDirection() uint32 {
 	return uint32(C.wrap_ImGuiTableColumnSettings_GetSortDirection(self.handle()))
 }
 
-func (self *TableColumnSettings) SetIsEnabled(v uint) {
+func (self TableColumnSettings) SetIsEnabled(v uint) {
 	C.wrap_ImGuiTableColumnSettings_SetIsEnabled(self.handle(), C.ImU8(v))
 }
 
@@ -12341,7 +12341,7 @@ func (self TableColumnSettings) IsEnabled() uint32 {
 	return uint32(C.wrap_ImGuiTableColumnSettings_GetIsEnabled(self.handle()))
 }
 
-func (self *TableColumnSettings) SetIsStretch(v uint) {
+func (self TableColumnSettings) SetIsStretch(v uint) {
 	C.wrap_ImGuiTableColumnSettings_SetIsStretch(self.handle(), C.ImU8(v))
 }
 
@@ -12349,7 +12349,7 @@ func (self TableColumnSettings) IsStretch() uint32 {
 	return uint32(C.wrap_ImGuiTableColumnSettings_GetIsStretch(self.handle()))
 }
 
-func (self *TableColumnSortSpecs) SetColumnUserID(v ID) {
+func (self TableColumnSortSpecs) SetColumnUserID(v ID) {
 	C.wrap_ImGuiTableColumnSortSpecs_SetColumnUserID(self.handle(), C.ImGuiID(v))
 }
 
@@ -12357,7 +12357,7 @@ func (self TableColumnSortSpecs) ColumnUserID() ID {
 	return ID(C.wrap_ImGuiTableColumnSortSpecs_GetColumnUserID(self.handle()))
 }
 
-func (self *TableColumnSortSpecs) SetColumnIndex(v int) {
+func (self TableColumnSortSpecs) SetColumnIndex(v int) {
 	C.wrap_ImGuiTableColumnSortSpecs_SetColumnIndex(self.handle(), C.ImS16(v))
 }
 
@@ -12365,7 +12365,7 @@ func (self TableColumnSortSpecs) ColumnIndex() int {
 	return int(C.wrap_ImGuiTableColumnSortSpecs_GetColumnIndex(self.handle()))
 }
 
-func (self *TableColumnSortSpecs) SetSortOrder(v int) {
+func (self TableColumnSortSpecs) SetSortOrder(v int) {
 	C.wrap_ImGuiTableColumnSortSpecs_SetSortOrder(self.handle(), C.ImS16(v))
 }
 
@@ -12373,7 +12373,7 @@ func (self TableColumnSortSpecs) SortOrder() int {
 	return int(C.wrap_ImGuiTableColumnSortSpecs_GetSortOrder(self.handle()))
 }
 
-func (self *TableColumnSortSpecs) SetSortDirection(v SortDirection) {
+func (self TableColumnSortSpecs) SetSortDirection(v SortDirection) {
 	C.wrap_ImGuiTableColumnSortSpecs_SetSortDirection(self.handle(), C.ImGuiSortDirection(v))
 }
 
@@ -12381,7 +12381,7 @@ func (self TableColumnSortSpecs) SortDirection() SortDirection {
 	return SortDirection(C.wrap_ImGuiTableColumnSortSpecs_GetSortDirection(self.handle()))
 }
 
-func (self *TableInstanceData) SetLastOuterHeight(v float32) {
+func (self TableInstanceData) SetLastOuterHeight(v float32) {
 	C.wrap_ImGuiTableInstanceData_SetLastOuterHeight(self.handle(), C.float(v))
 }
 
@@ -12389,7 +12389,7 @@ func (self TableInstanceData) LastOuterHeight() float32 {
 	return float32(C.wrap_ImGuiTableInstanceData_GetLastOuterHeight(self.handle()))
 }
 
-func (self *TableInstanceData) SetLastFirstRowHeight(v float32) {
+func (self TableInstanceData) SetLastFirstRowHeight(v float32) {
 	C.wrap_ImGuiTableInstanceData_SetLastFirstRowHeight(self.handle(), C.float(v))
 }
 
@@ -12397,7 +12397,7 @@ func (self TableInstanceData) LastFirstRowHeight() float32 {
 	return float32(C.wrap_ImGuiTableInstanceData_GetLastFirstRowHeight(self.handle()))
 }
 
-func (self *TableSettings) SetID(v ID) {
+func (self TableSettings) SetID(v ID) {
 	C.wrap_ImGuiTableSettings_SetID(self.handle(), C.ImGuiID(v))
 }
 
@@ -12405,7 +12405,7 @@ func (self TableSettings) ID() ID {
 	return ID(C.wrap_ImGuiTableSettings_GetID(self.handle()))
 }
 
-func (self *TableSettings) SetSaveFlags(v TableFlags) {
+func (self TableSettings) SetSaveFlags(v TableFlags) {
 	C.wrap_ImGuiTableSettings_SetSaveFlags(self.handle(), C.ImGuiTableFlags(v))
 }
 
@@ -12413,7 +12413,7 @@ func (self TableSettings) SaveFlags() TableFlags {
 	return TableFlags(C.wrap_ImGuiTableSettings_GetSaveFlags(self.handle()))
 }
 
-func (self *TableSettings) SetRefScale(v float32) {
+func (self TableSettings) SetRefScale(v float32) {
 	C.wrap_ImGuiTableSettings_SetRefScale(self.handle(), C.float(v))
 }
 
@@ -12421,7 +12421,7 @@ func (self TableSettings) RefScale() float32 {
 	return float32(C.wrap_ImGuiTableSettings_GetRefScale(self.handle()))
 }
 
-func (self *TableSettings) SetColumnsCount(v TableColumnIdx) {
+func (self TableSettings) SetColumnsCount(v TableColumnIdx) {
 	C.wrap_ImGuiTableSettings_SetColumnsCount(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -12429,7 +12429,7 @@ func (self TableSettings) ColumnsCount() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTableSettings_GetColumnsCount(self.handle()))
 }
 
-func (self *TableSettings) SetColumnsCountMax(v TableColumnIdx) {
+func (self TableSettings) SetColumnsCountMax(v TableColumnIdx) {
 	C.wrap_ImGuiTableSettings_SetColumnsCountMax(self.handle(), C.ImGuiTableColumnIdx(v))
 }
 
@@ -12437,7 +12437,7 @@ func (self TableSettings) ColumnsCountMax() TableColumnIdx {
 	return TableColumnIdx(C.wrap_ImGuiTableSettings_GetColumnsCountMax(self.handle()))
 }
 
-func (self *TableSettings) SetWantApply(v bool) {
+func (self TableSettings) SetWantApply(v bool) {
 	C.wrap_ImGuiTableSettings_SetWantApply(self.handle(), C.bool(v))
 }
 
@@ -12445,7 +12445,7 @@ func (self TableSettings) WantApply() bool {
 	return C.wrap_ImGuiTableSettings_GetWantApply(self.handle()) == C.bool(true)
 }
 
-func (self *TableSortSpecs) SetSpecs(v TableColumnSortSpecs) {
+func (self TableSortSpecs) SetSpecs(v TableColumnSortSpecs) {
 	C.wrap_ImGuiTableSortSpecs_SetSpecs(self.handle(), v.handle())
 }
 
@@ -12453,7 +12453,7 @@ func (self TableSortSpecs) Specs() TableColumnSortSpecs {
 	return (TableColumnSortSpecs)(unsafe.Pointer(C.wrap_ImGuiTableSortSpecs_GetSpecs(self.handle())))
 }
 
-func (self *TableSortSpecs) SetSpecsCount(v int32) {
+func (self TableSortSpecs) SetSpecsCount(v int32) {
 	C.wrap_ImGuiTableSortSpecs_SetSpecsCount(self.handle(), C.int(v))
 }
 
@@ -12461,7 +12461,7 @@ func (self TableSortSpecs) SpecsCount() int {
 	return int(C.wrap_ImGuiTableSortSpecs_GetSpecsCount(self.handle()))
 }
 
-func (self *TableSortSpecs) SetSpecsDirty(v bool) {
+func (self TableSortSpecs) SetSpecsDirty(v bool) {
 	C.wrap_ImGuiTableSortSpecs_SetSpecsDirty(self.handle(), C.bool(v))
 }
 
@@ -12469,7 +12469,7 @@ func (self TableSortSpecs) SpecsDirty() bool {
 	return C.wrap_ImGuiTableSortSpecs_GetSpecsDirty(self.handle()) == C.bool(true)
 }
 
-func (self *TableTempData) SetTableIndex(v int32) {
+func (self TableTempData) SetTableIndex(v int32) {
 	C.wrap_ImGuiTableTempData_SetTableIndex(self.handle(), C.int(v))
 }
 
@@ -12477,7 +12477,7 @@ func (self TableTempData) TableIndex() int {
 	return int(C.wrap_ImGuiTableTempData_GetTableIndex(self.handle()))
 }
 
-func (self *TableTempData) SetLastTimeActive(v float32) {
+func (self TableTempData) SetLastTimeActive(v float32) {
 	C.wrap_ImGuiTableTempData_SetLastTimeActive(self.handle(), C.float(v))
 }
 
@@ -12485,7 +12485,7 @@ func (self TableTempData) LastTimeActive() float32 {
 	return float32(C.wrap_ImGuiTableTempData_GetLastTimeActive(self.handle()))
 }
 
-func (self *TableTempData) SetUserOuterSize(v Vec2) {
+func (self TableTempData) SetUserOuterSize(v Vec2) {
 	C.wrap_ImGuiTableTempData_SetUserOuterSize(self.handle(), v.toC())
 }
 
@@ -12499,7 +12499,7 @@ func (self TableTempData) DrawSplitter() DrawListSplitter {
 	return newDrawListSplitterFromC(C.wrap_ImGuiTableTempData_GetDrawSplitter(self.handle()))
 }
 
-func (self *TableTempData) SetHostBackupWorkRect(v Rect) {
+func (self TableTempData) SetHostBackupWorkRect(v Rect) {
 	C.wrap_ImGuiTableTempData_SetHostBackupWorkRect(self.handle(), v.toC())
 }
 
@@ -12509,7 +12509,7 @@ func (self TableTempData) HostBackupWorkRect() Rect {
 	return *out
 }
 
-func (self *TableTempData) SetHostBackupParentWorkRect(v Rect) {
+func (self TableTempData) SetHostBackupParentWorkRect(v Rect) {
 	C.wrap_ImGuiTableTempData_SetHostBackupParentWorkRect(self.handle(), v.toC())
 }
 
@@ -12519,7 +12519,7 @@ func (self TableTempData) HostBackupParentWorkRect() Rect {
 	return *out
 }
 
-func (self *TableTempData) SetHostBackupPrevLineSize(v Vec2) {
+func (self TableTempData) SetHostBackupPrevLineSize(v Vec2) {
 	C.wrap_ImGuiTableTempData_SetHostBackupPrevLineSize(self.handle(), v.toC())
 }
 
@@ -12529,7 +12529,7 @@ func (self TableTempData) HostBackupPrevLineSize() Vec2 {
 	return *out
 }
 
-func (self *TableTempData) SetHostBackupCurrLineSize(v Vec2) {
+func (self TableTempData) SetHostBackupCurrLineSize(v Vec2) {
 	C.wrap_ImGuiTableTempData_SetHostBackupCurrLineSize(self.handle(), v.toC())
 }
 
@@ -12539,7 +12539,7 @@ func (self TableTempData) HostBackupCurrLineSize() Vec2 {
 	return *out
 }
 
-func (self *TableTempData) SetHostBackupCursorMaxPos(v Vec2) {
+func (self TableTempData) SetHostBackupCursorMaxPos(v Vec2) {
 	C.wrap_ImGuiTableTempData_SetHostBackupCursorMaxPos(self.handle(), v.toC())
 }
 
@@ -12549,7 +12549,7 @@ func (self TableTempData) HostBackupCursorMaxPos() Vec2 {
 	return *out
 }
 
-func (self *TableTempData) SetHostBackupItemWidth(v float32) {
+func (self TableTempData) SetHostBackupItemWidth(v float32) {
 	C.wrap_ImGuiTableTempData_SetHostBackupItemWidth(self.handle(), C.float(v))
 }
 
@@ -12557,7 +12557,7 @@ func (self TableTempData) HostBackupItemWidth() float32 {
 	return float32(C.wrap_ImGuiTableTempData_GetHostBackupItemWidth(self.handle()))
 }
 
-func (self *TableTempData) SetHostBackupItemWidthStackSize(v int32) {
+func (self TableTempData) SetHostBackupItemWidthStackSize(v int32) {
 	C.wrap_ImGuiTableTempData_SetHostBackupItemWidthStackSize(self.handle(), C.int(v))
 }
 
@@ -12565,7 +12565,7 @@ func (self TableTempData) HostBackupItemWidthStackSize() int {
 	return int(C.wrap_ImGuiTableTempData_GetHostBackupItemWidthStackSize(self.handle()))
 }
 
-func (self *TextFilter) SetCountGrep(v int32) {
+func (self TextFilter) SetCountGrep(v int32) {
 	C.wrap_ImGuiTextFilter_SetCountGrep(self.handle(), C.int(v))
 }
 
@@ -12573,7 +12573,7 @@ func (self TextFilter) CountGrep() int {
 	return int(C.wrap_ImGuiTextFilter_GetCountGrep(self.handle()))
 }
 
-func (self *TextRange) Setb(v string) {
+func (self TextRange) Setb(v string) {
 	vArg, vFin := wrapString(v)
 	defer vFin()
 
@@ -12584,7 +12584,7 @@ func (self TextRange) b() string {
 	return C.GoString(C.wrap_ImGuiTextRange_Getb(self.handle()))
 }
 
-func (self *TextRange) Sete(v string) {
+func (self TextRange) Sete(v string) {
 	vArg, vFin := wrapString(v)
 	defer vFin()
 
@@ -12595,7 +12595,7 @@ func (self TextRange) e() string {
 	return C.GoString(C.wrap_ImGuiTextRange_Gete(self.handle()))
 }
 
-func (self *Viewport) SetID(v ID) {
+func (self Viewport) SetID(v ID) {
 	C.wrap_ImGuiViewport_SetID(self.handle(), C.ImGuiID(v))
 }
 
@@ -12603,7 +12603,7 @@ func (self Viewport) ID() ID {
 	return ID(C.wrap_ImGuiViewport_GetID(self.handle()))
 }
 
-func (self *Viewport) SetFlags(v ViewportFlags) {
+func (self Viewport) SetFlags(v ViewportFlags) {
 	C.wrap_ImGuiViewport_SetFlags(self.handle(), C.ImGuiViewportFlags(v))
 }
 
@@ -12611,7 +12611,7 @@ func (self Viewport) Flags() ViewportFlags {
 	return ViewportFlags(C.wrap_ImGuiViewport_GetFlags(self.handle()))
 }
 
-func (self *Viewport) SetPos(v Vec2) {
+func (self Viewport) SetPos(v Vec2) {
 	C.wrap_ImGuiViewport_SetPos(self.handle(), v.toC())
 }
 
@@ -12621,7 +12621,7 @@ func (self Viewport) Pos() Vec2 {
 	return *out
 }
 
-func (self *Viewport) SetSize(v Vec2) {
+func (self Viewport) SetSize(v Vec2) {
 	C.wrap_ImGuiViewport_SetSize(self.handle(), v.toC())
 }
 
@@ -12631,7 +12631,7 @@ func (self Viewport) Size() Vec2 {
 	return *out
 }
 
-func (self *Viewport) SetWorkPos(v Vec2) {
+func (self Viewport) SetWorkPos(v Vec2) {
 	C.wrap_ImGuiViewport_SetWorkPos(self.handle(), v.toC())
 }
 
@@ -12641,7 +12641,7 @@ func (self Viewport) WorkPos() Vec2 {
 	return *out
 }
 
-func (self *Viewport) SetWorkSize(v Vec2) {
+func (self Viewport) SetWorkSize(v Vec2) {
 	C.wrap_ImGuiViewport_SetWorkSize(self.handle(), v.toC())
 }
 
@@ -12651,7 +12651,7 @@ func (self Viewport) WorkSize() Vec2 {
 	return *out
 }
 
-func (self *Viewport) SetDpiScale(v float32) {
+func (self Viewport) SetDpiScale(v float32) {
 	C.wrap_ImGuiViewport_SetDpiScale(self.handle(), C.float(v))
 }
 
@@ -12659,7 +12659,7 @@ func (self Viewport) DpiScale() float32 {
 	return float32(C.wrap_ImGuiViewport_GetDpiScale(self.handle()))
 }
 
-func (self *Viewport) SetParentViewportId(v ID) {
+func (self Viewport) SetParentViewportId(v ID) {
 	C.wrap_ImGuiViewport_SetParentViewportId(self.handle(), C.ImGuiID(v))
 }
 
@@ -12667,7 +12667,7 @@ func (self Viewport) ParentViewportId() ID {
 	return ID(C.wrap_ImGuiViewport_GetParentViewportId(self.handle()))
 }
 
-func (self *Viewport) SetDrawData(v DrawData) {
+func (self Viewport) SetDrawData(v DrawData) {
 	C.wrap_ImGuiViewport_SetDrawData(self.handle(), v.handle())
 }
 
@@ -12675,7 +12675,7 @@ func (self Viewport) DrawData() DrawData {
 	return (DrawData)(unsafe.Pointer(C.wrap_ImGuiViewport_GetDrawData(self.handle())))
 }
 
-func (self *Viewport) SetRendererUserData(v unsafe.Pointer) {
+func (self Viewport) SetRendererUserData(v unsafe.Pointer) {
 	C.wrap_ImGuiViewport_SetRendererUserData(self.handle(), (v))
 }
 
@@ -12683,7 +12683,7 @@ func (self Viewport) RendererUserData() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImGuiViewport_GetRendererUserData(self.handle()))
 }
 
-func (self *Viewport) SetPlatformUserData(v unsafe.Pointer) {
+func (self Viewport) SetPlatformUserData(v unsafe.Pointer) {
 	C.wrap_ImGuiViewport_SetPlatformUserData(self.handle(), (v))
 }
 
@@ -12691,7 +12691,7 @@ func (self Viewport) PlatformUserData() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImGuiViewport_GetPlatformUserData(self.handle()))
 }
 
-func (self *Viewport) SetPlatformHandle(v unsafe.Pointer) {
+func (self Viewport) SetPlatformHandle(v unsafe.Pointer) {
 	C.wrap_ImGuiViewport_SetPlatformHandle(self.handle(), (v))
 }
 
@@ -12699,7 +12699,7 @@ func (self Viewport) PlatformHandle() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImGuiViewport_GetPlatformHandle(self.handle()))
 }
 
-func (self *Viewport) SetPlatformHandleRaw(v unsafe.Pointer) {
+func (self Viewport) SetPlatformHandleRaw(v unsafe.Pointer) {
 	C.wrap_ImGuiViewport_SetPlatformHandleRaw(self.handle(), (v))
 }
 
@@ -12707,7 +12707,7 @@ func (self Viewport) PlatformHandleRaw() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImGuiViewport_GetPlatformHandleRaw(self.handle()))
 }
 
-func (self *Viewport) SetPlatformRequestMove(v bool) {
+func (self Viewport) SetPlatformRequestMove(v bool) {
 	C.wrap_ImGuiViewport_SetPlatformRequestMove(self.handle(), C.bool(v))
 }
 
@@ -12715,7 +12715,7 @@ func (self Viewport) PlatformRequestMove() bool {
 	return C.wrap_ImGuiViewport_GetPlatformRequestMove(self.handle()) == C.bool(true)
 }
 
-func (self *Viewport) SetPlatformRequestResize(v bool) {
+func (self Viewport) SetPlatformRequestResize(v bool) {
 	C.wrap_ImGuiViewport_SetPlatformRequestResize(self.handle(), C.bool(v))
 }
 
@@ -12723,7 +12723,7 @@ func (self Viewport) PlatformRequestResize() bool {
 	return C.wrap_ImGuiViewport_GetPlatformRequestResize(self.handle()) == C.bool(true)
 }
 
-func (self *Viewport) SetPlatformRequestClose(v bool) {
+func (self Viewport) SetPlatformRequestClose(v bool) {
 	C.wrap_ImGuiViewport_SetPlatformRequestClose(self.handle(), C.bool(v))
 }
 
@@ -12735,7 +12735,7 @@ func (self ViewportP) ImGuiViewport() Viewport {
 	return newViewportFromC(C.wrap_ImGuiViewportP_Get_ImGuiViewport(self.handle()))
 }
 
-func (self *ViewportP) SetIdx(v int32) {
+func (self ViewportP) SetIdx(v int32) {
 	C.wrap_ImGuiViewportP_SetIdx(self.handle(), C.int(v))
 }
 
@@ -12743,7 +12743,7 @@ func (self ViewportP) Idx() int {
 	return int(C.wrap_ImGuiViewportP_GetIdx(self.handle()))
 }
 
-func (self *ViewportP) SetLastFrameActive(v int32) {
+func (self ViewportP) SetLastFrameActive(v int32) {
 	C.wrap_ImGuiViewportP_SetLastFrameActive(self.handle(), C.int(v))
 }
 
@@ -12751,7 +12751,7 @@ func (self ViewportP) LastFrameActive() int {
 	return int(C.wrap_ImGuiViewportP_GetLastFrameActive(self.handle()))
 }
 
-func (self *ViewportP) SetLastFrontMostStampCount(v int32) {
+func (self ViewportP) SetLastFrontMostStampCount(v int32) {
 	C.wrap_ImGuiViewportP_SetLastFrontMostStampCount(self.handle(), C.int(v))
 }
 
@@ -12759,7 +12759,7 @@ func (self ViewportP) LastFrontMostStampCount() int {
 	return int(C.wrap_ImGuiViewportP_GetLastFrontMostStampCount(self.handle()))
 }
 
-func (self *ViewportP) SetLastNameHash(v ID) {
+func (self ViewportP) SetLastNameHash(v ID) {
 	C.wrap_ImGuiViewportP_SetLastNameHash(self.handle(), C.ImGuiID(v))
 }
 
@@ -12767,7 +12767,7 @@ func (self ViewportP) LastNameHash() ID {
 	return ID(C.wrap_ImGuiViewportP_GetLastNameHash(self.handle()))
 }
 
-func (self *ViewportP) SetLastPos(v Vec2) {
+func (self ViewportP) SetLastPos(v Vec2) {
 	C.wrap_ImGuiViewportP_SetLastPos(self.handle(), v.toC())
 }
 
@@ -12777,7 +12777,7 @@ func (self ViewportP) LastPos() Vec2 {
 	return *out
 }
 
-func (self *ViewportP) SetAlpha(v float32) {
+func (self ViewportP) SetAlpha(v float32) {
 	C.wrap_ImGuiViewportP_SetAlpha(self.handle(), C.float(v))
 }
 
@@ -12785,7 +12785,7 @@ func (self ViewportP) Alpha() float32 {
 	return float32(C.wrap_ImGuiViewportP_GetAlpha(self.handle()))
 }
 
-func (self *ViewportP) SetLastAlpha(v float32) {
+func (self ViewportP) SetLastAlpha(v float32) {
 	C.wrap_ImGuiViewportP_SetLastAlpha(self.handle(), C.float(v))
 }
 
@@ -12793,7 +12793,7 @@ func (self ViewportP) LastAlpha() float32 {
 	return float32(C.wrap_ImGuiViewportP_GetLastAlpha(self.handle()))
 }
 
-func (self *ViewportP) SetPlatformMonitor(v int) {
+func (self ViewportP) SetPlatformMonitor(v int) {
 	C.wrap_ImGuiViewportP_SetPlatformMonitor(self.handle(), C.short(v))
 }
 
@@ -12801,7 +12801,7 @@ func (self ViewportP) PlatformMonitor() int {
 	return int(C.wrap_ImGuiViewportP_GetPlatformMonitor(self.handle()))
 }
 
-func (self *ViewportP) SetPlatformWindowCreated(v bool) {
+func (self ViewportP) SetPlatformWindowCreated(v bool) {
 	C.wrap_ImGuiViewportP_SetPlatformWindowCreated(self.handle(), C.bool(v))
 }
 
@@ -12809,7 +12809,7 @@ func (self ViewportP) PlatformWindowCreated() bool {
 	return C.wrap_ImGuiViewportP_GetPlatformWindowCreated(self.handle()) == C.bool(true)
 }
 
-func (self *ViewportP) SetWindow(v Window) {
+func (self ViewportP) SetWindow(v Window) {
 	C.wrap_ImGuiViewportP_SetWindow(self.handle(), v.handle())
 }
 
@@ -12825,7 +12825,7 @@ func (self ViewportP) DrawDataBuilder() DrawDataBuilder {
 	return newDrawDataBuilderFromC(C.wrap_ImGuiViewportP_GetDrawDataBuilder(self.handle()))
 }
 
-func (self *ViewportP) SetLastPlatformPos(v Vec2) {
+func (self ViewportP) SetLastPlatformPos(v Vec2) {
 	C.wrap_ImGuiViewportP_SetLastPlatformPos(self.handle(), v.toC())
 }
 
@@ -12835,7 +12835,7 @@ func (self ViewportP) LastPlatformPos() Vec2 {
 	return *out
 }
 
-func (self *ViewportP) SetLastPlatformSize(v Vec2) {
+func (self ViewportP) SetLastPlatformSize(v Vec2) {
 	C.wrap_ImGuiViewportP_SetLastPlatformSize(self.handle(), v.toC())
 }
 
@@ -12845,7 +12845,7 @@ func (self ViewportP) LastPlatformSize() Vec2 {
 	return *out
 }
 
-func (self *ViewportP) SetLastRendererSize(v Vec2) {
+func (self ViewportP) SetLastRendererSize(v Vec2) {
 	C.wrap_ImGuiViewportP_SetLastRendererSize(self.handle(), v.toC())
 }
 
@@ -12855,7 +12855,7 @@ func (self ViewportP) LastRendererSize() Vec2 {
 	return *out
 }
 
-func (self *ViewportP) SetWorkOffsetMin(v Vec2) {
+func (self ViewportP) SetWorkOffsetMin(v Vec2) {
 	C.wrap_ImGuiViewportP_SetWorkOffsetMin(self.handle(), v.toC())
 }
 
@@ -12865,7 +12865,7 @@ func (self ViewportP) WorkOffsetMin() Vec2 {
 	return *out
 }
 
-func (self *ViewportP) SetWorkOffsetMax(v Vec2) {
+func (self ViewportP) SetWorkOffsetMax(v Vec2) {
 	C.wrap_ImGuiViewportP_SetWorkOffsetMax(self.handle(), v.toC())
 }
 
@@ -12875,7 +12875,7 @@ func (self ViewportP) WorkOffsetMax() Vec2 {
 	return *out
 }
 
-func (self *ViewportP) SetBuildWorkOffsetMin(v Vec2) {
+func (self ViewportP) SetBuildWorkOffsetMin(v Vec2) {
 	C.wrap_ImGuiViewportP_SetBuildWorkOffsetMin(self.handle(), v.toC())
 }
 
@@ -12885,7 +12885,7 @@ func (self ViewportP) BuildWorkOffsetMin() Vec2 {
 	return *out
 }
 
-func (self *ViewportP) SetBuildWorkOffsetMax(v Vec2) {
+func (self ViewportP) SetBuildWorkOffsetMax(v Vec2) {
 	C.wrap_ImGuiViewportP_SetBuildWorkOffsetMax(self.handle(), v.toC())
 }
 
@@ -12895,7 +12895,7 @@ func (self ViewportP) BuildWorkOffsetMax() Vec2 {
 	return *out
 }
 
-func (self *Window) SetName(v string) {
+func (self Window) SetName(v string) {
 	vArg, vFin := wrapString(v)
 	defer vFin()
 
@@ -12906,7 +12906,7 @@ func (self Window) Name() string {
 	return C.GoString(C.wrap_ImGuiWindow_GetName(self.handle()))
 }
 
-func (self *Window) SetID(v ID) {
+func (self Window) SetID(v ID) {
 	C.wrap_ImGuiWindow_SetID(self.handle(), C.ImGuiID(v))
 }
 
@@ -12914,7 +12914,7 @@ func (self Window) ID() ID {
 	return ID(C.wrap_ImGuiWindow_GetID(self.handle()))
 }
 
-func (self *Window) SetFlags(v WindowFlags) {
+func (self Window) SetFlags(v WindowFlags) {
 	C.wrap_ImGuiWindow_SetFlags(self.handle(), C.ImGuiWindowFlags(v))
 }
 
@@ -12922,7 +12922,7 @@ func (self Window) Flags() WindowFlags {
 	return WindowFlags(C.wrap_ImGuiWindow_GetFlags(self.handle()))
 }
 
-func (self *Window) SetFlagsPreviousFrame(v WindowFlags) {
+func (self Window) SetFlagsPreviousFrame(v WindowFlags) {
 	C.wrap_ImGuiWindow_SetFlagsPreviousFrame(self.handle(), C.ImGuiWindowFlags(v))
 }
 
@@ -12934,7 +12934,7 @@ func (self Window) WindowClass() WindowClass {
 	return newWindowClassFromC(C.wrap_ImGuiWindow_GetWindowClass(self.handle()))
 }
 
-func (self *Window) SetViewport(v ViewportP) {
+func (self Window) SetViewport(v ViewportP) {
 	C.wrap_ImGuiWindow_SetViewport(self.handle(), v.handle())
 }
 
@@ -12942,7 +12942,7 @@ func (self Window) Viewport() ViewportP {
 	return (ViewportP)(unsafe.Pointer(C.wrap_ImGuiWindow_GetViewport(self.handle())))
 }
 
-func (self *Window) SetViewportId(v ID) {
+func (self Window) SetViewportId(v ID) {
 	C.wrap_ImGuiWindow_SetViewportId(self.handle(), C.ImGuiID(v))
 }
 
@@ -12950,7 +12950,7 @@ func (self Window) ViewportId() ID {
 	return ID(C.wrap_ImGuiWindow_GetViewportId(self.handle()))
 }
 
-func (self *Window) SetViewportPos(v Vec2) {
+func (self Window) SetViewportPos(v Vec2) {
 	C.wrap_ImGuiWindow_SetViewportPos(self.handle(), v.toC())
 }
 
@@ -12960,7 +12960,7 @@ func (self Window) ViewportPos() Vec2 {
 	return *out
 }
 
-func (self *Window) SetViewportAllowPlatformMonitorExtend(v int32) {
+func (self Window) SetViewportAllowPlatformMonitorExtend(v int32) {
 	C.wrap_ImGuiWindow_SetViewportAllowPlatformMonitorExtend(self.handle(), C.int(v))
 }
 
@@ -12968,7 +12968,7 @@ func (self Window) ViewportAllowPlatformMonitorExtend() int {
 	return int(C.wrap_ImGuiWindow_GetViewportAllowPlatformMonitorExtend(self.handle()))
 }
 
-func (self *Window) SetPos(v Vec2) {
+func (self Window) SetPos(v Vec2) {
 	C.wrap_ImGuiWindow_SetPos(self.handle(), v.toC())
 }
 
@@ -12978,7 +12978,7 @@ func (self Window) Pos() Vec2 {
 	return *out
 }
 
-func (self *Window) SetSize(v Vec2) {
+func (self Window) SetSize(v Vec2) {
 	C.wrap_ImGuiWindow_SetSize(self.handle(), v.toC())
 }
 
@@ -12988,7 +12988,7 @@ func (self Window) Size() Vec2 {
 	return *out
 }
 
-func (self *Window) SetSizeFull(v Vec2) {
+func (self Window) SetSizeFull(v Vec2) {
 	C.wrap_ImGuiWindow_SetSizeFull(self.handle(), v.toC())
 }
 
@@ -12998,7 +12998,7 @@ func (self Window) SizeFull() Vec2 {
 	return *out
 }
 
-func (self *Window) SetContentSize(v Vec2) {
+func (self Window) SetContentSize(v Vec2) {
 	C.wrap_ImGuiWindow_SetContentSize(self.handle(), v.toC())
 }
 
@@ -13008,7 +13008,7 @@ func (self Window) ContentSize() Vec2 {
 	return *out
 }
 
-func (self *Window) SetContentSizeIdeal(v Vec2) {
+func (self Window) SetContentSizeIdeal(v Vec2) {
 	C.wrap_ImGuiWindow_SetContentSizeIdeal(self.handle(), v.toC())
 }
 
@@ -13018,7 +13018,7 @@ func (self Window) ContentSizeIdeal() Vec2 {
 	return *out
 }
 
-func (self *Window) SetContentSizeExplicit(v Vec2) {
+func (self Window) SetContentSizeExplicit(v Vec2) {
 	C.wrap_ImGuiWindow_SetContentSizeExplicit(self.handle(), v.toC())
 }
 
@@ -13028,7 +13028,7 @@ func (self Window) ContentSizeExplicit() Vec2 {
 	return *out
 }
 
-func (self *Window) SetWindowPadding(v Vec2) {
+func (self Window) SetWindowPadding(v Vec2) {
 	C.wrap_ImGuiWindow_SetWindowPadding(self.handle(), v.toC())
 }
 
@@ -13038,7 +13038,7 @@ func (self Window) WindowPadding() Vec2 {
 	return *out
 }
 
-func (self *Window) SetWindowRounding(v float32) {
+func (self Window) SetWindowRounding(v float32) {
 	C.wrap_ImGuiWindow_SetWindowRounding(self.handle(), C.float(v))
 }
 
@@ -13046,7 +13046,7 @@ func (self Window) WindowRounding() float32 {
 	return float32(C.wrap_ImGuiWindow_GetWindowRounding(self.handle()))
 }
 
-func (self *Window) SetWindowBorderSize(v float32) {
+func (self Window) SetWindowBorderSize(v float32) {
 	C.wrap_ImGuiWindow_SetWindowBorderSize(self.handle(), C.float(v))
 }
 
@@ -13054,7 +13054,7 @@ func (self Window) WindowBorderSize() float32 {
 	return float32(C.wrap_ImGuiWindow_GetWindowBorderSize(self.handle()))
 }
 
-func (self *Window) SetNameBufLen(v int32) {
+func (self Window) SetNameBufLen(v int32) {
 	C.wrap_ImGuiWindow_SetNameBufLen(self.handle(), C.int(v))
 }
 
@@ -13062,7 +13062,7 @@ func (self Window) NameBufLen() int {
 	return int(C.wrap_ImGuiWindow_GetNameBufLen(self.handle()))
 }
 
-func (self *Window) SetMoveId(v ID) {
+func (self Window) SetMoveId(v ID) {
 	C.wrap_ImGuiWindow_SetMoveId(self.handle(), C.ImGuiID(v))
 }
 
@@ -13070,7 +13070,7 @@ func (self Window) MoveId() ID {
 	return ID(C.wrap_ImGuiWindow_GetMoveId(self.handle()))
 }
 
-func (self *Window) SetTabId(v ID) {
+func (self Window) SetTabId(v ID) {
 	C.wrap_ImGuiWindow_SetTabId(self.handle(), C.ImGuiID(v))
 }
 
@@ -13078,7 +13078,7 @@ func (self Window) TabId() ID {
 	return ID(C.wrap_ImGuiWindow_GetTabId(self.handle()))
 }
 
-func (self *Window) SetChildId(v ID) {
+func (self Window) SetChildId(v ID) {
 	C.wrap_ImGuiWindow_SetChildId(self.handle(), C.ImGuiID(v))
 }
 
@@ -13086,7 +13086,7 @@ func (self Window) ChildId() ID {
 	return ID(C.wrap_ImGuiWindow_GetChildId(self.handle()))
 }
 
-func (self *Window) SetScroll(v Vec2) {
+func (self Window) SetScroll(v Vec2) {
 	C.wrap_ImGuiWindow_SetScroll(self.handle(), v.toC())
 }
 
@@ -13096,7 +13096,7 @@ func (self Window) Scroll() Vec2 {
 	return *out
 }
 
-func (self *Window) SetScrollMax(v Vec2) {
+func (self Window) SetScrollMax(v Vec2) {
 	C.wrap_ImGuiWindow_SetScrollMax(self.handle(), v.toC())
 }
 
@@ -13106,7 +13106,7 @@ func (self Window) ScrollMax() Vec2 {
 	return *out
 }
 
-func (self *Window) SetScrollTarget(v Vec2) {
+func (self Window) SetScrollTarget(v Vec2) {
 	C.wrap_ImGuiWindow_SetScrollTarget(self.handle(), v.toC())
 }
 
@@ -13116,7 +13116,7 @@ func (self Window) ScrollTarget() Vec2 {
 	return *out
 }
 
-func (self *Window) SetScrollTargetCenterRatio(v Vec2) {
+func (self Window) SetScrollTargetCenterRatio(v Vec2) {
 	C.wrap_ImGuiWindow_SetScrollTargetCenterRatio(self.handle(), v.toC())
 }
 
@@ -13126,7 +13126,7 @@ func (self Window) ScrollTargetCenterRatio() Vec2 {
 	return *out
 }
 
-func (self *Window) SetScrollTargetEdgeSnapDist(v Vec2) {
+func (self Window) SetScrollTargetEdgeSnapDist(v Vec2) {
 	C.wrap_ImGuiWindow_SetScrollTargetEdgeSnapDist(self.handle(), v.toC())
 }
 
@@ -13136,7 +13136,7 @@ func (self Window) ScrollTargetEdgeSnapDist() Vec2 {
 	return *out
 }
 
-func (self *Window) SetScrollbarSizes(v Vec2) {
+func (self Window) SetScrollbarSizes(v Vec2) {
 	C.wrap_ImGuiWindow_SetScrollbarSizes(self.handle(), v.toC())
 }
 
@@ -13146,7 +13146,7 @@ func (self Window) ScrollbarSizes() Vec2 {
 	return *out
 }
 
-func (self *Window) SetScrollbarX(v bool) {
+func (self Window) SetScrollbarX(v bool) {
 	C.wrap_ImGuiWindow_SetScrollbarX(self.handle(), C.bool(v))
 }
 
@@ -13154,7 +13154,7 @@ func (self Window) ScrollbarX() bool {
 	return C.wrap_ImGuiWindow_GetScrollbarX(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetScrollbarY(v bool) {
+func (self Window) SetScrollbarY(v bool) {
 	C.wrap_ImGuiWindow_SetScrollbarY(self.handle(), C.bool(v))
 }
 
@@ -13162,7 +13162,7 @@ func (self Window) ScrollbarY() bool {
 	return C.wrap_ImGuiWindow_GetScrollbarY(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetViewportOwned(v bool) {
+func (self Window) SetViewportOwned(v bool) {
 	C.wrap_ImGuiWindow_SetViewportOwned(self.handle(), C.bool(v))
 }
 
@@ -13170,7 +13170,7 @@ func (self Window) ViewportOwned() bool {
 	return C.wrap_ImGuiWindow_GetViewportOwned(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetActive(v bool) {
+func (self Window) SetActive(v bool) {
 	C.wrap_ImGuiWindow_SetActive(self.handle(), C.bool(v))
 }
 
@@ -13178,7 +13178,7 @@ func (self Window) Active() bool {
 	return C.wrap_ImGuiWindow_GetActive(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetWasActive(v bool) {
+func (self Window) SetWasActive(v bool) {
 	C.wrap_ImGuiWindow_SetWasActive(self.handle(), C.bool(v))
 }
 
@@ -13186,7 +13186,7 @@ func (self Window) WasActive() bool {
 	return C.wrap_ImGuiWindow_GetWasActive(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetWriteAccessed(v bool) {
+func (self Window) SetWriteAccessed(v bool) {
 	C.wrap_ImGuiWindow_SetWriteAccessed(self.handle(), C.bool(v))
 }
 
@@ -13194,7 +13194,7 @@ func (self Window) WriteAccessed() bool {
 	return C.wrap_ImGuiWindow_GetWriteAccessed(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetCollapsed(v bool) {
+func (self Window) SetCollapsed(v bool) {
 	C.wrap_ImGuiWindow_SetCollapsed(self.handle(), C.bool(v))
 }
 
@@ -13202,7 +13202,7 @@ func (self Window) Collapsed() bool {
 	return C.wrap_ImGuiWindow_GetCollapsed(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetWantCollapseToggle(v bool) {
+func (self Window) SetWantCollapseToggle(v bool) {
 	C.wrap_ImGuiWindow_SetWantCollapseToggle(self.handle(), C.bool(v))
 }
 
@@ -13210,7 +13210,7 @@ func (self Window) WantCollapseToggle() bool {
 	return C.wrap_ImGuiWindow_GetWantCollapseToggle(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetSkipItems(v bool) {
+func (self Window) SetSkipItems(v bool) {
 	C.wrap_ImGuiWindow_SetSkipItems(self.handle(), C.bool(v))
 }
 
@@ -13218,7 +13218,7 @@ func (self Window) SkipItems() bool {
 	return C.wrap_ImGuiWindow_GetSkipItems(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetAppearing(v bool) {
+func (self Window) SetAppearing(v bool) {
 	C.wrap_ImGuiWindow_SetAppearing(self.handle(), C.bool(v))
 }
 
@@ -13226,7 +13226,7 @@ func (self Window) Appearing() bool {
 	return C.wrap_ImGuiWindow_GetAppearing(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetHidden(v bool) {
+func (self Window) SetHidden(v bool) {
 	C.wrap_ImGuiWindow_SetHidden(self.handle(), C.bool(v))
 }
 
@@ -13234,7 +13234,7 @@ func (self Window) Hidden() bool {
 	return C.wrap_ImGuiWindow_GetHidden(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetIsFallbackWindow(v bool) {
+func (self Window) SetIsFallbackWindow(v bool) {
 	C.wrap_ImGuiWindow_SetIsFallbackWindow(self.handle(), C.bool(v))
 }
 
@@ -13242,7 +13242,7 @@ func (self Window) IsFallbackWindow() bool {
 	return C.wrap_ImGuiWindow_GetIsFallbackWindow(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetIsExplicitChild(v bool) {
+func (self Window) SetIsExplicitChild(v bool) {
 	C.wrap_ImGuiWindow_SetIsExplicitChild(self.handle(), C.bool(v))
 }
 
@@ -13250,7 +13250,7 @@ func (self Window) IsExplicitChild() bool {
 	return C.wrap_ImGuiWindow_GetIsExplicitChild(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetHasCloseButton(v bool) {
+func (self Window) SetHasCloseButton(v bool) {
 	C.wrap_ImGuiWindow_SetHasCloseButton(self.handle(), C.bool(v))
 }
 
@@ -13258,7 +13258,7 @@ func (self Window) HasCloseButton() bool {
 	return C.wrap_ImGuiWindow_GetHasCloseButton(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetBeginCount(v int) {
+func (self Window) SetBeginCount(v int) {
 	C.wrap_ImGuiWindow_SetBeginCount(self.handle(), C.short(v))
 }
 
@@ -13266,7 +13266,7 @@ func (self Window) BeginCount() int {
 	return int(C.wrap_ImGuiWindow_GetBeginCount(self.handle()))
 }
 
-func (self *Window) SetBeginOrderWithinParent(v int) {
+func (self Window) SetBeginOrderWithinParent(v int) {
 	C.wrap_ImGuiWindow_SetBeginOrderWithinParent(self.handle(), C.short(v))
 }
 
@@ -13274,7 +13274,7 @@ func (self Window) BeginOrderWithinParent() int {
 	return int(C.wrap_ImGuiWindow_GetBeginOrderWithinParent(self.handle()))
 }
 
-func (self *Window) SetBeginOrderWithinContext(v int) {
+func (self Window) SetBeginOrderWithinContext(v int) {
 	C.wrap_ImGuiWindow_SetBeginOrderWithinContext(self.handle(), C.short(v))
 }
 
@@ -13282,7 +13282,7 @@ func (self Window) BeginOrderWithinContext() int {
 	return int(C.wrap_ImGuiWindow_GetBeginOrderWithinContext(self.handle()))
 }
 
-func (self *Window) SetFocusOrder(v int) {
+func (self Window) SetFocusOrder(v int) {
 	C.wrap_ImGuiWindow_SetFocusOrder(self.handle(), C.short(v))
 }
 
@@ -13290,7 +13290,7 @@ func (self Window) FocusOrder() int {
 	return int(C.wrap_ImGuiWindow_GetFocusOrder(self.handle()))
 }
 
-func (self *Window) SetPopupId(v ID) {
+func (self Window) SetPopupId(v ID) {
 	C.wrap_ImGuiWindow_SetPopupId(self.handle(), C.ImGuiID(v))
 }
 
@@ -13298,7 +13298,7 @@ func (self Window) PopupId() ID {
 	return ID(C.wrap_ImGuiWindow_GetPopupId(self.handle()))
 }
 
-func (self *Window) SetAutoFitFramesX(v int) {
+func (self Window) SetAutoFitFramesX(v int) {
 	C.wrap_ImGuiWindow_SetAutoFitFramesX(self.handle(), C.ImS8(v))
 }
 
@@ -13306,7 +13306,7 @@ func (self Window) AutoFitFramesX() int {
 	return int(C.wrap_ImGuiWindow_GetAutoFitFramesX(self.handle()))
 }
 
-func (self *Window) SetAutoFitFramesY(v int) {
+func (self Window) SetAutoFitFramesY(v int) {
 	C.wrap_ImGuiWindow_SetAutoFitFramesY(self.handle(), C.ImS8(v))
 }
 
@@ -13314,7 +13314,7 @@ func (self Window) AutoFitFramesY() int {
 	return int(C.wrap_ImGuiWindow_GetAutoFitFramesY(self.handle()))
 }
 
-func (self *Window) SetAutoFitChildAxises(v int) {
+func (self Window) SetAutoFitChildAxises(v int) {
 	C.wrap_ImGuiWindow_SetAutoFitChildAxises(self.handle(), C.ImS8(v))
 }
 
@@ -13322,7 +13322,7 @@ func (self Window) AutoFitChildAxises() int {
 	return int(C.wrap_ImGuiWindow_GetAutoFitChildAxises(self.handle()))
 }
 
-func (self *Window) SetAutoFitOnlyGrows(v bool) {
+func (self Window) SetAutoFitOnlyGrows(v bool) {
 	C.wrap_ImGuiWindow_SetAutoFitOnlyGrows(self.handle(), C.bool(v))
 }
 
@@ -13330,7 +13330,7 @@ func (self Window) AutoFitOnlyGrows() bool {
 	return C.wrap_ImGuiWindow_GetAutoFitOnlyGrows(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetAutoPosLastDirection(v Dir) {
+func (self Window) SetAutoPosLastDirection(v Dir) {
 	C.wrap_ImGuiWindow_SetAutoPosLastDirection(self.handle(), C.ImGuiDir(v))
 }
 
@@ -13338,7 +13338,7 @@ func (self Window) AutoPosLastDirection() Dir {
 	return Dir(C.wrap_ImGuiWindow_GetAutoPosLastDirection(self.handle()))
 }
 
-func (self *Window) SetHiddenFramesCanSkipItems(v int) {
+func (self Window) SetHiddenFramesCanSkipItems(v int) {
 	C.wrap_ImGuiWindow_SetHiddenFramesCanSkipItems(self.handle(), C.ImS8(v))
 }
 
@@ -13346,7 +13346,7 @@ func (self Window) HiddenFramesCanSkipItems() int {
 	return int(C.wrap_ImGuiWindow_GetHiddenFramesCanSkipItems(self.handle()))
 }
 
-func (self *Window) SetHiddenFramesCannotSkipItems(v int) {
+func (self Window) SetHiddenFramesCannotSkipItems(v int) {
 	C.wrap_ImGuiWindow_SetHiddenFramesCannotSkipItems(self.handle(), C.ImS8(v))
 }
 
@@ -13354,7 +13354,7 @@ func (self Window) HiddenFramesCannotSkipItems() int {
 	return int(C.wrap_ImGuiWindow_GetHiddenFramesCannotSkipItems(self.handle()))
 }
 
-func (self *Window) SetHiddenFramesForRenderOnly(v int) {
+func (self Window) SetHiddenFramesForRenderOnly(v int) {
 	C.wrap_ImGuiWindow_SetHiddenFramesForRenderOnly(self.handle(), C.ImS8(v))
 }
 
@@ -13362,7 +13362,7 @@ func (self Window) HiddenFramesForRenderOnly() int {
 	return int(C.wrap_ImGuiWindow_GetHiddenFramesForRenderOnly(self.handle()))
 }
 
-func (self *Window) SetDisableInputsFrames(v int) {
+func (self Window) SetDisableInputsFrames(v int) {
 	C.wrap_ImGuiWindow_SetDisableInputsFrames(self.handle(), C.ImS8(v))
 }
 
@@ -13370,7 +13370,7 @@ func (self Window) DisableInputsFrames() int {
 	return int(C.wrap_ImGuiWindow_GetDisableInputsFrames(self.handle()))
 }
 
-func (self *Window) SetSetWindowPosAllowFlags(v Cond) {
+func (self Window) SetSetWindowPosAllowFlags(v Cond) {
 	C.wrap_ImGuiWindow_SetSetWindowPosAllowFlags(self.handle(), C.ImGuiCond(v))
 }
 
@@ -13378,7 +13378,7 @@ func (self Window) SetWindowPosAllowFlags() Cond {
 	return Cond(C.wrap_ImGuiWindow_GetSetWindowPosAllowFlags(self.handle()))
 }
 
-func (self *Window) SetSetWindowSizeAllowFlags(v Cond) {
+func (self Window) SetSetWindowSizeAllowFlags(v Cond) {
 	C.wrap_ImGuiWindow_SetSetWindowSizeAllowFlags(self.handle(), C.ImGuiCond(v))
 }
 
@@ -13386,7 +13386,7 @@ func (self Window) SetWindowSizeAllowFlags() Cond {
 	return Cond(C.wrap_ImGuiWindow_GetSetWindowSizeAllowFlags(self.handle()))
 }
 
-func (self *Window) SetSetWindowCollapsedAllowFlags(v Cond) {
+func (self Window) SetSetWindowCollapsedAllowFlags(v Cond) {
 	C.wrap_ImGuiWindow_SetSetWindowCollapsedAllowFlags(self.handle(), C.ImGuiCond(v))
 }
 
@@ -13394,7 +13394,7 @@ func (self Window) SetWindowCollapsedAllowFlags() Cond {
 	return Cond(C.wrap_ImGuiWindow_GetSetWindowCollapsedAllowFlags(self.handle()))
 }
 
-func (self *Window) SetSetWindowDockAllowFlags(v Cond) {
+func (self Window) SetSetWindowDockAllowFlags(v Cond) {
 	C.wrap_ImGuiWindow_SetSetWindowDockAllowFlags(self.handle(), C.ImGuiCond(v))
 }
 
@@ -13402,7 +13402,7 @@ func (self Window) SetWindowDockAllowFlags() Cond {
 	return Cond(C.wrap_ImGuiWindow_GetSetWindowDockAllowFlags(self.handle()))
 }
 
-func (self *Window) SetSetWindowPosVal(v Vec2) {
+func (self Window) SetSetWindowPosVal(v Vec2) {
 	C.wrap_ImGuiWindow_SetSetWindowPosVal(self.handle(), v.toC())
 }
 
@@ -13412,7 +13412,7 @@ func (self Window) SetWindowPosVal() Vec2 {
 	return *out
 }
 
-func (self *Window) SetSetWindowPosPivot(v Vec2) {
+func (self Window) SetSetWindowPosPivot(v Vec2) {
 	C.wrap_ImGuiWindow_SetSetWindowPosPivot(self.handle(), v.toC())
 }
 
@@ -13426,7 +13426,7 @@ func (self Window) DC() WindowTempData {
 	return newWindowTempDataFromC(C.wrap_ImGuiWindow_GetDC(self.handle()))
 }
 
-func (self *Window) SetOuterRectClipped(v Rect) {
+func (self Window) SetOuterRectClipped(v Rect) {
 	C.wrap_ImGuiWindow_SetOuterRectClipped(self.handle(), v.toC())
 }
 
@@ -13436,7 +13436,7 @@ func (self Window) OuterRectClipped() Rect {
 	return *out
 }
 
-func (self *Window) SetInnerRect(v Rect) {
+func (self Window) SetInnerRect(v Rect) {
 	C.wrap_ImGuiWindow_SetInnerRect(self.handle(), v.toC())
 }
 
@@ -13446,7 +13446,7 @@ func (self Window) InnerRect() Rect {
 	return *out
 }
 
-func (self *Window) SetInnerClipRect(v Rect) {
+func (self Window) SetInnerClipRect(v Rect) {
 	C.wrap_ImGuiWindow_SetInnerClipRect(self.handle(), v.toC())
 }
 
@@ -13456,7 +13456,7 @@ func (self Window) InnerClipRect() Rect {
 	return *out
 }
 
-func (self *Window) SetWorkRect(v Rect) {
+func (self Window) SetWorkRect(v Rect) {
 	C.wrap_ImGuiWindow_SetWorkRect(self.handle(), v.toC())
 }
 
@@ -13466,7 +13466,7 @@ func (self Window) WorkRect() Rect {
 	return *out
 }
 
-func (self *Window) SetParentWorkRect(v Rect) {
+func (self Window) SetParentWorkRect(v Rect) {
 	C.wrap_ImGuiWindow_SetParentWorkRect(self.handle(), v.toC())
 }
 
@@ -13476,7 +13476,7 @@ func (self Window) ParentWorkRect() Rect {
 	return *out
 }
 
-func (self *Window) SetClipRect(v Rect) {
+func (self Window) SetClipRect(v Rect) {
 	C.wrap_ImGuiWindow_SetClipRect(self.handle(), v.toC())
 }
 
@@ -13486,7 +13486,7 @@ func (self Window) ClipRect() Rect {
 	return *out
 }
 
-func (self *Window) SetContentRegionRect(v Rect) {
+func (self Window) SetContentRegionRect(v Rect) {
 	C.wrap_ImGuiWindow_SetContentRegionRect(self.handle(), v.toC())
 }
 
@@ -13496,7 +13496,7 @@ func (self Window) ContentRegionRect() Rect {
 	return *out
 }
 
-func (self *Window) SetLastFrameActive(v int32) {
+func (self Window) SetLastFrameActive(v int32) {
 	C.wrap_ImGuiWindow_SetLastFrameActive(self.handle(), C.int(v))
 }
 
@@ -13504,7 +13504,7 @@ func (self Window) LastFrameActive() int {
 	return int(C.wrap_ImGuiWindow_GetLastFrameActive(self.handle()))
 }
 
-func (self *Window) SetLastFrameJustFocused(v int32) {
+func (self Window) SetLastFrameJustFocused(v int32) {
 	C.wrap_ImGuiWindow_SetLastFrameJustFocused(self.handle(), C.int(v))
 }
 
@@ -13512,7 +13512,7 @@ func (self Window) LastFrameJustFocused() int {
 	return int(C.wrap_ImGuiWindow_GetLastFrameJustFocused(self.handle()))
 }
 
-func (self *Window) SetLastTimeActive(v float32) {
+func (self Window) SetLastTimeActive(v float32) {
 	C.wrap_ImGuiWindow_SetLastTimeActive(self.handle(), C.float(v))
 }
 
@@ -13520,7 +13520,7 @@ func (self Window) LastTimeActive() float32 {
 	return float32(C.wrap_ImGuiWindow_GetLastTimeActive(self.handle()))
 }
 
-func (self *Window) SetItemWidthDefault(v float32) {
+func (self Window) SetItemWidthDefault(v float32) {
 	C.wrap_ImGuiWindow_SetItemWidthDefault(self.handle(), C.float(v))
 }
 
@@ -13532,7 +13532,7 @@ func (self Window) StateStorage() Storage {
 	return newStorageFromC(C.wrap_ImGuiWindow_GetStateStorage(self.handle()))
 }
 
-func (self *Window) SetFontWindowScale(v float32) {
+func (self Window) SetFontWindowScale(v float32) {
 	C.wrap_ImGuiWindow_SetFontWindowScale(self.handle(), C.float(v))
 }
 
@@ -13540,7 +13540,7 @@ func (self Window) FontWindowScale() float32 {
 	return float32(C.wrap_ImGuiWindow_GetFontWindowScale(self.handle()))
 }
 
-func (self *Window) SetFontDpiScale(v float32) {
+func (self Window) SetFontDpiScale(v float32) {
 	C.wrap_ImGuiWindow_SetFontDpiScale(self.handle(), C.float(v))
 }
 
@@ -13548,7 +13548,7 @@ func (self Window) FontDpiScale() float32 {
 	return float32(C.wrap_ImGuiWindow_GetFontDpiScale(self.handle()))
 }
 
-func (self *Window) SetSettingsOffset(v int32) {
+func (self Window) SetSettingsOffset(v int32) {
 	C.wrap_ImGuiWindow_SetSettingsOffset(self.handle(), C.int(v))
 }
 
@@ -13556,7 +13556,7 @@ func (self Window) SettingsOffset() int {
 	return int(C.wrap_ImGuiWindow_GetSettingsOffset(self.handle()))
 }
 
-func (self *Window) SetDrawList(v DrawList) {
+func (self Window) SetDrawList(v DrawList) {
 	C.wrap_ImGuiWindow_SetDrawList(self.handle(), v.handle())
 }
 
@@ -13568,7 +13568,7 @@ func (self Window) DrawListInst() DrawList {
 	return newDrawListFromC(C.wrap_ImGuiWindow_GetDrawListInst(self.handle()))
 }
 
-func (self *Window) SetParentWindow(v Window) {
+func (self Window) SetParentWindow(v Window) {
 	C.wrap_ImGuiWindow_SetParentWindow(self.handle(), v.handle())
 }
 
@@ -13576,7 +13576,7 @@ func (self Window) ParentWindow() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiWindow_GetParentWindow(self.handle())))
 }
 
-func (self *Window) SetParentWindowInBeginStack(v Window) {
+func (self Window) SetParentWindowInBeginStack(v Window) {
 	C.wrap_ImGuiWindow_SetParentWindowInBeginStack(self.handle(), v.handle())
 }
 
@@ -13584,7 +13584,7 @@ func (self Window) ParentWindowInBeginStack() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiWindow_GetParentWindowInBeginStack(self.handle())))
 }
 
-func (self *Window) SetRootWindow(v Window) {
+func (self Window) SetRootWindow(v Window) {
 	C.wrap_ImGuiWindow_SetRootWindow(self.handle(), v.handle())
 }
 
@@ -13592,7 +13592,7 @@ func (self Window) RootWindow() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiWindow_GetRootWindow(self.handle())))
 }
 
-func (self *Window) SetRootWindowPopupTree(v Window) {
+func (self Window) SetRootWindowPopupTree(v Window) {
 	C.wrap_ImGuiWindow_SetRootWindowPopupTree(self.handle(), v.handle())
 }
 
@@ -13600,7 +13600,7 @@ func (self Window) RootWindowPopupTree() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiWindow_GetRootWindowPopupTree(self.handle())))
 }
 
-func (self *Window) SetRootWindowDockTree(v Window) {
+func (self Window) SetRootWindowDockTree(v Window) {
 	C.wrap_ImGuiWindow_SetRootWindowDockTree(self.handle(), v.handle())
 }
 
@@ -13608,7 +13608,7 @@ func (self Window) RootWindowDockTree() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiWindow_GetRootWindowDockTree(self.handle())))
 }
 
-func (self *Window) SetRootWindowForTitleBarHighlight(v Window) {
+func (self Window) SetRootWindowForTitleBarHighlight(v Window) {
 	C.wrap_ImGuiWindow_SetRootWindowForTitleBarHighlight(self.handle(), v.handle())
 }
 
@@ -13616,7 +13616,7 @@ func (self Window) RootWindowForTitleBarHighlight() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiWindow_GetRootWindowForTitleBarHighlight(self.handle())))
 }
 
-func (self *Window) SetRootWindowForNav(v Window) {
+func (self Window) SetRootWindowForNav(v Window) {
 	C.wrap_ImGuiWindow_SetRootWindowForNav(self.handle(), v.handle())
 }
 
@@ -13624,7 +13624,7 @@ func (self Window) RootWindowForNav() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiWindow_GetRootWindowForNav(self.handle())))
 }
 
-func (self *Window) SetNavLastChildNavWindow(v Window) {
+func (self Window) SetNavLastChildNavWindow(v Window) {
 	C.wrap_ImGuiWindow_SetNavLastChildNavWindow(self.handle(), v.handle())
 }
 
@@ -13632,7 +13632,7 @@ func (self Window) NavLastChildNavWindow() Window {
 	return (Window)(unsafe.Pointer(C.wrap_ImGuiWindow_GetNavLastChildNavWindow(self.handle())))
 }
 
-func (self *Window) SetMemoryDrawListIdxCapacity(v int32) {
+func (self Window) SetMemoryDrawListIdxCapacity(v int32) {
 	C.wrap_ImGuiWindow_SetMemoryDrawListIdxCapacity(self.handle(), C.int(v))
 }
 
@@ -13640,7 +13640,7 @@ func (self Window) MemoryDrawListIdxCapacity() int {
 	return int(C.wrap_ImGuiWindow_GetMemoryDrawListIdxCapacity(self.handle()))
 }
 
-func (self *Window) SetMemoryDrawListVtxCapacity(v int32) {
+func (self Window) SetMemoryDrawListVtxCapacity(v int32) {
 	C.wrap_ImGuiWindow_SetMemoryDrawListVtxCapacity(self.handle(), C.int(v))
 }
 
@@ -13648,7 +13648,7 @@ func (self Window) MemoryDrawListVtxCapacity() int {
 	return int(C.wrap_ImGuiWindow_GetMemoryDrawListVtxCapacity(self.handle()))
 }
 
-func (self *Window) SetMemoryCompacted(v bool) {
+func (self Window) SetMemoryCompacted(v bool) {
 	C.wrap_ImGuiWindow_SetMemoryCompacted(self.handle(), C.bool(v))
 }
 
@@ -13656,7 +13656,7 @@ func (self Window) MemoryCompacted() bool {
 	return C.wrap_ImGuiWindow_GetMemoryCompacted(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetDockIsActive(v bool) {
+func (self Window) SetDockIsActive(v bool) {
 	C.wrap_ImGuiWindow_SetDockIsActive(self.handle(), C.bool(v))
 }
 
@@ -13664,7 +13664,7 @@ func (self Window) DockIsActive() bool {
 	return C.wrap_ImGuiWindow_GetDockIsActive(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetDockNodeIsVisible(v bool) {
+func (self Window) SetDockNodeIsVisible(v bool) {
 	C.wrap_ImGuiWindow_SetDockNodeIsVisible(self.handle(), C.bool(v))
 }
 
@@ -13672,7 +13672,7 @@ func (self Window) DockNodeIsVisible() bool {
 	return C.wrap_ImGuiWindow_GetDockNodeIsVisible(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetDockTabIsVisible(v bool) {
+func (self Window) SetDockTabIsVisible(v bool) {
 	C.wrap_ImGuiWindow_SetDockTabIsVisible(self.handle(), C.bool(v))
 }
 
@@ -13680,7 +13680,7 @@ func (self Window) DockTabIsVisible() bool {
 	return C.wrap_ImGuiWindow_GetDockTabIsVisible(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetDockTabWantClose(v bool) {
+func (self Window) SetDockTabWantClose(v bool) {
 	C.wrap_ImGuiWindow_SetDockTabWantClose(self.handle(), C.bool(v))
 }
 
@@ -13688,7 +13688,7 @@ func (self Window) DockTabWantClose() bool {
 	return C.wrap_ImGuiWindow_GetDockTabWantClose(self.handle()) == C.bool(true)
 }
 
-func (self *Window) SetDockOrder(v int) {
+func (self Window) SetDockOrder(v int) {
 	C.wrap_ImGuiWindow_SetDockOrder(self.handle(), C.short(v))
 }
 
@@ -13700,7 +13700,7 @@ func (self Window) DockStyle() WindowDockStyle {
 	return newWindowDockStyleFromC(C.wrap_ImGuiWindow_GetDockStyle(self.handle()))
 }
 
-func (self *Window) SetDockNode(v DockNode) {
+func (self Window) SetDockNode(v DockNode) {
 	C.wrap_ImGuiWindow_SetDockNode(self.handle(), v.handle())
 }
 
@@ -13708,7 +13708,7 @@ func (self Window) DockNode() DockNode {
 	return (DockNode)(unsafe.Pointer(C.wrap_ImGuiWindow_GetDockNode(self.handle())))
 }
 
-func (self *Window) SetDockNodeAsHost(v DockNode) {
+func (self Window) SetDockNodeAsHost(v DockNode) {
 	C.wrap_ImGuiWindow_SetDockNodeAsHost(self.handle(), v.handle())
 }
 
@@ -13716,7 +13716,7 @@ func (self Window) DockNodeAsHost() DockNode {
 	return (DockNode)(unsafe.Pointer(C.wrap_ImGuiWindow_GetDockNodeAsHost(self.handle())))
 }
 
-func (self *Window) SetDockId(v ID) {
+func (self Window) SetDockId(v ID) {
 	C.wrap_ImGuiWindow_SetDockId(self.handle(), C.ImGuiID(v))
 }
 
@@ -13724,7 +13724,7 @@ func (self Window) DockId() ID {
 	return ID(C.wrap_ImGuiWindow_GetDockId(self.handle()))
 }
 
-func (self *Window) SetDockTabItemStatusFlags(v ItemStatusFlags) {
+func (self Window) SetDockTabItemStatusFlags(v ItemStatusFlags) {
 	C.wrap_ImGuiWindow_SetDockTabItemStatusFlags(self.handle(), C.ImGuiItemStatusFlags(v))
 }
 
@@ -13732,7 +13732,7 @@ func (self Window) DockTabItemStatusFlags() ItemStatusFlags {
 	return ItemStatusFlags(C.wrap_ImGuiWindow_GetDockTabItemStatusFlags(self.handle()))
 }
 
-func (self *Window) SetDockTabItemRect(v Rect) {
+func (self Window) SetDockTabItemRect(v Rect) {
 	C.wrap_ImGuiWindow_SetDockTabItemRect(self.handle(), v.toC())
 }
 
@@ -13742,7 +13742,7 @@ func (self Window) DockTabItemRect() Rect {
 	return *out
 }
 
-func (self *WindowClass) SetClassId(v ID) {
+func (self WindowClass) SetClassId(v ID) {
 	C.wrap_ImGuiWindowClass_SetClassId(self.handle(), C.ImGuiID(v))
 }
 
@@ -13750,7 +13750,7 @@ func (self WindowClass) ClassId() ID {
 	return ID(C.wrap_ImGuiWindowClass_GetClassId(self.handle()))
 }
 
-func (self *WindowClass) SetParentViewportId(v ID) {
+func (self WindowClass) SetParentViewportId(v ID) {
 	C.wrap_ImGuiWindowClass_SetParentViewportId(self.handle(), C.ImGuiID(v))
 }
 
@@ -13758,7 +13758,7 @@ func (self WindowClass) ParentViewportId() ID {
 	return ID(C.wrap_ImGuiWindowClass_GetParentViewportId(self.handle()))
 }
 
-func (self *WindowClass) SetViewportFlagsOverrideSet(v ViewportFlags) {
+func (self WindowClass) SetViewportFlagsOverrideSet(v ViewportFlags) {
 	C.wrap_ImGuiWindowClass_SetViewportFlagsOverrideSet(self.handle(), C.ImGuiViewportFlags(v))
 }
 
@@ -13766,7 +13766,7 @@ func (self WindowClass) ViewportFlagsOverrideSet() ViewportFlags {
 	return ViewportFlags(C.wrap_ImGuiWindowClass_GetViewportFlagsOverrideSet(self.handle()))
 }
 
-func (self *WindowClass) SetViewportFlagsOverrideClear(v ViewportFlags) {
+func (self WindowClass) SetViewportFlagsOverrideClear(v ViewportFlags) {
 	C.wrap_ImGuiWindowClass_SetViewportFlagsOverrideClear(self.handle(), C.ImGuiViewportFlags(v))
 }
 
@@ -13774,7 +13774,7 @@ func (self WindowClass) ViewportFlagsOverrideClear() ViewportFlags {
 	return ViewportFlags(C.wrap_ImGuiWindowClass_GetViewportFlagsOverrideClear(self.handle()))
 }
 
-func (self *WindowClass) SetTabItemFlagsOverrideSet(v TabItemFlags) {
+func (self WindowClass) SetTabItemFlagsOverrideSet(v TabItemFlags) {
 	C.wrap_ImGuiWindowClass_SetTabItemFlagsOverrideSet(self.handle(), C.ImGuiTabItemFlags(v))
 }
 
@@ -13782,7 +13782,7 @@ func (self WindowClass) TabItemFlagsOverrideSet() TabItemFlags {
 	return TabItemFlags(C.wrap_ImGuiWindowClass_GetTabItemFlagsOverrideSet(self.handle()))
 }
 
-func (self *WindowClass) SetDockNodeFlagsOverrideSet(v DockNodeFlags) {
+func (self WindowClass) SetDockNodeFlagsOverrideSet(v DockNodeFlags) {
 	C.wrap_ImGuiWindowClass_SetDockNodeFlagsOverrideSet(self.handle(), C.ImGuiDockNodeFlags(v))
 }
 
@@ -13790,7 +13790,7 @@ func (self WindowClass) DockNodeFlagsOverrideSet() DockNodeFlags {
 	return DockNodeFlags(C.wrap_ImGuiWindowClass_GetDockNodeFlagsOverrideSet(self.handle()))
 }
 
-func (self *WindowClass) SetDockingAlwaysTabBar(v bool) {
+func (self WindowClass) SetDockingAlwaysTabBar(v bool) {
 	C.wrap_ImGuiWindowClass_SetDockingAlwaysTabBar(self.handle(), C.bool(v))
 }
 
@@ -13798,7 +13798,7 @@ func (self WindowClass) DockingAlwaysTabBar() bool {
 	return C.wrap_ImGuiWindowClass_GetDockingAlwaysTabBar(self.handle()) == C.bool(true)
 }
 
-func (self *WindowClass) SetDockingAllowUnclassed(v bool) {
+func (self WindowClass) SetDockingAllowUnclassed(v bool) {
 	C.wrap_ImGuiWindowClass_SetDockingAllowUnclassed(self.handle(), C.bool(v))
 }
 
@@ -13806,7 +13806,7 @@ func (self WindowClass) DockingAllowUnclassed() bool {
 	return C.wrap_ImGuiWindowClass_GetDockingAllowUnclassed(self.handle()) == C.bool(true)
 }
 
-func (self *WindowSettings) SetID(v ID) {
+func (self WindowSettings) SetID(v ID) {
 	C.wrap_ImGuiWindowSettings_SetID(self.handle(), C.ImGuiID(v))
 }
 
@@ -13814,7 +13814,7 @@ func (self WindowSettings) ID() ID {
 	return ID(C.wrap_ImGuiWindowSettings_GetID(self.handle()))
 }
 
-func (self *WindowSettings) SetViewportId(v ID) {
+func (self WindowSettings) SetViewportId(v ID) {
 	C.wrap_ImGuiWindowSettings_SetViewportId(self.handle(), C.ImGuiID(v))
 }
 
@@ -13822,7 +13822,7 @@ func (self WindowSettings) ViewportId() ID {
 	return ID(C.wrap_ImGuiWindowSettings_GetViewportId(self.handle()))
 }
 
-func (self *WindowSettings) SetDockId(v ID) {
+func (self WindowSettings) SetDockId(v ID) {
 	C.wrap_ImGuiWindowSettings_SetDockId(self.handle(), C.ImGuiID(v))
 }
 
@@ -13830,7 +13830,7 @@ func (self WindowSettings) DockId() ID {
 	return ID(C.wrap_ImGuiWindowSettings_GetDockId(self.handle()))
 }
 
-func (self *WindowSettings) SetClassId(v ID) {
+func (self WindowSettings) SetClassId(v ID) {
 	C.wrap_ImGuiWindowSettings_SetClassId(self.handle(), C.ImGuiID(v))
 }
 
@@ -13838,7 +13838,7 @@ func (self WindowSettings) ClassId() ID {
 	return ID(C.wrap_ImGuiWindowSettings_GetClassId(self.handle()))
 }
 
-func (self *WindowSettings) SetDockOrder(v int) {
+func (self WindowSettings) SetDockOrder(v int) {
 	C.wrap_ImGuiWindowSettings_SetDockOrder(self.handle(), C.short(v))
 }
 
@@ -13846,7 +13846,7 @@ func (self WindowSettings) DockOrder() int {
 	return int(C.wrap_ImGuiWindowSettings_GetDockOrder(self.handle()))
 }
 
-func (self *WindowSettings) SetCollapsed(v bool) {
+func (self WindowSettings) SetCollapsed(v bool) {
 	C.wrap_ImGuiWindowSettings_SetCollapsed(self.handle(), C.bool(v))
 }
 
@@ -13854,7 +13854,7 @@ func (self WindowSettings) Collapsed() bool {
 	return C.wrap_ImGuiWindowSettings_GetCollapsed(self.handle()) == C.bool(true)
 }
 
-func (self *WindowSettings) SetWantApply(v bool) {
+func (self WindowSettings) SetWantApply(v bool) {
 	C.wrap_ImGuiWindowSettings_SetWantApply(self.handle(), C.bool(v))
 }
 
@@ -13862,7 +13862,7 @@ func (self WindowSettings) WantApply() bool {
 	return C.wrap_ImGuiWindowSettings_GetWantApply(self.handle()) == C.bool(true)
 }
 
-func (self *WindowStackData) SetWindow(v Window) {
+func (self WindowStackData) SetWindow(v Window) {
 	C.wrap_ImGuiWindowStackData_SetWindow(self.handle(), v.handle())
 }
 
@@ -13878,7 +13878,7 @@ func (self WindowStackData) StackSizesOnBegin() StackSizes {
 	return newStackSizesFromC(C.wrap_ImGuiWindowStackData_GetStackSizesOnBegin(self.handle()))
 }
 
-func (self *WindowTempData) SetCursorPos(v Vec2) {
+func (self WindowTempData) SetCursorPos(v Vec2) {
 	C.wrap_ImGuiWindowTempData_SetCursorPos(self.handle(), v.toC())
 }
 
@@ -13888,7 +13888,7 @@ func (self WindowTempData) CursorPos() Vec2 {
 	return *out
 }
 
-func (self *WindowTempData) SetCursorPosPrevLine(v Vec2) {
+func (self WindowTempData) SetCursorPosPrevLine(v Vec2) {
 	C.wrap_ImGuiWindowTempData_SetCursorPosPrevLine(self.handle(), v.toC())
 }
 
@@ -13898,7 +13898,7 @@ func (self WindowTempData) CursorPosPrevLine() Vec2 {
 	return *out
 }
 
-func (self *WindowTempData) SetCursorStartPos(v Vec2) {
+func (self WindowTempData) SetCursorStartPos(v Vec2) {
 	C.wrap_ImGuiWindowTempData_SetCursorStartPos(self.handle(), v.toC())
 }
 
@@ -13908,7 +13908,7 @@ func (self WindowTempData) CursorStartPos() Vec2 {
 	return *out
 }
 
-func (self *WindowTempData) SetCursorMaxPos(v Vec2) {
+func (self WindowTempData) SetCursorMaxPos(v Vec2) {
 	C.wrap_ImGuiWindowTempData_SetCursorMaxPos(self.handle(), v.toC())
 }
 
@@ -13918,7 +13918,7 @@ func (self WindowTempData) CursorMaxPos() Vec2 {
 	return *out
 }
 
-func (self *WindowTempData) SetIdealMaxPos(v Vec2) {
+func (self WindowTempData) SetIdealMaxPos(v Vec2) {
 	C.wrap_ImGuiWindowTempData_SetIdealMaxPos(self.handle(), v.toC())
 }
 
@@ -13928,7 +13928,7 @@ func (self WindowTempData) IdealMaxPos() Vec2 {
 	return *out
 }
 
-func (self *WindowTempData) SetCurrLineSize(v Vec2) {
+func (self WindowTempData) SetCurrLineSize(v Vec2) {
 	C.wrap_ImGuiWindowTempData_SetCurrLineSize(self.handle(), v.toC())
 }
 
@@ -13938,7 +13938,7 @@ func (self WindowTempData) CurrLineSize() Vec2 {
 	return *out
 }
 
-func (self *WindowTempData) SetPrevLineSize(v Vec2) {
+func (self WindowTempData) SetPrevLineSize(v Vec2) {
 	C.wrap_ImGuiWindowTempData_SetPrevLineSize(self.handle(), v.toC())
 }
 
@@ -13948,7 +13948,7 @@ func (self WindowTempData) PrevLineSize() Vec2 {
 	return *out
 }
 
-func (self *WindowTempData) SetCurrLineTextBaseOffset(v float32) {
+func (self WindowTempData) SetCurrLineTextBaseOffset(v float32) {
 	C.wrap_ImGuiWindowTempData_SetCurrLineTextBaseOffset(self.handle(), C.float(v))
 }
 
@@ -13956,7 +13956,7 @@ func (self WindowTempData) CurrLineTextBaseOffset() float32 {
 	return float32(C.wrap_ImGuiWindowTempData_GetCurrLineTextBaseOffset(self.handle()))
 }
 
-func (self *WindowTempData) SetPrevLineTextBaseOffset(v float32) {
+func (self WindowTempData) SetPrevLineTextBaseOffset(v float32) {
 	C.wrap_ImGuiWindowTempData_SetPrevLineTextBaseOffset(self.handle(), C.float(v))
 }
 
@@ -13964,7 +13964,7 @@ func (self WindowTempData) PrevLineTextBaseOffset() float32 {
 	return float32(C.wrap_ImGuiWindowTempData_GetPrevLineTextBaseOffset(self.handle()))
 }
 
-func (self *WindowTempData) SetIsSameLine(v bool) {
+func (self WindowTempData) SetIsSameLine(v bool) {
 	C.wrap_ImGuiWindowTempData_SetIsSameLine(self.handle(), C.bool(v))
 }
 
@@ -13972,7 +13972,7 @@ func (self WindowTempData) IsSameLine() bool {
 	return C.wrap_ImGuiWindowTempData_GetIsSameLine(self.handle()) == C.bool(true)
 }
 
-func (self *WindowTempData) SetCursorStartPosLossyness(v Vec2) {
+func (self WindowTempData) SetCursorStartPosLossyness(v Vec2) {
 	C.wrap_ImGuiWindowTempData_SetCursorStartPosLossyness(self.handle(), v.toC())
 }
 
@@ -13982,7 +13982,7 @@ func (self WindowTempData) CursorStartPosLossyness() Vec2 {
 	return *out
 }
 
-func (self *WindowTempData) SetNavLayerCurrent(v NavLayer) {
+func (self WindowTempData) SetNavLayerCurrent(v NavLayer) {
 	C.wrap_ImGuiWindowTempData_SetNavLayerCurrent(self.handle(), C.ImGuiNavLayer(v))
 }
 
@@ -13990,7 +13990,7 @@ func (self WindowTempData) NavLayerCurrent() NavLayer {
 	return NavLayer(C.wrap_ImGuiWindowTempData_GetNavLayerCurrent(self.handle()))
 }
 
-func (self *WindowTempData) SetNavLayersActiveMask(v int) {
+func (self WindowTempData) SetNavLayersActiveMask(v int) {
 	C.wrap_ImGuiWindowTempData_SetNavLayersActiveMask(self.handle(), C.short(v))
 }
 
@@ -13998,7 +13998,7 @@ func (self WindowTempData) NavLayersActiveMask() int {
 	return int(C.wrap_ImGuiWindowTempData_GetNavLayersActiveMask(self.handle()))
 }
 
-func (self *WindowTempData) SetNavLayersActiveMaskNext(v int) {
+func (self WindowTempData) SetNavLayersActiveMaskNext(v int) {
 	C.wrap_ImGuiWindowTempData_SetNavLayersActiveMaskNext(self.handle(), C.short(v))
 }
 
@@ -14006,7 +14006,7 @@ func (self WindowTempData) NavLayersActiveMaskNext() int {
 	return int(C.wrap_ImGuiWindowTempData_GetNavLayersActiveMaskNext(self.handle()))
 }
 
-func (self *WindowTempData) SetNavFocusScopeIdCurrent(v ID) {
+func (self WindowTempData) SetNavFocusScopeIdCurrent(v ID) {
 	C.wrap_ImGuiWindowTempData_SetNavFocusScopeIdCurrent(self.handle(), C.ImGuiID(v))
 }
 
@@ -14014,7 +14014,7 @@ func (self WindowTempData) NavFocusScopeIdCurrent() ID {
 	return ID(C.wrap_ImGuiWindowTempData_GetNavFocusScopeIdCurrent(self.handle()))
 }
 
-func (self *WindowTempData) SetNavHideHighlightOneFrame(v bool) {
+func (self WindowTempData) SetNavHideHighlightOneFrame(v bool) {
 	C.wrap_ImGuiWindowTempData_SetNavHideHighlightOneFrame(self.handle(), C.bool(v))
 }
 
@@ -14022,7 +14022,7 @@ func (self WindowTempData) NavHideHighlightOneFrame() bool {
 	return C.wrap_ImGuiWindowTempData_GetNavHideHighlightOneFrame(self.handle()) == C.bool(true)
 }
 
-func (self *WindowTempData) SetNavHasScroll(v bool) {
+func (self WindowTempData) SetNavHasScroll(v bool) {
 	C.wrap_ImGuiWindowTempData_SetNavHasScroll(self.handle(), C.bool(v))
 }
 
@@ -14030,7 +14030,7 @@ func (self WindowTempData) NavHasScroll() bool {
 	return C.wrap_ImGuiWindowTempData_GetNavHasScroll(self.handle()) == C.bool(true)
 }
 
-func (self *WindowTempData) SetMenuBarAppending(v bool) {
+func (self WindowTempData) SetMenuBarAppending(v bool) {
 	C.wrap_ImGuiWindowTempData_SetMenuBarAppending(self.handle(), C.bool(v))
 }
 
@@ -14038,7 +14038,7 @@ func (self WindowTempData) MenuBarAppending() bool {
 	return C.wrap_ImGuiWindowTempData_GetMenuBarAppending(self.handle()) == C.bool(true)
 }
 
-func (self *WindowTempData) SetMenuBarOffset(v Vec2) {
+func (self WindowTempData) SetMenuBarOffset(v Vec2) {
 	C.wrap_ImGuiWindowTempData_SetMenuBarOffset(self.handle(), v.toC())
 }
 
@@ -14052,7 +14052,7 @@ func (self WindowTempData) MenuColumns() MenuColumns {
 	return newMenuColumnsFromC(C.wrap_ImGuiWindowTempData_GetMenuColumns(self.handle()))
 }
 
-func (self *WindowTempData) SetTreeDepth(v int32) {
+func (self WindowTempData) SetTreeDepth(v int32) {
 	C.wrap_ImGuiWindowTempData_SetTreeDepth(self.handle(), C.int(v))
 }
 
@@ -14060,7 +14060,7 @@ func (self WindowTempData) TreeDepth() int {
 	return int(C.wrap_ImGuiWindowTempData_GetTreeDepth(self.handle()))
 }
 
-func (self *WindowTempData) SetTreeJumpToParentOnPopMask(v uint32) {
+func (self WindowTempData) SetTreeJumpToParentOnPopMask(v uint32) {
 	C.wrap_ImGuiWindowTempData_SetTreeJumpToParentOnPopMask(self.handle(), C.ImU32(v))
 }
 
@@ -14068,7 +14068,7 @@ func (self WindowTempData) TreeJumpToParentOnPopMask() uint32 {
 	return uint32(C.wrap_ImGuiWindowTempData_GetTreeJumpToParentOnPopMask(self.handle()))
 }
 
-func (self *WindowTempData) SetStateStorage(v Storage) {
+func (self WindowTempData) SetStateStorage(v Storage) {
 	C.wrap_ImGuiWindowTempData_SetStateStorage(self.handle(), v.handle())
 }
 
@@ -14076,7 +14076,7 @@ func (self WindowTempData) StateStorage() Storage {
 	return (Storage)(unsafe.Pointer(C.wrap_ImGuiWindowTempData_GetStateStorage(self.handle())))
 }
 
-func (self *WindowTempData) SetCurrentColumns(v OldColumns) {
+func (self WindowTempData) SetCurrentColumns(v OldColumns) {
 	C.wrap_ImGuiWindowTempData_SetCurrentColumns(self.handle(), v.handle())
 }
 
@@ -14084,7 +14084,7 @@ func (self WindowTempData) CurrentColumns() OldColumns {
 	return (OldColumns)(unsafe.Pointer(C.wrap_ImGuiWindowTempData_GetCurrentColumns(self.handle())))
 }
 
-func (self *WindowTempData) SetCurrentTableIdx(v int32) {
+func (self WindowTempData) SetCurrentTableIdx(v int32) {
 	C.wrap_ImGuiWindowTempData_SetCurrentTableIdx(self.handle(), C.int(v))
 }
 
@@ -14092,7 +14092,7 @@ func (self WindowTempData) CurrentTableIdx() int {
 	return int(C.wrap_ImGuiWindowTempData_GetCurrentTableIdx(self.handle()))
 }
 
-func (self *WindowTempData) SetLayoutType(v LayoutType) {
+func (self WindowTempData) SetLayoutType(v LayoutType) {
 	C.wrap_ImGuiWindowTempData_SetLayoutType(self.handle(), C.ImGuiLayoutType(v))
 }
 
@@ -14100,7 +14100,7 @@ func (self WindowTempData) LayoutType() LayoutType {
 	return LayoutType(C.wrap_ImGuiWindowTempData_GetLayoutType(self.handle()))
 }
 
-func (self *WindowTempData) SetParentLayoutType(v LayoutType) {
+func (self WindowTempData) SetParentLayoutType(v LayoutType) {
 	C.wrap_ImGuiWindowTempData_SetParentLayoutType(self.handle(), C.ImGuiLayoutType(v))
 }
 
@@ -14108,7 +14108,7 @@ func (self WindowTempData) ParentLayoutType() LayoutType {
 	return LayoutType(C.wrap_ImGuiWindowTempData_GetParentLayoutType(self.handle()))
 }
 
-func (self *WindowTempData) SetItemWidth(v float32) {
+func (self WindowTempData) SetItemWidth(v float32) {
 	C.wrap_ImGuiWindowTempData_SetItemWidth(self.handle(), C.float(v))
 }
 
@@ -14116,7 +14116,7 @@ func (self WindowTempData) ItemWidth() float32 {
 	return float32(C.wrap_ImGuiWindowTempData_GetItemWidth(self.handle()))
 }
 
-func (self *WindowTempData) SetTextWrapPos(v float32) {
+func (self WindowTempData) SetTextWrapPos(v float32) {
 	C.wrap_ImGuiWindowTempData_SetTextWrapPos(self.handle(), C.float(v))
 }
 

--- a/cimplot_funcs.go
+++ b/cimplot_funcs.go
@@ -9201,7 +9201,7 @@ func PlotTagYBool(y float64, col Vec4) {
 	C.wrap_ImPlot_TagY_Bool(C.double(y), col.toC())
 }
 
-func (self *PlotAlignmentData) SetVertical(v bool) {
+func (self PlotAlignmentData) SetVertical(v bool) {
 	C.wrap_ImPlotAlignmentData_SetVertical(self.handle(), C.bool(v))
 }
 
@@ -9209,7 +9209,7 @@ func (self PlotAlignmentData) Vertical() bool {
 	return C.wrap_ImPlotAlignmentData_GetVertical(self.handle()) == C.bool(true)
 }
 
-func (self *PlotAlignmentData) SetPadA(v float32) {
+func (self PlotAlignmentData) SetPadA(v float32) {
 	C.wrap_ImPlotAlignmentData_SetPadA(self.handle(), C.float(v))
 }
 
@@ -9217,7 +9217,7 @@ func (self PlotAlignmentData) PadA() float32 {
 	return float32(C.wrap_ImPlotAlignmentData_GetPadA(self.handle()))
 }
 
-func (self *PlotAlignmentData) SetPadB(v float32) {
+func (self PlotAlignmentData) SetPadB(v float32) {
 	C.wrap_ImPlotAlignmentData_SetPadB(self.handle(), C.float(v))
 }
 
@@ -9225,7 +9225,7 @@ func (self PlotAlignmentData) PadB() float32 {
 	return float32(C.wrap_ImPlotAlignmentData_GetPadB(self.handle()))
 }
 
-func (self *PlotAlignmentData) SetPadAMax(v float32) {
+func (self PlotAlignmentData) SetPadAMax(v float32) {
 	C.wrap_ImPlotAlignmentData_SetPadAMax(self.handle(), C.float(v))
 }
 
@@ -9233,7 +9233,7 @@ func (self PlotAlignmentData) PadAMax() float32 {
 	return float32(C.wrap_ImPlotAlignmentData_GetPadAMax(self.handle()))
 }
 
-func (self *PlotAlignmentData) SetPadBMax(v float32) {
+func (self PlotAlignmentData) SetPadBMax(v float32) {
 	C.wrap_ImPlotAlignmentData_SetPadBMax(self.handle(), C.float(v))
 }
 
@@ -9241,7 +9241,7 @@ func (self PlotAlignmentData) PadBMax() float32 {
 	return float32(C.wrap_ImPlotAlignmentData_GetPadBMax(self.handle()))
 }
 
-func (self *PlotAnnotation) SetPos(v Vec2) {
+func (self PlotAnnotation) SetPos(v Vec2) {
 	C.wrap_ImPlotAnnotation_SetPos(self.handle(), v.toC())
 }
 
@@ -9251,7 +9251,7 @@ func (self PlotAnnotation) Pos() Vec2 {
 	return *out
 }
 
-func (self *PlotAnnotation) SetOffset(v Vec2) {
+func (self PlotAnnotation) SetOffset(v Vec2) {
 	C.wrap_ImPlotAnnotation_SetOffset(self.handle(), v.toC())
 }
 
@@ -9261,7 +9261,7 @@ func (self PlotAnnotation) Offset() Vec2 {
 	return *out
 }
 
-func (self *PlotAnnotation) SetColorBg(v uint32) {
+func (self PlotAnnotation) SetColorBg(v uint32) {
 	C.wrap_ImPlotAnnotation_SetColorBg(self.handle(), C.ImU32(v))
 }
 
@@ -9269,7 +9269,7 @@ func (self PlotAnnotation) ColorBg() uint32 {
 	return uint32(C.wrap_ImPlotAnnotation_GetColorBg(self.handle()))
 }
 
-func (self *PlotAnnotation) SetColorFg(v uint32) {
+func (self PlotAnnotation) SetColorFg(v uint32) {
 	C.wrap_ImPlotAnnotation_SetColorFg(self.handle(), C.ImU32(v))
 }
 
@@ -9277,7 +9277,7 @@ func (self PlotAnnotation) ColorFg() uint32 {
 	return uint32(C.wrap_ImPlotAnnotation_GetColorFg(self.handle()))
 }
 
-func (self *PlotAnnotation) SetTextOffset(v int32) {
+func (self PlotAnnotation) SetTextOffset(v int32) {
 	C.wrap_ImPlotAnnotation_SetTextOffset(self.handle(), C.int(v))
 }
 
@@ -9285,7 +9285,7 @@ func (self PlotAnnotation) TextOffset() int {
 	return int(C.wrap_ImPlotAnnotation_GetTextOffset(self.handle()))
 }
 
-func (self *PlotAnnotation) SetClamp(v bool) {
+func (self PlotAnnotation) SetClamp(v bool) {
 	C.wrap_ImPlotAnnotation_SetClamp(self.handle(), C.bool(v))
 }
 
@@ -9297,7 +9297,7 @@ func (self PlotAnnotationCollection) TextBuffer() TextBuffer {
 	return newTextBufferFromC(C.wrap_ImPlotAnnotationCollection_GetTextBuffer(self.handle()))
 }
 
-func (self *PlotAnnotationCollection) SetSize(v int32) {
+func (self PlotAnnotationCollection) SetSize(v int32) {
 	C.wrap_ImPlotAnnotationCollection_SetSize(self.handle(), C.int(v))
 }
 
@@ -9305,7 +9305,7 @@ func (self PlotAnnotationCollection) Size() int {
 	return int(C.wrap_ImPlotAnnotationCollection_GetSize(self.handle()))
 }
 
-func (self *PlotAxis) SetID(v ID) {
+func (self PlotAxis) SetID(v ID) {
 	C.wrap_ImPlotAxis_SetID(self.handle(), C.ImGuiID(v))
 }
 
@@ -9313,7 +9313,7 @@ func (self PlotAxis) ID() ID {
 	return ID(C.wrap_ImPlotAxis_GetID(self.handle()))
 }
 
-func (self *PlotAxis) SetFlags(v PlotAxisFlags) {
+func (self PlotAxis) SetFlags(v PlotAxisFlags) {
 	C.wrap_ImPlotAxis_SetFlags(self.handle(), C.ImPlotAxisFlags(v))
 }
 
@@ -9321,7 +9321,7 @@ func (self PlotAxis) Flags() PlotAxisFlags {
 	return PlotAxisFlags(C.wrap_ImPlotAxis_GetFlags(self.handle()))
 }
 
-func (self *PlotAxis) SetPreviousFlags(v PlotAxisFlags) {
+func (self PlotAxis) SetPreviousFlags(v PlotAxisFlags) {
 	C.wrap_ImPlotAxis_SetPreviousFlags(self.handle(), C.ImPlotAxisFlags(v))
 }
 
@@ -9333,7 +9333,7 @@ func (self PlotAxis) Range() PlotRange {
 	return newPlotRangeFromC(C.wrap_ImPlotAxis_GetRange(self.handle()))
 }
 
-func (self *PlotAxis) SetRangeCond(v PlotCond) {
+func (self PlotAxis) SetRangeCond(v PlotCond) {
 	C.wrap_ImPlotAxis_SetRangeCond(self.handle(), C.ImPlotCond(v))
 }
 
@@ -9341,7 +9341,7 @@ func (self PlotAxis) RangeCond() PlotCond {
 	return PlotCond(C.wrap_ImPlotAxis_GetRangeCond(self.handle()))
 }
 
-func (self *PlotAxis) SetScale(v PlotScale) {
+func (self PlotAxis) SetScale(v PlotScale) {
 	C.wrap_ImPlotAxis_SetScale(self.handle(), C.ImPlotScale(v))
 }
 
@@ -9353,7 +9353,7 @@ func (self PlotAxis) FitExtents() PlotRange {
 	return newPlotRangeFromC(C.wrap_ImPlotAxis_GetFitExtents(self.handle()))
 }
 
-func (self *PlotAxis) SetOrthoAxis(v PlotAxis) {
+func (self PlotAxis) SetOrthoAxis(v PlotAxis) {
 	C.wrap_ImPlotAxis_SetOrthoAxis(self.handle(), v.handle())
 }
 
@@ -9373,7 +9373,7 @@ func (self PlotAxis) Ticker() PlotTicker {
 	return newPlotTickerFromC(C.wrap_ImPlotAxis_GetTicker(self.handle()))
 }
 
-func (self *PlotAxis) SetFormatterData(v unsafe.Pointer) {
+func (self PlotAxis) SetFormatterData(v unsafe.Pointer) {
 	C.wrap_ImPlotAxis_SetFormatterData(self.handle(), (v))
 }
 
@@ -9381,21 +9381,21 @@ func (self PlotAxis) FormatterData() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImPlotAxis_GetFormatterData(self.handle()))
 }
 
-func (self *PlotAxis) SetLinkedMin(v *float64) {
+func (self PlotAxis) SetLinkedMin(v *float64) {
 	vArg, vFin := wrapNumberPtr[C.double, float64](v)
 	defer vFin()
 
 	C.wrap_ImPlotAxis_SetLinkedMin(self.handle(), vArg)
 }
 
-func (self *PlotAxis) SetLinkedMax(v *float64) {
+func (self PlotAxis) SetLinkedMax(v *float64) {
 	vArg, vFin := wrapNumberPtr[C.double, float64](v)
 	defer vFin()
 
 	C.wrap_ImPlotAxis_SetLinkedMax(self.handle(), vArg)
 }
 
-func (self *PlotAxis) SetPickerLevel(v int32) {
+func (self PlotAxis) SetPickerLevel(v int32) {
 	C.wrap_ImPlotAxis_SetPickerLevel(self.handle(), C.int(v))
 }
 
@@ -9411,7 +9411,7 @@ func (self PlotAxis) PickerTimeMax() PlotTime {
 	return newPlotTimeFromC(C.wrap_ImPlotAxis_GetPickerTimeMax(self.handle()))
 }
 
-func (self *PlotAxis) SetTransformData(v unsafe.Pointer) {
+func (self PlotAxis) SetTransformData(v unsafe.Pointer) {
 	C.wrap_ImPlotAxis_SetTransformData(self.handle(), (v))
 }
 
@@ -9419,7 +9419,7 @@ func (self PlotAxis) TransformData() unsafe.Pointer {
 	return unsafe.Pointer(C.wrap_ImPlotAxis_GetTransformData(self.handle()))
 }
 
-func (self *PlotAxis) SetPixelMin(v float32) {
+func (self PlotAxis) SetPixelMin(v float32) {
 	C.wrap_ImPlotAxis_SetPixelMin(self.handle(), C.float(v))
 }
 
@@ -9427,7 +9427,7 @@ func (self PlotAxis) PixelMin() float32 {
 	return float32(C.wrap_ImPlotAxis_GetPixelMin(self.handle()))
 }
 
-func (self *PlotAxis) SetPixelMax(v float32) {
+func (self PlotAxis) SetPixelMax(v float32) {
 	C.wrap_ImPlotAxis_SetPixelMax(self.handle(), C.float(v))
 }
 
@@ -9435,7 +9435,7 @@ func (self PlotAxis) PixelMax() float32 {
 	return float32(C.wrap_ImPlotAxis_GetPixelMax(self.handle()))
 }
 
-func (self *PlotAxis) SetScaleMin(v float64) {
+func (self PlotAxis) SetScaleMin(v float64) {
 	C.wrap_ImPlotAxis_SetScaleMin(self.handle(), C.double(v))
 }
 
@@ -9443,7 +9443,7 @@ func (self PlotAxis) ScaleMin() float64 {
 	return float64(C.wrap_ImPlotAxis_GetScaleMin(self.handle()))
 }
 
-func (self *PlotAxis) SetScaleMax(v float64) {
+func (self PlotAxis) SetScaleMax(v float64) {
 	C.wrap_ImPlotAxis_SetScaleMax(self.handle(), C.double(v))
 }
 
@@ -9451,7 +9451,7 @@ func (self PlotAxis) ScaleMax() float64 {
 	return float64(C.wrap_ImPlotAxis_GetScaleMax(self.handle()))
 }
 
-func (self *PlotAxis) SetScaleToPixel(v float64) {
+func (self PlotAxis) SetScaleToPixel(v float64) {
 	C.wrap_ImPlotAxis_SetScaleToPixel(self.handle(), C.double(v))
 }
 
@@ -9459,7 +9459,7 @@ func (self PlotAxis) ScaleToPixel() float64 {
 	return float64(C.wrap_ImPlotAxis_GetScaleToPixel(self.handle()))
 }
 
-func (self *PlotAxis) SetDatum1(v float32) {
+func (self PlotAxis) SetDatum1(v float32) {
 	C.wrap_ImPlotAxis_SetDatum1(self.handle(), C.float(v))
 }
 
@@ -9467,7 +9467,7 @@ func (self PlotAxis) Datum1() float32 {
 	return float32(C.wrap_ImPlotAxis_GetDatum1(self.handle()))
 }
 
-func (self *PlotAxis) SetDatum2(v float32) {
+func (self PlotAxis) SetDatum2(v float32) {
 	C.wrap_ImPlotAxis_SetDatum2(self.handle(), C.float(v))
 }
 
@@ -9475,7 +9475,7 @@ func (self PlotAxis) Datum2() float32 {
 	return float32(C.wrap_ImPlotAxis_GetDatum2(self.handle()))
 }
 
-func (self *PlotAxis) SetHoverRect(v Rect) {
+func (self PlotAxis) SetHoverRect(v Rect) {
 	C.wrap_ImPlotAxis_SetHoverRect(self.handle(), v.toC())
 }
 
@@ -9485,7 +9485,7 @@ func (self PlotAxis) HoverRect() Rect {
 	return *out
 }
 
-func (self *PlotAxis) SetLabelOffset(v int32) {
+func (self PlotAxis) SetLabelOffset(v int32) {
 	C.wrap_ImPlotAxis_SetLabelOffset(self.handle(), C.int(v))
 }
 
@@ -9493,7 +9493,7 @@ func (self PlotAxis) LabelOffset() int {
 	return int(C.wrap_ImPlotAxis_GetLabelOffset(self.handle()))
 }
 
-func (self *PlotAxis) SetColorMaj(v uint32) {
+func (self PlotAxis) SetColorMaj(v uint32) {
 	C.wrap_ImPlotAxis_SetColorMaj(self.handle(), C.ImU32(v))
 }
 
@@ -9501,7 +9501,7 @@ func (self PlotAxis) ColorMaj() uint32 {
 	return uint32(C.wrap_ImPlotAxis_GetColorMaj(self.handle()))
 }
 
-func (self *PlotAxis) SetColorMin(v uint32) {
+func (self PlotAxis) SetColorMin(v uint32) {
 	C.wrap_ImPlotAxis_SetColorMin(self.handle(), C.ImU32(v))
 }
 
@@ -9509,7 +9509,7 @@ func (self PlotAxis) ColorMin() uint32 {
 	return uint32(C.wrap_ImPlotAxis_GetColorMin(self.handle()))
 }
 
-func (self *PlotAxis) SetColorTick(v uint32) {
+func (self PlotAxis) SetColorTick(v uint32) {
 	C.wrap_ImPlotAxis_SetColorTick(self.handle(), C.ImU32(v))
 }
 
@@ -9517,7 +9517,7 @@ func (self PlotAxis) ColorTick() uint32 {
 	return uint32(C.wrap_ImPlotAxis_GetColorTick(self.handle()))
 }
 
-func (self *PlotAxis) SetColorTxt(v uint32) {
+func (self PlotAxis) SetColorTxt(v uint32) {
 	C.wrap_ImPlotAxis_SetColorTxt(self.handle(), C.ImU32(v))
 }
 
@@ -9525,7 +9525,7 @@ func (self PlotAxis) ColorTxt() uint32 {
 	return uint32(C.wrap_ImPlotAxis_GetColorTxt(self.handle()))
 }
 
-func (self *PlotAxis) SetColorBg(v uint32) {
+func (self PlotAxis) SetColorBg(v uint32) {
 	C.wrap_ImPlotAxis_SetColorBg(self.handle(), C.ImU32(v))
 }
 
@@ -9533,7 +9533,7 @@ func (self PlotAxis) ColorBg() uint32 {
 	return uint32(C.wrap_ImPlotAxis_GetColorBg(self.handle()))
 }
 
-func (self *PlotAxis) SetColorHov(v uint32) {
+func (self PlotAxis) SetColorHov(v uint32) {
 	C.wrap_ImPlotAxis_SetColorHov(self.handle(), C.ImU32(v))
 }
 
@@ -9541,7 +9541,7 @@ func (self PlotAxis) ColorHov() uint32 {
 	return uint32(C.wrap_ImPlotAxis_GetColorHov(self.handle()))
 }
 
-func (self *PlotAxis) SetColorAct(v uint32) {
+func (self PlotAxis) SetColorAct(v uint32) {
 	C.wrap_ImPlotAxis_SetColorAct(self.handle(), C.ImU32(v))
 }
 
@@ -9549,7 +9549,7 @@ func (self PlotAxis) ColorAct() uint32 {
 	return uint32(C.wrap_ImPlotAxis_GetColorAct(self.handle()))
 }
 
-func (self *PlotAxis) SetColorHiLi(v uint32) {
+func (self PlotAxis) SetColorHiLi(v uint32) {
 	C.wrap_ImPlotAxis_SetColorHiLi(self.handle(), C.ImU32(v))
 }
 
@@ -9557,7 +9557,7 @@ func (self PlotAxis) ColorHiLi() uint32 {
 	return uint32(C.wrap_ImPlotAxis_GetColorHiLi(self.handle()))
 }
 
-func (self *PlotAxis) SetEnabled(v bool) {
+func (self PlotAxis) SetEnabled(v bool) {
 	C.wrap_ImPlotAxis_SetEnabled(self.handle(), C.bool(v))
 }
 
@@ -9565,7 +9565,7 @@ func (self PlotAxis) Enabled() bool {
 	return C.wrap_ImPlotAxis_GetEnabled(self.handle()) == C.bool(true)
 }
 
-func (self *PlotAxis) SetVertical(v bool) {
+func (self PlotAxis) SetVertical(v bool) {
 	C.wrap_ImPlotAxis_SetVertical(self.handle(), C.bool(v))
 }
 
@@ -9573,7 +9573,7 @@ func (self PlotAxis) Vertical() bool {
 	return C.wrap_ImPlotAxis_GetVertical(self.handle()) == C.bool(true)
 }
 
-func (self *PlotAxis) SetFitThisFrame(v bool) {
+func (self PlotAxis) SetFitThisFrame(v bool) {
 	C.wrap_ImPlotAxis_SetFitThisFrame(self.handle(), C.bool(v))
 }
 
@@ -9581,7 +9581,7 @@ func (self PlotAxis) FitThisFrame() bool {
 	return C.wrap_ImPlotAxis_GetFitThisFrame(self.handle()) == C.bool(true)
 }
 
-func (self *PlotAxis) SetHasRange(v bool) {
+func (self PlotAxis) SetHasRange(v bool) {
 	C.wrap_ImPlotAxis_SetHasRange(self.handle(), C.bool(v))
 }
 
@@ -9589,7 +9589,7 @@ func (self PlotAxis) HasRange() bool {
 	return C.wrap_ImPlotAxis_GetHasRange(self.handle()) == C.bool(true)
 }
 
-func (self *PlotAxis) SetHasFormatSpec(v bool) {
+func (self PlotAxis) SetHasFormatSpec(v bool) {
 	C.wrap_ImPlotAxis_SetHasFormatSpec(self.handle(), C.bool(v))
 }
 
@@ -9597,7 +9597,7 @@ func (self PlotAxis) HasFormatSpec() bool {
 	return C.wrap_ImPlotAxis_GetHasFormatSpec(self.handle()) == C.bool(true)
 }
 
-func (self *PlotAxis) SetShowDefaultTicks(v bool) {
+func (self PlotAxis) SetShowDefaultTicks(v bool) {
 	C.wrap_ImPlotAxis_SetShowDefaultTicks(self.handle(), C.bool(v))
 }
 
@@ -9605,7 +9605,7 @@ func (self PlotAxis) ShowDefaultTicks() bool {
 	return C.wrap_ImPlotAxis_GetShowDefaultTicks(self.handle()) == C.bool(true)
 }
 
-func (self *PlotAxis) SetHovered(v bool) {
+func (self PlotAxis) SetHovered(v bool) {
 	C.wrap_ImPlotAxis_SetHovered(self.handle(), C.bool(v))
 }
 
@@ -9613,7 +9613,7 @@ func (self PlotAxis) Hovered() bool {
 	return C.wrap_ImPlotAxis_GetHovered(self.handle()) == C.bool(true)
 }
 
-func (self *PlotAxis) SetHeld(v bool) {
+func (self PlotAxis) SetHeld(v bool) {
 	C.wrap_ImPlotAxis_SetHeld(self.handle(), C.bool(v))
 }
 
@@ -9629,7 +9629,7 @@ func (self PlotColormapData) Map() Storage {
 	return newStorageFromC(C.wrap_ImPlotColormapData_GetMap(self.handle()))
 }
 
-func (self *PlotColormapData) SetCount(v int32) {
+func (self PlotColormapData) SetCount(v int32) {
 	C.wrap_ImPlotColormapData_SetCount(self.handle(), C.int(v))
 }
 
@@ -9637,7 +9637,7 @@ func (self PlotColormapData) Count() int {
 	return int(C.wrap_ImPlotColormapData_GetCount(self.handle()))
 }
 
-func (self *PlotContext) SetCurrentPlot(v PlotPlot) {
+func (self PlotContext) SetCurrentPlot(v PlotPlot) {
 	C.wrap_ImPlotContext_SetCurrentPlot(self.handle(), v.handle())
 }
 
@@ -9645,7 +9645,7 @@ func (self PlotContext) CurrentPlot() PlotPlot {
 	return (PlotPlot)(unsafe.Pointer(C.wrap_ImPlotContext_GetCurrentPlot(self.handle())))
 }
 
-func (self *PlotContext) SetCurrentSubplot(v PlotSubplot) {
+func (self PlotContext) SetCurrentSubplot(v PlotSubplot) {
 	C.wrap_ImPlotContext_SetCurrentSubplot(self.handle(), v.handle())
 }
 
@@ -9653,7 +9653,7 @@ func (self PlotContext) CurrentSubplot() PlotSubplot {
 	return (PlotSubplot)(unsafe.Pointer(C.wrap_ImPlotContext_GetCurrentSubplot(self.handle())))
 }
 
-func (self *PlotContext) SetCurrentItems(v PlotItemGroup) {
+func (self PlotContext) SetCurrentItems(v PlotItemGroup) {
 	C.wrap_ImPlotContext_SetCurrentItems(self.handle(), v.handle())
 }
 
@@ -9661,7 +9661,7 @@ func (self PlotContext) CurrentItems() PlotItemGroup {
 	return (PlotItemGroup)(unsafe.Pointer(C.wrap_ImPlotContext_GetCurrentItems(self.handle())))
 }
 
-func (self *PlotContext) SetCurrentItem(v PlotItem) {
+func (self PlotContext) SetCurrentItem(v PlotItem) {
 	C.wrap_ImPlotContext_SetCurrentItem(self.handle(), v.handle())
 }
 
@@ -9669,7 +9669,7 @@ func (self PlotContext) CurrentItem() PlotItem {
 	return (PlotItem)(unsafe.Pointer(C.wrap_ImPlotContext_GetCurrentItem(self.handle())))
 }
 
-func (self *PlotContext) SetPreviousItem(v PlotItem) {
+func (self PlotContext) SetPreviousItem(v PlotItem) {
 	C.wrap_ImPlotContext_SetPreviousItem(self.handle(), v.handle())
 }
 
@@ -9689,7 +9689,7 @@ func (self PlotContext) Tags() PlotTagCollection {
 	return newPlotTagCollectionFromC(C.wrap_ImPlotContext_GetTags(self.handle()))
 }
 
-func (self *PlotContext) SetChildWindowMade(v bool) {
+func (self PlotContext) SetChildWindowMade(v bool) {
 	C.wrap_ImPlotContext_SetChildWindowMade(self.handle(), C.bool(v))
 }
 
@@ -9705,7 +9705,7 @@ func (self PlotContext) ColormapData() PlotColormapData {
 	return newPlotColormapDataFromC(C.wrap_ImPlotContext_GetColormapData(self.handle()))
 }
 
-func (self *PlotContext) SetDigitalPlotItemCnt(v int32) {
+func (self PlotContext) SetDigitalPlotItemCnt(v int32) {
 	C.wrap_ImPlotContext_SetDigitalPlotItemCnt(self.handle(), C.int(v))
 }
 
@@ -9713,7 +9713,7 @@ func (self PlotContext) DigitalPlotItemCnt() int {
 	return int(C.wrap_ImPlotContext_GetDigitalPlotItemCnt(self.handle()))
 }
 
-func (self *PlotContext) SetDigitalPlotOffset(v int32) {
+func (self PlotContext) SetDigitalPlotOffset(v int32) {
 	C.wrap_ImPlotContext_SetDigitalPlotOffset(self.handle(), C.int(v))
 }
 
@@ -9733,7 +9733,7 @@ func (self PlotContext) InputMap() PlotInputMap {
 	return newPlotInputMapFromC(C.wrap_ImPlotContext_GetInputMap(self.handle()))
 }
 
-func (self *PlotContext) SetOpenContextThisFrame(v bool) {
+func (self PlotContext) SetOpenContextThisFrame(v bool) {
 	C.wrap_ImPlotContext_SetOpenContextThisFrame(self.handle(), C.bool(v))
 }
 
@@ -9745,7 +9745,7 @@ func (self PlotContext) MousePosStringBuilder() TextBuffer {
 	return newTextBufferFromC(C.wrap_ImPlotContext_GetMousePosStringBuilder(self.handle()))
 }
 
-func (self *PlotContext) SetCurrentAlignmentH(v PlotAlignmentData) {
+func (self PlotContext) SetCurrentAlignmentH(v PlotAlignmentData) {
 	C.wrap_ImPlotContext_SetCurrentAlignmentH(self.handle(), v.handle())
 }
 
@@ -9753,7 +9753,7 @@ func (self PlotContext) CurrentAlignmentH() PlotAlignmentData {
 	return (PlotAlignmentData)(unsafe.Pointer(C.wrap_ImPlotContext_GetCurrentAlignmentH(self.handle())))
 }
 
-func (self *PlotContext) SetCurrentAlignmentV(v PlotAlignmentData) {
+func (self PlotContext) SetCurrentAlignmentV(v PlotAlignmentData) {
 	C.wrap_ImPlotContext_SetCurrentAlignmentV(self.handle(), v.handle())
 }
 
@@ -9761,7 +9761,7 @@ func (self PlotContext) CurrentAlignmentV() PlotAlignmentData {
 	return (PlotAlignmentData)(unsafe.Pointer(C.wrap_ImPlotContext_GetCurrentAlignmentV(self.handle())))
 }
 
-func (self *PlotDateTimeSpec) SetDate(v PlotDateFmt) {
+func (self PlotDateTimeSpec) SetDate(v PlotDateFmt) {
 	C.wrap_ImPlotDateTimeSpec_SetDate(self.handle(), C.ImPlotDateFmt(v))
 }
 
@@ -9769,7 +9769,7 @@ func (self PlotDateTimeSpec) Date() PlotDateFmt {
 	return PlotDateFmt(C.wrap_ImPlotDateTimeSpec_GetDate(self.handle()))
 }
 
-func (self *PlotDateTimeSpec) SetTime(v PlotTimeFmt) {
+func (self PlotDateTimeSpec) SetTime(v PlotTimeFmt) {
 	C.wrap_ImPlotDateTimeSpec_SetTime(self.handle(), C.ImPlotTimeFmt(v))
 }
 
@@ -9777,7 +9777,7 @@ func (self PlotDateTimeSpec) Time() PlotTimeFmt {
 	return PlotTimeFmt(C.wrap_ImPlotDateTimeSpec_GetTime(self.handle()))
 }
 
-func (self *PlotDateTimeSpec) SetUseISO8601(v bool) {
+func (self PlotDateTimeSpec) SetUseISO8601(v bool) {
 	C.wrap_ImPlotDateTimeSpec_SetUseISO8601(self.handle(), C.bool(v))
 }
 
@@ -9785,7 +9785,7 @@ func (self PlotDateTimeSpec) UseISO8601() bool {
 	return C.wrap_ImPlotDateTimeSpec_GetUseISO8601(self.handle()) == C.bool(true)
 }
 
-func (self *PlotDateTimeSpec) SetUse24HourClock(v bool) {
+func (self PlotDateTimeSpec) SetUse24HourClock(v bool) {
 	C.wrap_ImPlotDateTimeSpec_SetUse24HourClock(self.handle(), C.bool(v))
 }
 
@@ -9793,7 +9793,7 @@ func (self PlotDateTimeSpec) Use24HourClock() bool {
 	return C.wrap_ImPlotDateTimeSpec_GetUse24HourClock(self.handle()) == C.bool(true)
 }
 
-func (self *PlotInputMap) SetZoomRate(v float32) {
+func (self PlotInputMap) SetZoomRate(v float32) {
 	C.wrap_ImPlotInputMap_SetZoomRate(self.handle(), C.float(v))
 }
 
@@ -9801,7 +9801,7 @@ func (self PlotInputMap) ZoomRate() float32 {
 	return float32(C.wrap_ImPlotInputMap_GetZoomRate(self.handle()))
 }
 
-func (self *PlotItem) SetID(v ID) {
+func (self PlotItem) SetID(v ID) {
 	C.wrap_ImPlotItem_SetID(self.handle(), C.ImGuiID(v))
 }
 
@@ -9809,7 +9809,7 @@ func (self PlotItem) ID() ID {
 	return ID(C.wrap_ImPlotItem_GetID(self.handle()))
 }
 
-func (self *PlotItem) SetColor(v uint32) {
+func (self PlotItem) SetColor(v uint32) {
 	C.wrap_ImPlotItem_SetColor(self.handle(), C.ImU32(v))
 }
 
@@ -9817,7 +9817,7 @@ func (self PlotItem) Color() uint32 {
 	return uint32(C.wrap_ImPlotItem_GetColor(self.handle()))
 }
 
-func (self *PlotItem) SetLegendHoverRect(v Rect) {
+func (self PlotItem) SetLegendHoverRect(v Rect) {
 	C.wrap_ImPlotItem_SetLegendHoverRect(self.handle(), v.toC())
 }
 
@@ -9827,7 +9827,7 @@ func (self PlotItem) LegendHoverRect() Rect {
 	return *out
 }
 
-func (self *PlotItem) SetNameOffset(v int32) {
+func (self PlotItem) SetNameOffset(v int32) {
 	C.wrap_ImPlotItem_SetNameOffset(self.handle(), C.int(v))
 }
 
@@ -9835,7 +9835,7 @@ func (self PlotItem) NameOffset() int {
 	return int(C.wrap_ImPlotItem_GetNameOffset(self.handle()))
 }
 
-func (self *PlotItem) SetShow(v bool) {
+func (self PlotItem) SetShow(v bool) {
 	C.wrap_ImPlotItem_SetShow(self.handle(), C.bool(v))
 }
 
@@ -9843,7 +9843,7 @@ func (self PlotItem) Show() bool {
 	return C.wrap_ImPlotItem_GetShow(self.handle()) == C.bool(true)
 }
 
-func (self *PlotItem) SetLegendHovered(v bool) {
+func (self PlotItem) SetLegendHovered(v bool) {
 	C.wrap_ImPlotItem_SetLegendHovered(self.handle(), C.bool(v))
 }
 
@@ -9851,7 +9851,7 @@ func (self PlotItem) LegendHovered() bool {
 	return C.wrap_ImPlotItem_GetLegendHovered(self.handle()) == C.bool(true)
 }
 
-func (self *PlotItem) SetSeenThisFrame(v bool) {
+func (self PlotItem) SetSeenThisFrame(v bool) {
 	C.wrap_ImPlotItem_SetSeenThisFrame(self.handle(), C.bool(v))
 }
 
@@ -9859,7 +9859,7 @@ func (self PlotItem) SeenThisFrame() bool {
 	return C.wrap_ImPlotItem_GetSeenThisFrame(self.handle()) == C.bool(true)
 }
 
-func (self *PlotItemGroup) SetID(v ID) {
+func (self PlotItemGroup) SetID(v ID) {
 	C.wrap_ImPlotItemGroup_SetID(self.handle(), C.ImGuiID(v))
 }
 
@@ -9871,7 +9871,7 @@ func (self PlotItemGroup) Legend() PlotLegend {
 	return newPlotLegendFromC(C.wrap_ImPlotItemGroup_GetLegend(self.handle()))
 }
 
-func (self *PlotItemGroup) SetColormapIdx(v int32) {
+func (self PlotItemGroup) SetColormapIdx(v int32) {
 	C.wrap_ImPlotItemGroup_SetColormapIdx(self.handle(), C.int(v))
 }
 
@@ -9879,7 +9879,7 @@ func (self PlotItemGroup) ColormapIdx() int {
 	return int(C.wrap_ImPlotItemGroup_GetColormapIdx(self.handle()))
 }
 
-func (self *PlotLegend) SetFlags(v PlotLegendFlags) {
+func (self PlotLegend) SetFlags(v PlotLegendFlags) {
 	C.wrap_ImPlotLegend_SetFlags(self.handle(), C.ImPlotLegendFlags(v))
 }
 
@@ -9887,7 +9887,7 @@ func (self PlotLegend) Flags() PlotLegendFlags {
 	return PlotLegendFlags(C.wrap_ImPlotLegend_GetFlags(self.handle()))
 }
 
-func (self *PlotLegend) SetPreviousFlags(v PlotLegendFlags) {
+func (self PlotLegend) SetPreviousFlags(v PlotLegendFlags) {
 	C.wrap_ImPlotLegend_SetPreviousFlags(self.handle(), C.ImPlotLegendFlags(v))
 }
 
@@ -9895,7 +9895,7 @@ func (self PlotLegend) PreviousFlags() PlotLegendFlags {
 	return PlotLegendFlags(C.wrap_ImPlotLegend_GetPreviousFlags(self.handle()))
 }
 
-func (self *PlotLegend) SetLocation(v PlotLocation) {
+func (self PlotLegend) SetLocation(v PlotLocation) {
 	C.wrap_ImPlotLegend_SetLocation(self.handle(), C.ImPlotLocation(v))
 }
 
@@ -9903,7 +9903,7 @@ func (self PlotLegend) Location() PlotLocation {
 	return PlotLocation(C.wrap_ImPlotLegend_GetLocation(self.handle()))
 }
 
-func (self *PlotLegend) SetPreviousLocation(v PlotLocation) {
+func (self PlotLegend) SetPreviousLocation(v PlotLocation) {
 	C.wrap_ImPlotLegend_SetPreviousLocation(self.handle(), C.ImPlotLocation(v))
 }
 
@@ -9915,7 +9915,7 @@ func (self PlotLegend) Labels() TextBuffer {
 	return newTextBufferFromC(C.wrap_ImPlotLegend_GetLabels(self.handle()))
 }
 
-func (self *PlotLegend) SetRect(v Rect) {
+func (self PlotLegend) SetRect(v Rect) {
 	C.wrap_ImPlotLegend_SetRect(self.handle(), v.toC())
 }
 
@@ -9925,7 +9925,7 @@ func (self PlotLegend) Rect() Rect {
 	return *out
 }
 
-func (self *PlotLegend) SetHovered(v bool) {
+func (self PlotLegend) SetHovered(v bool) {
 	C.wrap_ImPlotLegend_SetHovered(self.handle(), C.bool(v))
 }
 
@@ -9933,7 +9933,7 @@ func (self PlotLegend) Hovered() bool {
 	return C.wrap_ImPlotLegend_GetHovered(self.handle()) == C.bool(true)
 }
 
-func (self *PlotLegend) SetHeld(v bool) {
+func (self PlotLegend) SetHeld(v bool) {
 	C.wrap_ImPlotLegend_SetHeld(self.handle(), C.bool(v))
 }
 
@@ -9941,7 +9941,7 @@ func (self PlotLegend) Held() bool {
 	return C.wrap_ImPlotLegend_GetHeld(self.handle()) == C.bool(true)
 }
 
-func (self *PlotLegend) SetCanGoInside(v bool) {
+func (self PlotLegend) SetCanGoInside(v bool) {
 	C.wrap_ImPlotLegend_SetCanGoInside(self.handle(), C.bool(v))
 }
 
@@ -9949,7 +9949,7 @@ func (self PlotLegend) CanGoInside() bool {
 	return C.wrap_ImPlotLegend_GetCanGoInside(self.handle()) == C.bool(true)
 }
 
-func (self *PlotNextItemData) SetLineWeight(v float32) {
+func (self PlotNextItemData) SetLineWeight(v float32) {
 	C.wrap_ImPlotNextItemData_SetLineWeight(self.handle(), C.float(v))
 }
 
@@ -9957,7 +9957,7 @@ func (self PlotNextItemData) LineWeight() float32 {
 	return float32(C.wrap_ImPlotNextItemData_GetLineWeight(self.handle()))
 }
 
-func (self *PlotNextItemData) SetMarker(v PlotMarker) {
+func (self PlotNextItemData) SetMarker(v PlotMarker) {
 	C.wrap_ImPlotNextItemData_SetMarker(self.handle(), C.ImPlotMarker(v))
 }
 
@@ -9965,7 +9965,7 @@ func (self PlotNextItemData) Marker() PlotMarker {
 	return PlotMarker(C.wrap_ImPlotNextItemData_GetMarker(self.handle()))
 }
 
-func (self *PlotNextItemData) SetMarkerSize(v float32) {
+func (self PlotNextItemData) SetMarkerSize(v float32) {
 	C.wrap_ImPlotNextItemData_SetMarkerSize(self.handle(), C.float(v))
 }
 
@@ -9973,7 +9973,7 @@ func (self PlotNextItemData) MarkerSize() float32 {
 	return float32(C.wrap_ImPlotNextItemData_GetMarkerSize(self.handle()))
 }
 
-func (self *PlotNextItemData) SetMarkerWeight(v float32) {
+func (self PlotNextItemData) SetMarkerWeight(v float32) {
 	C.wrap_ImPlotNextItemData_SetMarkerWeight(self.handle(), C.float(v))
 }
 
@@ -9981,7 +9981,7 @@ func (self PlotNextItemData) MarkerWeight() float32 {
 	return float32(C.wrap_ImPlotNextItemData_GetMarkerWeight(self.handle()))
 }
 
-func (self *PlotNextItemData) SetFillAlpha(v float32) {
+func (self PlotNextItemData) SetFillAlpha(v float32) {
 	C.wrap_ImPlotNextItemData_SetFillAlpha(self.handle(), C.float(v))
 }
 
@@ -9989,7 +9989,7 @@ func (self PlotNextItemData) FillAlpha() float32 {
 	return float32(C.wrap_ImPlotNextItemData_GetFillAlpha(self.handle()))
 }
 
-func (self *PlotNextItemData) SetErrorBarSize(v float32) {
+func (self PlotNextItemData) SetErrorBarSize(v float32) {
 	C.wrap_ImPlotNextItemData_SetErrorBarSize(self.handle(), C.float(v))
 }
 
@@ -9997,7 +9997,7 @@ func (self PlotNextItemData) ErrorBarSize() float32 {
 	return float32(C.wrap_ImPlotNextItemData_GetErrorBarSize(self.handle()))
 }
 
-func (self *PlotNextItemData) SetErrorBarWeight(v float32) {
+func (self PlotNextItemData) SetErrorBarWeight(v float32) {
 	C.wrap_ImPlotNextItemData_SetErrorBarWeight(self.handle(), C.float(v))
 }
 
@@ -10005,7 +10005,7 @@ func (self PlotNextItemData) ErrorBarWeight() float32 {
 	return float32(C.wrap_ImPlotNextItemData_GetErrorBarWeight(self.handle()))
 }
 
-func (self *PlotNextItemData) SetDigitalBitHeight(v float32) {
+func (self PlotNextItemData) SetDigitalBitHeight(v float32) {
 	C.wrap_ImPlotNextItemData_SetDigitalBitHeight(self.handle(), C.float(v))
 }
 
@@ -10013,7 +10013,7 @@ func (self PlotNextItemData) DigitalBitHeight() float32 {
 	return float32(C.wrap_ImPlotNextItemData_GetDigitalBitHeight(self.handle()))
 }
 
-func (self *PlotNextItemData) SetDigitalBitGap(v float32) {
+func (self PlotNextItemData) SetDigitalBitGap(v float32) {
 	C.wrap_ImPlotNextItemData_SetDigitalBitGap(self.handle(), C.float(v))
 }
 
@@ -10021,7 +10021,7 @@ func (self PlotNextItemData) DigitalBitGap() float32 {
 	return float32(C.wrap_ImPlotNextItemData_GetDigitalBitGap(self.handle()))
 }
 
-func (self *PlotNextItemData) SetRenderLine(v bool) {
+func (self PlotNextItemData) SetRenderLine(v bool) {
 	C.wrap_ImPlotNextItemData_SetRenderLine(self.handle(), C.bool(v))
 }
 
@@ -10029,7 +10029,7 @@ func (self PlotNextItemData) RenderLine() bool {
 	return C.wrap_ImPlotNextItemData_GetRenderLine(self.handle()) == C.bool(true)
 }
 
-func (self *PlotNextItemData) SetRenderFill(v bool) {
+func (self PlotNextItemData) SetRenderFill(v bool) {
 	C.wrap_ImPlotNextItemData_SetRenderFill(self.handle(), C.bool(v))
 }
 
@@ -10037,7 +10037,7 @@ func (self PlotNextItemData) RenderFill() bool {
 	return C.wrap_ImPlotNextItemData_GetRenderFill(self.handle()) == C.bool(true)
 }
 
-func (self *PlotNextItemData) SetRenderMarkerLine(v bool) {
+func (self PlotNextItemData) SetRenderMarkerLine(v bool) {
 	C.wrap_ImPlotNextItemData_SetRenderMarkerLine(self.handle(), C.bool(v))
 }
 
@@ -10045,7 +10045,7 @@ func (self PlotNextItemData) RenderMarkerLine() bool {
 	return C.wrap_ImPlotNextItemData_GetRenderMarkerLine(self.handle()) == C.bool(true)
 }
 
-func (self *PlotNextItemData) SetRenderMarkerFill(v bool) {
+func (self PlotNextItemData) SetRenderMarkerFill(v bool) {
 	C.wrap_ImPlotNextItemData_SetRenderMarkerFill(self.handle(), C.bool(v))
 }
 
@@ -10053,7 +10053,7 @@ func (self PlotNextItemData) RenderMarkerFill() bool {
 	return C.wrap_ImPlotNextItemData_GetRenderMarkerFill(self.handle()) == C.bool(true)
 }
 
-func (self *PlotNextItemData) SetHasHidden(v bool) {
+func (self PlotNextItemData) SetHasHidden(v bool) {
 	C.wrap_ImPlotNextItemData_SetHasHidden(self.handle(), C.bool(v))
 }
 
@@ -10061,7 +10061,7 @@ func (self PlotNextItemData) HasHidden() bool {
 	return C.wrap_ImPlotNextItemData_GetHasHidden(self.handle()) == C.bool(true)
 }
 
-func (self *PlotNextItemData) SetHidden(v bool) {
+func (self PlotNextItemData) SetHidden(v bool) {
 	C.wrap_ImPlotNextItemData_SetHidden(self.handle(), C.bool(v))
 }
 
@@ -10069,7 +10069,7 @@ func (self PlotNextItemData) Hidden() bool {
 	return C.wrap_ImPlotNextItemData_GetHidden(self.handle()) == C.bool(true)
 }
 
-func (self *PlotNextItemData) SetHiddenCond(v PlotCond) {
+func (self PlotNextItemData) SetHiddenCond(v PlotCond) {
 	C.wrap_ImPlotNextItemData_SetHiddenCond(self.handle(), C.ImPlotCond(v))
 }
 
@@ -10077,7 +10077,7 @@ func (self PlotNextItemData) HiddenCond() PlotCond {
 	return PlotCond(C.wrap_ImPlotNextItemData_GetHiddenCond(self.handle()))
 }
 
-func (self *PlotPlot) SetID(v ID) {
+func (self PlotPlot) SetID(v ID) {
 	C.wrap_ImPlotPlot_SetID(self.handle(), C.ImGuiID(v))
 }
 
@@ -10085,7 +10085,7 @@ func (self PlotPlot) ID() ID {
 	return ID(C.wrap_ImPlotPlot_GetID(self.handle()))
 }
 
-func (self *PlotPlot) SetFlags(v PlotFlags) {
+func (self PlotPlot) SetFlags(v PlotFlags) {
 	C.wrap_ImPlotPlot_SetFlags(self.handle(), C.ImPlotFlags(v))
 }
 
@@ -10093,7 +10093,7 @@ func (self PlotPlot) Flags() PlotFlags {
 	return PlotFlags(C.wrap_ImPlotPlot_GetFlags(self.handle()))
 }
 
-func (self *PlotPlot) SetPreviousFlags(v PlotFlags) {
+func (self PlotPlot) SetPreviousFlags(v PlotFlags) {
 	C.wrap_ImPlotPlot_SetPreviousFlags(self.handle(), C.ImPlotFlags(v))
 }
 
@@ -10101,7 +10101,7 @@ func (self PlotPlot) PreviousFlags() PlotFlags {
 	return PlotFlags(C.wrap_ImPlotPlot_GetPreviousFlags(self.handle()))
 }
 
-func (self *PlotPlot) SetMouseTextLocation(v PlotLocation) {
+func (self PlotPlot) SetMouseTextLocation(v PlotLocation) {
 	C.wrap_ImPlotPlot_SetMouseTextLocation(self.handle(), C.ImPlotLocation(v))
 }
 
@@ -10109,7 +10109,7 @@ func (self PlotPlot) MouseTextLocation() PlotLocation {
 	return PlotLocation(C.wrap_ImPlotPlot_GetMouseTextLocation(self.handle()))
 }
 
-func (self *PlotPlot) SetMouseTextFlags(v PlotMouseTextFlags) {
+func (self PlotPlot) SetMouseTextFlags(v PlotMouseTextFlags) {
 	C.wrap_ImPlotPlot_SetMouseTextFlags(self.handle(), C.ImPlotMouseTextFlags(v))
 }
 
@@ -10125,7 +10125,7 @@ func (self PlotPlot) Items() PlotItemGroup {
 	return newPlotItemGroupFromC(C.wrap_ImPlotPlot_GetItems(self.handle()))
 }
 
-func (self *PlotPlot) SetCurrentX(v PlotAxisEnum) {
+func (self PlotPlot) SetCurrentX(v PlotAxisEnum) {
 	C.wrap_ImPlotPlot_SetCurrentX(self.handle(), C.ImAxis(v))
 }
 
@@ -10133,7 +10133,7 @@ func (self PlotPlot) CurrentX() PlotAxisEnum {
 	return PlotAxisEnum(C.wrap_ImPlotPlot_GetCurrentX(self.handle()))
 }
 
-func (self *PlotPlot) SetCurrentY(v PlotAxisEnum) {
+func (self PlotPlot) SetCurrentY(v PlotAxisEnum) {
 	C.wrap_ImPlotPlot_SetCurrentY(self.handle(), C.ImAxis(v))
 }
 
@@ -10141,7 +10141,7 @@ func (self PlotPlot) CurrentY() PlotAxisEnum {
 	return PlotAxisEnum(C.wrap_ImPlotPlot_GetCurrentY(self.handle()))
 }
 
-func (self *PlotPlot) SetFrameRect(v Rect) {
+func (self PlotPlot) SetFrameRect(v Rect) {
 	C.wrap_ImPlotPlot_SetFrameRect(self.handle(), v.toC())
 }
 
@@ -10151,7 +10151,7 @@ func (self PlotPlot) FrameRect() Rect {
 	return *out
 }
 
-func (self *PlotPlot) SetCanvasRect(v Rect) {
+func (self PlotPlot) SetCanvasRect(v Rect) {
 	C.wrap_ImPlotPlot_SetCanvasRect(self.handle(), v.toC())
 }
 
@@ -10161,7 +10161,7 @@ func (self PlotPlot) CanvasRect() Rect {
 	return *out
 }
 
-func (self *PlotPlot) SetPlotRect(v Rect) {
+func (self PlotPlot) SetPlotRect(v Rect) {
 	C.wrap_ImPlotPlot_SetPlotRect(self.handle(), v.toC())
 }
 
@@ -10171,7 +10171,7 @@ func (self PlotPlot) PlotRect() Rect {
 	return *out
 }
 
-func (self *PlotPlot) SetAxesRect(v Rect) {
+func (self PlotPlot) SetAxesRect(v Rect) {
 	C.wrap_ImPlotPlot_SetAxesRect(self.handle(), v.toC())
 }
 
@@ -10181,7 +10181,7 @@ func (self PlotPlot) AxesRect() Rect {
 	return *out
 }
 
-func (self *PlotPlot) SetSelectRect(v Rect) {
+func (self PlotPlot) SetSelectRect(v Rect) {
 	C.wrap_ImPlotPlot_SetSelectRect(self.handle(), v.toC())
 }
 
@@ -10191,7 +10191,7 @@ func (self PlotPlot) SelectRect() Rect {
 	return *out
 }
 
-func (self *PlotPlot) SetSelectStart(v Vec2) {
+func (self PlotPlot) SetSelectStart(v Vec2) {
 	C.wrap_ImPlotPlot_SetSelectStart(self.handle(), v.toC())
 }
 
@@ -10201,7 +10201,7 @@ func (self PlotPlot) SelectStart() Vec2 {
 	return *out
 }
 
-func (self *PlotPlot) SetTitleOffset(v int32) {
+func (self PlotPlot) SetTitleOffset(v int32) {
 	C.wrap_ImPlotPlot_SetTitleOffset(self.handle(), C.int(v))
 }
 
@@ -10209,7 +10209,7 @@ func (self PlotPlot) TitleOffset() int {
 	return int(C.wrap_ImPlotPlot_GetTitleOffset(self.handle()))
 }
 
-func (self *PlotPlot) SetJustCreated(v bool) {
+func (self PlotPlot) SetJustCreated(v bool) {
 	C.wrap_ImPlotPlot_SetJustCreated(self.handle(), C.bool(v))
 }
 
@@ -10217,7 +10217,7 @@ func (self PlotPlot) JustCreated() bool {
 	return C.wrap_ImPlotPlot_GetJustCreated(self.handle()) == C.bool(true)
 }
 
-func (self *PlotPlot) SetInitialized(v bool) {
+func (self PlotPlot) SetInitialized(v bool) {
 	C.wrap_ImPlotPlot_SetInitialized(self.handle(), C.bool(v))
 }
 
@@ -10225,7 +10225,7 @@ func (self PlotPlot) Initialized() bool {
 	return C.wrap_ImPlotPlot_GetInitialized(self.handle()) == C.bool(true)
 }
 
-func (self *PlotPlot) SetSetupLocked(v bool) {
+func (self PlotPlot) SetSetupLocked(v bool) {
 	C.wrap_ImPlotPlot_SetSetupLocked(self.handle(), C.bool(v))
 }
 
@@ -10233,7 +10233,7 @@ func (self PlotPlot) SetupLocked() bool {
 	return C.wrap_ImPlotPlot_GetSetupLocked(self.handle()) == C.bool(true)
 }
 
-func (self *PlotPlot) SetFitThisFrame(v bool) {
+func (self PlotPlot) SetFitThisFrame(v bool) {
 	C.wrap_ImPlotPlot_SetFitThisFrame(self.handle(), C.bool(v))
 }
 
@@ -10241,7 +10241,7 @@ func (self PlotPlot) FitThisFrame() bool {
 	return C.wrap_ImPlotPlot_GetFitThisFrame(self.handle()) == C.bool(true)
 }
 
-func (self *PlotPlot) SetHovered(v bool) {
+func (self PlotPlot) SetHovered(v bool) {
 	C.wrap_ImPlotPlot_SetHovered(self.handle(), C.bool(v))
 }
 
@@ -10249,7 +10249,7 @@ func (self PlotPlot) Hovered() bool {
 	return C.wrap_ImPlotPlot_GetHovered(self.handle()) == C.bool(true)
 }
 
-func (self *PlotPlot) SetHeld(v bool) {
+func (self PlotPlot) SetHeld(v bool) {
 	C.wrap_ImPlotPlot_SetHeld(self.handle(), C.bool(v))
 }
 
@@ -10257,7 +10257,7 @@ func (self PlotPlot) Held() bool {
 	return C.wrap_ImPlotPlot_GetHeld(self.handle()) == C.bool(true)
 }
 
-func (self *PlotPlot) SetSelecting(v bool) {
+func (self PlotPlot) SetSelecting(v bool) {
 	C.wrap_ImPlotPlot_SetSelecting(self.handle(), C.bool(v))
 }
 
@@ -10265,7 +10265,7 @@ func (self PlotPlot) Selecting() bool {
 	return C.wrap_ImPlotPlot_GetSelecting(self.handle()) == C.bool(true)
 }
 
-func (self *PlotPlot) SetSelected(v bool) {
+func (self PlotPlot) SetSelected(v bool) {
 	C.wrap_ImPlotPlot_SetSelected(self.handle(), C.bool(v))
 }
 
@@ -10273,7 +10273,7 @@ func (self PlotPlot) Selected() bool {
 	return C.wrap_ImPlotPlot_GetSelected(self.handle()) == C.bool(true)
 }
 
-func (self *PlotPlot) SetContextLocked(v bool) {
+func (self PlotPlot) SetContextLocked(v bool) {
 	C.wrap_ImPlotPlot_SetContextLocked(self.handle(), C.bool(v))
 }
 
@@ -10281,7 +10281,7 @@ func (self PlotPlot) ContextLocked() bool {
 	return C.wrap_ImPlotPlot_GetContextLocked(self.handle()) == C.bool(true)
 }
 
-func (self *PlotPointError) SetX(v float64) {
+func (self PlotPointError) SetX(v float64) {
 	C.wrap_ImPlotPointError_SetX(self.handle(), C.double(v))
 }
 
@@ -10289,7 +10289,7 @@ func (self PlotPointError) X() float64 {
 	return float64(C.wrap_ImPlotPointError_GetX(self.handle()))
 }
 
-func (self *PlotPointError) SetY(v float64) {
+func (self PlotPointError) SetY(v float64) {
 	C.wrap_ImPlotPointError_SetY(self.handle(), C.double(v))
 }
 
@@ -10297,7 +10297,7 @@ func (self PlotPointError) Y() float64 {
 	return float64(C.wrap_ImPlotPointError_GetY(self.handle()))
 }
 
-func (self *PlotPointError) SetNeg(v float64) {
+func (self PlotPointError) SetNeg(v float64) {
 	C.wrap_ImPlotPointError_SetNeg(self.handle(), C.double(v))
 }
 
@@ -10305,7 +10305,7 @@ func (self PlotPointError) Neg() float64 {
 	return float64(C.wrap_ImPlotPointError_GetNeg(self.handle()))
 }
 
-func (self *PlotPointError) SetPos(v float64) {
+func (self PlotPointError) SetPos(v float64) {
 	C.wrap_ImPlotPointError_SetPos(self.handle(), C.double(v))
 }
 
@@ -10313,7 +10313,7 @@ func (self PlotPointError) Pos() float64 {
 	return float64(C.wrap_ImPlotPointError_GetPos(self.handle()))
 }
 
-func (self *PlotRange) SetMin(v float64) {
+func (self PlotRange) SetMin(v float64) {
 	C.wrap_ImPlotRange_SetMin(self.handle(), C.double(v))
 }
 
@@ -10321,7 +10321,7 @@ func (self PlotRange) Min() float64 {
 	return float64(C.wrap_ImPlotRange_GetMin(self.handle()))
 }
 
-func (self *PlotRange) SetMax(v float64) {
+func (self PlotRange) SetMax(v float64) {
 	C.wrap_ImPlotRange_SetMax(self.handle(), C.double(v))
 }
 
@@ -10337,7 +10337,7 @@ func (self PlotRect) Y() PlotRange {
 	return newPlotRangeFromC(C.wrap_ImPlotRect_GetY(self.handle()))
 }
 
-func (self *PlotStyle) SetLineWeight(v float32) {
+func (self PlotStyle) SetLineWeight(v float32) {
 	C.wrap_ImPlotStyle_SetLineWeight(self.handle(), C.float(v))
 }
 
@@ -10345,7 +10345,7 @@ func (self PlotStyle) LineWeight() float32 {
 	return float32(C.wrap_ImPlotStyle_GetLineWeight(self.handle()))
 }
 
-func (self *PlotStyle) SetMarker(v int32) {
+func (self PlotStyle) SetMarker(v int32) {
 	C.wrap_ImPlotStyle_SetMarker(self.handle(), C.int(v))
 }
 
@@ -10353,7 +10353,7 @@ func (self PlotStyle) Marker() int {
 	return int(C.wrap_ImPlotStyle_GetMarker(self.handle()))
 }
 
-func (self *PlotStyle) SetMarkerSize(v float32) {
+func (self PlotStyle) SetMarkerSize(v float32) {
 	C.wrap_ImPlotStyle_SetMarkerSize(self.handle(), C.float(v))
 }
 
@@ -10361,7 +10361,7 @@ func (self PlotStyle) MarkerSize() float32 {
 	return float32(C.wrap_ImPlotStyle_GetMarkerSize(self.handle()))
 }
 
-func (self *PlotStyle) SetMarkerWeight(v float32) {
+func (self PlotStyle) SetMarkerWeight(v float32) {
 	C.wrap_ImPlotStyle_SetMarkerWeight(self.handle(), C.float(v))
 }
 
@@ -10369,7 +10369,7 @@ func (self PlotStyle) MarkerWeight() float32 {
 	return float32(C.wrap_ImPlotStyle_GetMarkerWeight(self.handle()))
 }
 
-func (self *PlotStyle) SetFillAlpha(v float32) {
+func (self PlotStyle) SetFillAlpha(v float32) {
 	C.wrap_ImPlotStyle_SetFillAlpha(self.handle(), C.float(v))
 }
 
@@ -10377,7 +10377,7 @@ func (self PlotStyle) FillAlpha() float32 {
 	return float32(C.wrap_ImPlotStyle_GetFillAlpha(self.handle()))
 }
 
-func (self *PlotStyle) SetErrorBarSize(v float32) {
+func (self PlotStyle) SetErrorBarSize(v float32) {
 	C.wrap_ImPlotStyle_SetErrorBarSize(self.handle(), C.float(v))
 }
 
@@ -10385,7 +10385,7 @@ func (self PlotStyle) ErrorBarSize() float32 {
 	return float32(C.wrap_ImPlotStyle_GetErrorBarSize(self.handle()))
 }
 
-func (self *PlotStyle) SetErrorBarWeight(v float32) {
+func (self PlotStyle) SetErrorBarWeight(v float32) {
 	C.wrap_ImPlotStyle_SetErrorBarWeight(self.handle(), C.float(v))
 }
 
@@ -10393,7 +10393,7 @@ func (self PlotStyle) ErrorBarWeight() float32 {
 	return float32(C.wrap_ImPlotStyle_GetErrorBarWeight(self.handle()))
 }
 
-func (self *PlotStyle) SetDigitalBitHeight(v float32) {
+func (self PlotStyle) SetDigitalBitHeight(v float32) {
 	C.wrap_ImPlotStyle_SetDigitalBitHeight(self.handle(), C.float(v))
 }
 
@@ -10401,7 +10401,7 @@ func (self PlotStyle) DigitalBitHeight() float32 {
 	return float32(C.wrap_ImPlotStyle_GetDigitalBitHeight(self.handle()))
 }
 
-func (self *PlotStyle) SetDigitalBitGap(v float32) {
+func (self PlotStyle) SetDigitalBitGap(v float32) {
 	C.wrap_ImPlotStyle_SetDigitalBitGap(self.handle(), C.float(v))
 }
 
@@ -10409,7 +10409,7 @@ func (self PlotStyle) DigitalBitGap() float32 {
 	return float32(C.wrap_ImPlotStyle_GetDigitalBitGap(self.handle()))
 }
 
-func (self *PlotStyle) SetPlotBorderSize(v float32) {
+func (self PlotStyle) SetPlotBorderSize(v float32) {
 	C.wrap_ImPlotStyle_SetPlotBorderSize(self.handle(), C.float(v))
 }
 
@@ -10417,7 +10417,7 @@ func (self PlotStyle) PlotBorderSize() float32 {
 	return float32(C.wrap_ImPlotStyle_GetPlotBorderSize(self.handle()))
 }
 
-func (self *PlotStyle) SetMinorAlpha(v float32) {
+func (self PlotStyle) SetMinorAlpha(v float32) {
 	C.wrap_ImPlotStyle_SetMinorAlpha(self.handle(), C.float(v))
 }
 
@@ -10425,7 +10425,7 @@ func (self PlotStyle) MinorAlpha() float32 {
 	return float32(C.wrap_ImPlotStyle_GetMinorAlpha(self.handle()))
 }
 
-func (self *PlotStyle) SetMajorTickLen(v Vec2) {
+func (self PlotStyle) SetMajorTickLen(v Vec2) {
 	C.wrap_ImPlotStyle_SetMajorTickLen(self.handle(), v.toC())
 }
 
@@ -10435,7 +10435,7 @@ func (self PlotStyle) MajorTickLen() Vec2 {
 	return *out
 }
 
-func (self *PlotStyle) SetMinorTickLen(v Vec2) {
+func (self PlotStyle) SetMinorTickLen(v Vec2) {
 	C.wrap_ImPlotStyle_SetMinorTickLen(self.handle(), v.toC())
 }
 
@@ -10445,7 +10445,7 @@ func (self PlotStyle) MinorTickLen() Vec2 {
 	return *out
 }
 
-func (self *PlotStyle) SetMajorTickSize(v Vec2) {
+func (self PlotStyle) SetMajorTickSize(v Vec2) {
 	C.wrap_ImPlotStyle_SetMajorTickSize(self.handle(), v.toC())
 }
 
@@ -10455,7 +10455,7 @@ func (self PlotStyle) MajorTickSize() Vec2 {
 	return *out
 }
 
-func (self *PlotStyle) SetMinorTickSize(v Vec2) {
+func (self PlotStyle) SetMinorTickSize(v Vec2) {
 	C.wrap_ImPlotStyle_SetMinorTickSize(self.handle(), v.toC())
 }
 
@@ -10465,7 +10465,7 @@ func (self PlotStyle) MinorTickSize() Vec2 {
 	return *out
 }
 
-func (self *PlotStyle) SetMajorGridSize(v Vec2) {
+func (self PlotStyle) SetMajorGridSize(v Vec2) {
 	C.wrap_ImPlotStyle_SetMajorGridSize(self.handle(), v.toC())
 }
 
@@ -10475,7 +10475,7 @@ func (self PlotStyle) MajorGridSize() Vec2 {
 	return *out
 }
 
-func (self *PlotStyle) SetMinorGridSize(v Vec2) {
+func (self PlotStyle) SetMinorGridSize(v Vec2) {
 	C.wrap_ImPlotStyle_SetMinorGridSize(self.handle(), v.toC())
 }
 
@@ -10485,7 +10485,7 @@ func (self PlotStyle) MinorGridSize() Vec2 {
 	return *out
 }
 
-func (self *PlotStyle) SetPlotPadding(v Vec2) {
+func (self PlotStyle) SetPlotPadding(v Vec2) {
 	C.wrap_ImPlotStyle_SetPlotPadding(self.handle(), v.toC())
 }
 
@@ -10495,7 +10495,7 @@ func (self PlotStyle) PlotPadding() Vec2 {
 	return *out
 }
 
-func (self *PlotStyle) SetLabelPadding(v Vec2) {
+func (self PlotStyle) SetLabelPadding(v Vec2) {
 	C.wrap_ImPlotStyle_SetLabelPadding(self.handle(), v.toC())
 }
 
@@ -10505,7 +10505,7 @@ func (self PlotStyle) LabelPadding() Vec2 {
 	return *out
 }
 
-func (self *PlotStyle) SetLegendPadding(v Vec2) {
+func (self PlotStyle) SetLegendPadding(v Vec2) {
 	C.wrap_ImPlotStyle_SetLegendPadding(self.handle(), v.toC())
 }
 
@@ -10515,7 +10515,7 @@ func (self PlotStyle) LegendPadding() Vec2 {
 	return *out
 }
 
-func (self *PlotStyle) SetLegendInnerPadding(v Vec2) {
+func (self PlotStyle) SetLegendInnerPadding(v Vec2) {
 	C.wrap_ImPlotStyle_SetLegendInnerPadding(self.handle(), v.toC())
 }
 
@@ -10525,7 +10525,7 @@ func (self PlotStyle) LegendInnerPadding() Vec2 {
 	return *out
 }
 
-func (self *PlotStyle) SetLegendSpacing(v Vec2) {
+func (self PlotStyle) SetLegendSpacing(v Vec2) {
 	C.wrap_ImPlotStyle_SetLegendSpacing(self.handle(), v.toC())
 }
 
@@ -10535,7 +10535,7 @@ func (self PlotStyle) LegendSpacing() Vec2 {
 	return *out
 }
 
-func (self *PlotStyle) SetMousePosPadding(v Vec2) {
+func (self PlotStyle) SetMousePosPadding(v Vec2) {
 	C.wrap_ImPlotStyle_SetMousePosPadding(self.handle(), v.toC())
 }
 
@@ -10545,7 +10545,7 @@ func (self PlotStyle) MousePosPadding() Vec2 {
 	return *out
 }
 
-func (self *PlotStyle) SetAnnotationPadding(v Vec2) {
+func (self PlotStyle) SetAnnotationPadding(v Vec2) {
 	C.wrap_ImPlotStyle_SetAnnotationPadding(self.handle(), v.toC())
 }
 
@@ -10555,7 +10555,7 @@ func (self PlotStyle) AnnotationPadding() Vec2 {
 	return *out
 }
 
-func (self *PlotStyle) SetFitPadding(v Vec2) {
+func (self PlotStyle) SetFitPadding(v Vec2) {
 	C.wrap_ImPlotStyle_SetFitPadding(self.handle(), v.toC())
 }
 
@@ -10565,7 +10565,7 @@ func (self PlotStyle) FitPadding() Vec2 {
 	return *out
 }
 
-func (self *PlotStyle) SetPlotDefaultSize(v Vec2) {
+func (self PlotStyle) SetPlotDefaultSize(v Vec2) {
 	C.wrap_ImPlotStyle_SetPlotDefaultSize(self.handle(), v.toC())
 }
 
@@ -10575,7 +10575,7 @@ func (self PlotStyle) PlotDefaultSize() Vec2 {
 	return *out
 }
 
-func (self *PlotStyle) SetPlotMinSize(v Vec2) {
+func (self PlotStyle) SetPlotMinSize(v Vec2) {
 	C.wrap_ImPlotStyle_SetPlotMinSize(self.handle(), v.toC())
 }
 
@@ -10585,7 +10585,7 @@ func (self PlotStyle) PlotMinSize() Vec2 {
 	return *out
 }
 
-func (self *PlotStyle) SetColormap(v PlotColormap) {
+func (self PlotStyle) SetColormap(v PlotColormap) {
 	C.wrap_ImPlotStyle_SetColormap(self.handle(), C.ImPlotColormap(v))
 }
 
@@ -10593,7 +10593,7 @@ func (self PlotStyle) Colormap() PlotColormap {
 	return PlotColormap(C.wrap_ImPlotStyle_GetColormap(self.handle()))
 }
 
-func (self *PlotStyle) SetUseLocalTime(v bool) {
+func (self PlotStyle) SetUseLocalTime(v bool) {
 	C.wrap_ImPlotStyle_SetUseLocalTime(self.handle(), C.bool(v))
 }
 
@@ -10601,7 +10601,7 @@ func (self PlotStyle) UseLocalTime() bool {
 	return C.wrap_ImPlotStyle_GetUseLocalTime(self.handle()) == C.bool(true)
 }
 
-func (self *PlotStyle) SetUseISO8601(v bool) {
+func (self PlotStyle) SetUseISO8601(v bool) {
 	C.wrap_ImPlotStyle_SetUseISO8601(self.handle(), C.bool(v))
 }
 
@@ -10609,7 +10609,7 @@ func (self PlotStyle) UseISO8601() bool {
 	return C.wrap_ImPlotStyle_GetUseISO8601(self.handle()) == C.bool(true)
 }
 
-func (self *PlotStyle) SetUse24HourClock(v bool) {
+func (self PlotStyle) SetUse24HourClock(v bool) {
 	C.wrap_ImPlotStyle_SetUse24HourClock(self.handle(), C.bool(v))
 }
 
@@ -10617,7 +10617,7 @@ func (self PlotStyle) Use24HourClock() bool {
 	return C.wrap_ImPlotStyle_GetUse24HourClock(self.handle()) == C.bool(true)
 }
 
-func (self *PlotSubplot) SetID(v ID) {
+func (self PlotSubplot) SetID(v ID) {
 	C.wrap_ImPlotSubplot_SetID(self.handle(), C.ImGuiID(v))
 }
 
@@ -10625,7 +10625,7 @@ func (self PlotSubplot) ID() ID {
 	return ID(C.wrap_ImPlotSubplot_GetID(self.handle()))
 }
 
-func (self *PlotSubplot) SetFlags(v PlotSubplotFlags) {
+func (self PlotSubplot) SetFlags(v PlotSubplotFlags) {
 	C.wrap_ImPlotSubplot_SetFlags(self.handle(), C.ImPlotSubplotFlags(v))
 }
 
@@ -10633,7 +10633,7 @@ func (self PlotSubplot) Flags() PlotSubplotFlags {
 	return PlotSubplotFlags(C.wrap_ImPlotSubplot_GetFlags(self.handle()))
 }
 
-func (self *PlotSubplot) SetPreviousFlags(v PlotSubplotFlags) {
+func (self PlotSubplot) SetPreviousFlags(v PlotSubplotFlags) {
 	C.wrap_ImPlotSubplot_SetPreviousFlags(self.handle(), C.ImPlotSubplotFlags(v))
 }
 
@@ -10645,7 +10645,7 @@ func (self PlotSubplot) Items() PlotItemGroup {
 	return newPlotItemGroupFromC(C.wrap_ImPlotSubplot_GetItems(self.handle()))
 }
 
-func (self *PlotSubplot) SetRows(v int32) {
+func (self PlotSubplot) SetRows(v int32) {
 	C.wrap_ImPlotSubplot_SetRows(self.handle(), C.int(v))
 }
 
@@ -10653,7 +10653,7 @@ func (self PlotSubplot) Rows() int {
 	return int(C.wrap_ImPlotSubplot_GetRows(self.handle()))
 }
 
-func (self *PlotSubplot) SetCols(v int32) {
+func (self PlotSubplot) SetCols(v int32) {
 	C.wrap_ImPlotSubplot_SetCols(self.handle(), C.int(v))
 }
 
@@ -10661,7 +10661,7 @@ func (self PlotSubplot) Cols() int {
 	return int(C.wrap_ImPlotSubplot_GetCols(self.handle()))
 }
 
-func (self *PlotSubplot) SetCurrentIdx(v int32) {
+func (self PlotSubplot) SetCurrentIdx(v int32) {
 	C.wrap_ImPlotSubplot_SetCurrentIdx(self.handle(), C.int(v))
 }
 
@@ -10669,7 +10669,7 @@ func (self PlotSubplot) CurrentIdx() int {
 	return int(C.wrap_ImPlotSubplot_GetCurrentIdx(self.handle()))
 }
 
-func (self *PlotSubplot) SetFrameRect(v Rect) {
+func (self PlotSubplot) SetFrameRect(v Rect) {
 	C.wrap_ImPlotSubplot_SetFrameRect(self.handle(), v.toC())
 }
 
@@ -10679,7 +10679,7 @@ func (self PlotSubplot) FrameRect() Rect {
 	return *out
 }
 
-func (self *PlotSubplot) SetGridRect(v Rect) {
+func (self PlotSubplot) SetGridRect(v Rect) {
 	C.wrap_ImPlotSubplot_SetGridRect(self.handle(), v.toC())
 }
 
@@ -10689,7 +10689,7 @@ func (self PlotSubplot) GridRect() Rect {
 	return *out
 }
 
-func (self *PlotSubplot) SetCellSize(v Vec2) {
+func (self PlotSubplot) SetCellSize(v Vec2) {
 	C.wrap_ImPlotSubplot_SetCellSize(self.handle(), v.toC())
 }
 
@@ -10699,7 +10699,7 @@ func (self PlotSubplot) CellSize() Vec2 {
 	return *out
 }
 
-func (self *PlotSubplot) SetFrameHovered(v bool) {
+func (self PlotSubplot) SetFrameHovered(v bool) {
 	C.wrap_ImPlotSubplot_SetFrameHovered(self.handle(), C.bool(v))
 }
 
@@ -10707,7 +10707,7 @@ func (self PlotSubplot) FrameHovered() bool {
 	return C.wrap_ImPlotSubplot_GetFrameHovered(self.handle()) == C.bool(true)
 }
 
-func (self *PlotSubplot) SetHasTitle(v bool) {
+func (self PlotSubplot) SetHasTitle(v bool) {
 	C.wrap_ImPlotSubplot_SetHasTitle(self.handle(), C.bool(v))
 }
 
@@ -10715,7 +10715,7 @@ func (self PlotSubplot) HasTitle() bool {
 	return C.wrap_ImPlotSubplot_GetHasTitle(self.handle()) == C.bool(true)
 }
 
-func (self *PlotTag) SetAxis(v PlotAxisEnum) {
+func (self PlotTag) SetAxis(v PlotAxisEnum) {
 	C.wrap_ImPlotTag_SetAxis(self.handle(), C.ImAxis(v))
 }
 
@@ -10723,7 +10723,7 @@ func (self PlotTag) Axis() PlotAxisEnum {
 	return PlotAxisEnum(C.wrap_ImPlotTag_GetAxis(self.handle()))
 }
 
-func (self *PlotTag) SetValue(v float64) {
+func (self PlotTag) SetValue(v float64) {
 	C.wrap_ImPlotTag_SetValue(self.handle(), C.double(v))
 }
 
@@ -10731,7 +10731,7 @@ func (self PlotTag) Value() float64 {
 	return float64(C.wrap_ImPlotTag_GetValue(self.handle()))
 }
 
-func (self *PlotTag) SetColorBg(v uint32) {
+func (self PlotTag) SetColorBg(v uint32) {
 	C.wrap_ImPlotTag_SetColorBg(self.handle(), C.ImU32(v))
 }
 
@@ -10739,7 +10739,7 @@ func (self PlotTag) ColorBg() uint32 {
 	return uint32(C.wrap_ImPlotTag_GetColorBg(self.handle()))
 }
 
-func (self *PlotTag) SetColorFg(v uint32) {
+func (self PlotTag) SetColorFg(v uint32) {
 	C.wrap_ImPlotTag_SetColorFg(self.handle(), C.ImU32(v))
 }
 
@@ -10747,7 +10747,7 @@ func (self PlotTag) ColorFg() uint32 {
 	return uint32(C.wrap_ImPlotTag_GetColorFg(self.handle()))
 }
 
-func (self *PlotTag) SetTextOffset(v int32) {
+func (self PlotTag) SetTextOffset(v int32) {
 	C.wrap_ImPlotTag_SetTextOffset(self.handle(), C.int(v))
 }
 
@@ -10759,7 +10759,7 @@ func (self PlotTagCollection) TextBuffer() TextBuffer {
 	return newTextBufferFromC(C.wrap_ImPlotTagCollection_GetTextBuffer(self.handle()))
 }
 
-func (self *PlotTagCollection) SetSize(v int32) {
+func (self PlotTagCollection) SetSize(v int32) {
 	C.wrap_ImPlotTagCollection_SetSize(self.handle(), C.int(v))
 }
 
@@ -10767,7 +10767,7 @@ func (self PlotTagCollection) Size() int {
 	return int(C.wrap_ImPlotTagCollection_GetSize(self.handle()))
 }
 
-func (self *PlotTick) SetPlotPos(v float64) {
+func (self PlotTick) SetPlotPos(v float64) {
 	C.wrap_ImPlotTick_SetPlotPos(self.handle(), C.double(v))
 }
 
@@ -10775,7 +10775,7 @@ func (self PlotTick) PlotPos() float64 {
 	return float64(C.wrap_ImPlotTick_GetPlotPos(self.handle()))
 }
 
-func (self *PlotTick) SetPixelPos(v float32) {
+func (self PlotTick) SetPixelPos(v float32) {
 	C.wrap_ImPlotTick_SetPixelPos(self.handle(), C.float(v))
 }
 
@@ -10783,7 +10783,7 @@ func (self PlotTick) PixelPos() float32 {
 	return float32(C.wrap_ImPlotTick_GetPixelPos(self.handle()))
 }
 
-func (self *PlotTick) SetLabelSize(v Vec2) {
+func (self PlotTick) SetLabelSize(v Vec2) {
 	C.wrap_ImPlotTick_SetLabelSize(self.handle(), v.toC())
 }
 
@@ -10793,7 +10793,7 @@ func (self PlotTick) LabelSize() Vec2 {
 	return *out
 }
 
-func (self *PlotTick) SetTextOffset(v int32) {
+func (self PlotTick) SetTextOffset(v int32) {
 	C.wrap_ImPlotTick_SetTextOffset(self.handle(), C.int(v))
 }
 
@@ -10801,7 +10801,7 @@ func (self PlotTick) TextOffset() int {
 	return int(C.wrap_ImPlotTick_GetTextOffset(self.handle()))
 }
 
-func (self *PlotTick) SetMajor(v bool) {
+func (self PlotTick) SetMajor(v bool) {
 	C.wrap_ImPlotTick_SetMajor(self.handle(), C.bool(v))
 }
 
@@ -10809,7 +10809,7 @@ func (self PlotTick) Major() bool {
 	return C.wrap_ImPlotTick_GetMajor(self.handle()) == C.bool(true)
 }
 
-func (self *PlotTick) SetShowLabel(v bool) {
+func (self PlotTick) SetShowLabel(v bool) {
 	C.wrap_ImPlotTick_SetShowLabel(self.handle(), C.bool(v))
 }
 
@@ -10817,7 +10817,7 @@ func (self PlotTick) ShowLabel() bool {
 	return C.wrap_ImPlotTick_GetShowLabel(self.handle()) == C.bool(true)
 }
 
-func (self *PlotTick) SetLevel(v int32) {
+func (self PlotTick) SetLevel(v int32) {
 	C.wrap_ImPlotTick_SetLevel(self.handle(), C.int(v))
 }
 
@@ -10825,7 +10825,7 @@ func (self PlotTick) Level() int {
 	return int(C.wrap_ImPlotTick_GetLevel(self.handle()))
 }
 
-func (self *PlotTick) SetIdx(v int32) {
+func (self PlotTick) SetIdx(v int32) {
 	C.wrap_ImPlotTick_SetIdx(self.handle(), C.int(v))
 }
 
@@ -10837,7 +10837,7 @@ func (self PlotTicker) TextBuffer() TextBuffer {
 	return newTextBufferFromC(C.wrap_ImPlotTicker_GetTextBuffer(self.handle()))
 }
 
-func (self *PlotTicker) SetMaxSize(v Vec2) {
+func (self PlotTicker) SetMaxSize(v Vec2) {
 	C.wrap_ImPlotTicker_SetMaxSize(self.handle(), v.toC())
 }
 
@@ -10847,7 +10847,7 @@ func (self PlotTicker) MaxSize() Vec2 {
 	return *out
 }
 
-func (self *PlotTicker) SetLateSize(v Vec2) {
+func (self PlotTicker) SetLateSize(v Vec2) {
 	C.wrap_ImPlotTicker_SetLateSize(self.handle(), v.toC())
 }
 
@@ -10857,7 +10857,7 @@ func (self PlotTicker) LateSize() Vec2 {
 	return *out
 }
 
-func (self *PlotTicker) SetLevels(v int32) {
+func (self PlotTicker) SetLevels(v int32) {
 	C.wrap_ImPlotTicker_SetLevels(self.handle(), C.int(v))
 }
 
@@ -10865,7 +10865,7 @@ func (self PlotTicker) Levels() int {
 	return int(C.wrap_ImPlotTicker_GetLevels(self.handle()))
 }
 
-func (self *PlotTime) SetUs(v int32) {
+func (self PlotTime) SetUs(v int32) {
 	C.wrap_ImPlotTime_SetUs(self.handle(), C.int(v))
 }
 

--- a/cmd/codegen/gengo.go
+++ b/cmd/codegen/gengo.go
@@ -57,12 +57,17 @@ func renameGoIdentifier(n string) string {
 	if r, ok := replace[n]; ok {
 		n = r
 	}
+
 	n = trimImGuiPrefix(n)
-	if strings.HasPrefix(n, "New") {
+	switch {
+	case strings.HasPrefix(n, "New"):
 		n = "New" + trimImGuiPrefix(n[3:])
-	} else if strings.HasPrefix(n, "new") {
+	case strings.HasPrefix(n, "new"):
 		n = "new" + trimImGuiPrefix(n[3:])
+	case strings.HasPrefix(n, "*"):
+		n = "*" + trimImGuiPrefix(n[1:])
 	}
+
 	n = strings.TrimPrefix(n, "Get")
 	if n != "_" {
 		n = strings.ReplaceAll(n, "_", "")

--- a/cmd/codegen/gengo_funcs.go
+++ b/cmd/codegen/gengo_funcs.go
@@ -274,7 +274,7 @@ func (g *goFuncsGenerator) generateFuncDeclarationStmt(receiver string, funcName
 	typeName := funcParts[0]
 
 	if len(receiver) > 0 {
-		receiver = fmt.Sprintf("(self *%s)", renameGoIdentifier(receiver))
+		receiver = fmt.Sprintf("(self %s)", renameGoIdentifier(receiver))
 	}
 
 	// Generate default param value hint


### PR DESCRIPTION
since all the auto-generated structs are already uintptrs (what means they are pointer on C-side) we don't need pointer receivers in GO (because of #87)

close #87