### PR TITLE
add window.SetShouldClose method

### DIFF
--- a/backend.cpp
+++ b/backend.cpp
@@ -277,4 +277,8 @@ void igGLFWWindow_GetDisplaySize(GLFWwindow *window, int *width, int *height) {
   glfwGetWindowSize(window, width, height);
 }
 
+void igGLFWWindow_SetShouldClose(GLFWwindow *window, int value){
+  glfwSetWindowShouldClose(window, value);
+}
+
 #endif

--- a/backend.go
+++ b/backend.go
@@ -90,13 +90,7 @@ func (w GLFWwindow) DisplaySize() (width int32, height int32) {
 }
 
 func (w GLFWwindow) SetShouldClose(value bool) {
-	var valueInt int
-
-	if value {
-		valueInt = 1
-	}
-
-	C.igGLFWWindow_SetShouldClose(w.handle(), C.int(valueInt))
+	C.igGLFWWindow_SetShouldClose(w.handle(), C.int(castBool(value)))
 }
 
 //export glfwWindowLoopCallback

--- a/backend.go
+++ b/backend.go
@@ -89,6 +89,16 @@ func (w GLFWwindow) DisplaySize() (width int32, height int32) {
 	return
 }
 
+func (w GLFWwindow) SetWindowShouldClose(value bool) {
+	var valueInt int
+
+	if value {
+		valueInt = 1
+	}
+
+	C.igGLFWWindow_SetShouldClose(w.handle(), C.int(valueInt))
+}
+
 //export glfwWindowLoopCallback
 func glfwWindowLoopCallback() {
 	if loopFunc != nil {

--- a/backend.go
+++ b/backend.go
@@ -89,7 +89,7 @@ func (w GLFWwindow) DisplaySize() (width int32, height int32) {
 	return
 }
 
-func (w GLFWwindow) SetWindowShouldClose(value bool) {
+func (w GLFWwindow) SetShouldClose(value bool) {
 	var valueInt int
 
 	if value {

--- a/backend.h
+++ b/backend.h
@@ -30,6 +30,7 @@ extern GLFWwindow *igCreateGLFWWindow(const char *title, int width, int height, 
 extern void igRunLoop(GLFWwindow *window, VoidCallback loop, VoidCallback beforeRender, VoidCallback afterRender,
                       VoidCallback beforeDestroyContext);
 extern void igGLFWWindow_GetDisplaySize(GLFWwindow *window, int *width, int *height);
+extern void igGLFWWindow_SetShouldClose(GLFWwindow *window, int value);
 extern void igRefresh();
 extern ImTextureID igCreateTexture(unsigned char *pixels, int width, int height);
 extern void igDeleteTexture(ImTextureID id);


### PR DESCRIPTION
Issue #108 

[glfwSetWindowShouldClose](https://www.glfw.org/docs/latest/group__window.html#ga49c449dde2a6f87d996f4daaa09d6708)
```
This function sets the value of the close flag of the specified window. This can be used to override the user's attempt to close the window, or to signal that it should be closed.
```