### PR TITLE
make: use gofumpt instead of gofmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ all: generate
 define generate
 	@echo "Generating for $(1)"
 	go run github.com/AllenDang/cimgui-go/cmd/codegen -p $(1) -i $(2) -d $(3) -e $(4) $(5)
-	gofmt -w $(1)_enums.go
-	gofmt -w $(1)_structs.go
-	gofmt -w $(1)_funcs.go
+	go run mvdan.cc/gofumpt@latest -w $(1)_enums.go
+	go run mvdan.cc/gofumpt@latest -w $(1)_structs.go
+	go run mvdan.cc/gofumpt@latest -w $(1)_funcs.go
 endef
 
 ## cimgui: generate cimgui binding

--- a/cimgui_funcs.go
+++ b/cimgui_funcs.go
@@ -29,7 +29,6 @@ func (self *Color) SetHSVV(h float32, s float32, v float32, a float32) {
 	C.ImColor_SetHSV(selfArg, C.float(h), C.float(s), C.float(v), C.float(a))
 
 	selfFin()
-
 }
 
 func (self *Color) Destroy() {
@@ -37,7 +36,6 @@ func (self *Color) Destroy() {
 	C.ImColor_destroy(selfArg)
 
 	selfFin()
-
 }
 
 func (self DrawCmd) TexID() TextureID {
@@ -134,7 +132,6 @@ func (self DrawList) AddConvexPolyFilled(points *Vec2, num_points int32, col uin
 	C.ImDrawList_AddConvexPolyFilled(self.handle(), pointsArg, C.int(num_points), C.ImU32(col))
 
 	pointsFin()
-
 }
 
 func (self DrawList) AddDrawCmd() {
@@ -186,7 +183,6 @@ func (self DrawList) AddPolyline(points *Vec2, num_points int32, col uint32, fla
 	C.ImDrawList_AddPolyline(self.handle(), pointsArg, C.int(num_points), C.ImU32(col), C.ImDrawFlags(flags), C.float(thickness))
 
 	pointsFin()
-
 }
 
 // AddQuadV parameter default value hint:
@@ -229,7 +225,6 @@ func (self DrawList) AddTextFontPtrV(font Font, font_size float32, pos Vec2, col
 
 	text_beginFin()
 	cpu_fine_clip_rectFin()
-
 }
 
 // AddTextVec2V parameter default value hint:
@@ -239,7 +234,6 @@ func (self DrawList) AddTextVec2V(pos Vec2, col uint32, text_begin string) {
 	C.wrap_ImDrawList_AddText_Vec2V(self.handle(), pos.toC(), C.ImU32(col), text_beginArg)
 
 	text_beginFin()
-
 }
 
 // AddTriangleV parameter default value hint:
@@ -444,7 +438,6 @@ func (self FontAtlas) AddFontFromFileTTFV(filename string, size_pixels float32, 
 
 	defer func() {
 		filenameFin()
-
 	}()
 	return (Font)(unsafe.Pointer(C.ImFontAtlas_AddFontFromFileTTF(self.handle(), filenameArg, C.float(size_pixels), font_cfg.handle(), (*C.ImWchar)(glyph_ranges))))
 }
@@ -457,7 +450,6 @@ func (self FontAtlas) AddFontFromMemoryCompressedBase85TTFV(compressed_font_data
 
 	defer func() {
 		compressed_font_data_base85Fin()
-
 	}()
 	return (Font)(unsafe.Pointer(C.ImFontAtlas_AddFontFromMemoryCompressedBase85TTF(self.handle(), compressed_font_data_base85Arg, C.float(size_pixels), font_cfg.handle(), (*C.ImWchar)(glyph_ranges))))
 }
@@ -487,7 +479,6 @@ func (self FontAtlas) CalcCustomRectUV(rect FontAtlasCustomRect, out_uv_min *Vec
 
 	out_uv_minFin()
 	out_uv_maxFin()
-
 }
 
 func (self FontAtlas) Clear() {
@@ -576,7 +567,6 @@ func (self FontAtlas) MouseCursorTexData(cursor MouseCursor, out_offset *Vec2, o
 		for _, out_uv_fillV := range out_uv_fillFin {
 			out_uv_fillV()
 		}
-
 	}()
 	return C.ImFontAtlas_GetMouseCursorTexData(self.handle(), C.ImGuiMouseCursor(cursor), out_offsetArg, out_sizeArg, (*C.ImVec2)(&out_uv_borderArg[0]), (*C.ImVec2)(&out_uv_fillArg[0])) == C.bool(true)
 }
@@ -620,7 +610,6 @@ func (self FontGlyphRangesBuilder) AddTextV(text string) {
 	C.wrap_ImFontGlyphRangesBuilder_AddTextV(self.handle(), textArg)
 
 	textFin()
-
 }
 
 func (self FontGlyphRangesBuilder) Clear() {
@@ -680,7 +669,6 @@ func (self Font) CalcWordWrapPositionA(scale float32, text string, wrap_width fl
 
 	defer func() {
 		textFin()
-
 	}()
 	return C.GoString(C.wrap_ImFont_CalcWordWrapPositionA(self.handle(), C.float(scale), textArg, C.float(wrap_width)))
 }
@@ -733,7 +721,6 @@ func (self Font) RenderTextV(draw_list DrawList, size float32, pos Vec2, col uin
 	C.wrap_ImFont_RenderTextV(self.handle(), draw_list.handle(), C.float(size), pos.toC(), C.ImU32(col), clip_rect.toC(), text_beginArg, C.float(wrap_width), C.bool(cpu_fine_clip))
 
 	text_beginFin()
-
 }
 
 func (self Font) SetGlyphVisible(c Wchar, visible bool) {
@@ -773,7 +760,6 @@ func (self IO) AddInputCharactersUTF8(str string) {
 	C.ImGuiIO_AddInputCharactersUTF8(self.handle(), strArg)
 
 	strFin()
-
 }
 
 func (self IO) AddKeyAnalogEvent(key Key, down bool, v float32) {
@@ -853,7 +839,6 @@ func (self InputTextCallbackData) InsertCharsV(pos int32, text string) {
 	C.wrap_ImGuiInputTextCallbackData_InsertCharsV(self.handle(), C.int(pos), textArg)
 
 	textFin()
-
 }
 
 func (self InputTextCallbackData) SelectAll() {
@@ -959,7 +944,6 @@ func (self Payload) IsDataType(typeArg string) bool {
 
 	defer func() {
 		typeArgFin()
-
 	}()
 	return C.ImGuiPayload_IsDataType(self.handle(), typeArgArg) == C.bool(true)
 }
@@ -1097,7 +1081,6 @@ func (self TextBuffer) AppendV(str string, str_end string) {
 
 	strFin()
 	str_endFin()
-
 }
 
 func (self TextBuffer) Appendf(fmt string) {
@@ -1105,7 +1088,6 @@ func (self TextBuffer) Appendf(fmt string) {
 	C.wrap_ImGuiTextBuffer_Appendf(self.handle(), fmtArg)
 
 	fmtFin()
-
 }
 
 func (self TextBuffer) Begin() string {
@@ -1156,7 +1138,6 @@ func (self TextFilter) DrawV(label string, width float32) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.ImGuiTextFilter_Draw(self.handle(), labelArg, C.float(width)) == C.bool(true)
 }
@@ -1168,7 +1149,6 @@ func NewTextFilter(default_filter string) TextFilter {
 
 	defer func() {
 		default_filterFin()
-
 	}()
 	return (TextFilter)(unsafe.Pointer(C.ImGuiTextFilter_ImGuiTextFilter(default_filterArg)))
 }
@@ -1184,7 +1164,6 @@ func (self TextFilter) PassFilterV(text string) bool {
 
 	defer func() {
 		textFin()
-
 	}()
 	return C.wrap_ImGuiTextFilter_PassFilterV(self.handle(), textArg) == C.bool(true)
 }
@@ -1240,7 +1219,6 @@ func (self *Rect) Destroy() {
 	C.ImRect_destroy(selfArg)
 
 	selfFin()
-
 }
 
 func (self *Vec2) Destroy() {
@@ -1248,7 +1226,6 @@ func (self *Vec2) Destroy() {
 	C.ImVec2_destroy(selfArg)
 
 	selfFin()
-
 }
 
 func (self *Vec4) Destroy() {
@@ -1256,7 +1233,6 @@ func (self *Vec4) Destroy() {
 	C.ImVec4_destroy(selfArg)
 
 	selfFin()
-
 }
 
 // AcceptDragDropPayloadV parameter default value hint:
@@ -1266,7 +1242,6 @@ func AcceptDragDropPayloadV(typeArg string, flags DragDropFlags) Payload {
 
 	defer func() {
 		typeArgFin()
-
 	}()
 	return (Payload)(unsafe.Pointer(C.igAcceptDragDropPayload(typeArgArg, C.ImGuiDragDropFlags(flags))))
 }
@@ -1280,7 +1255,6 @@ func ArrowButton(str_id string, dir Dir) bool {
 
 	defer func() {
 		str_idFin()
-
 	}()
 	return C.igArrowButton(str_idArg, C.ImGuiDir(dir)) == C.bool(true)
 }
@@ -1295,7 +1269,6 @@ func BeginV(name string, p_open *bool, flags WindowFlags) bool {
 	defer func() {
 		nameFin()
 		p_openFin()
-
 	}()
 	return C.igBegin(nameArg, p_openArg, C.ImGuiWindowFlags(flags)) == C.bool(true)
 }
@@ -1323,7 +1296,6 @@ func BeginChildStrV(str_id string, size Vec2, border bool, flags WindowFlags) bo
 
 	defer func() {
 		str_idFin()
-
 	}()
 	return C.igBeginChild_Str(str_idArg, size.toC(), C.bool(border), C.ImGuiWindowFlags(flags)) == C.bool(true)
 }
@@ -1337,7 +1309,6 @@ func BeginComboV(label string, preview_value string, flags ComboFlags) bool {
 	defer func() {
 		labelFin()
 		preview_valueFin()
-
 	}()
 	return C.igBeginCombo(labelArg, preview_valueArg, C.ImGuiComboFlags(flags)) == C.bool(true)
 }
@@ -1369,7 +1340,6 @@ func BeginListBoxV(label string, size Vec2) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.igBeginListBox(labelArg, size.toC()) == C.bool(true)
 }
@@ -1385,7 +1355,6 @@ func BeginMenuV(label string, enabled bool) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.igBeginMenu(labelArg, C.bool(enabled)) == C.bool(true)
 }
@@ -1401,7 +1370,6 @@ func BeginPopupV(str_id string, flags WindowFlags) bool {
 
 	defer func() {
 		str_idFin()
-
 	}()
 	return C.igBeginPopup(str_idArg, C.ImGuiWindowFlags(flags)) == C.bool(true)
 }
@@ -1414,7 +1382,6 @@ func BeginPopupContextItemV(str_id string, popup_flags PopupFlags) bool {
 
 	defer func() {
 		str_idFin()
-
 	}()
 	return C.igBeginPopupContextItem(str_idArg, C.ImGuiPopupFlags(popup_flags)) == C.bool(true)
 }
@@ -1427,7 +1394,6 @@ func BeginPopupContextVoidV(str_id string, popup_flags PopupFlags) bool {
 
 	defer func() {
 		str_idFin()
-
 	}()
 	return C.igBeginPopupContextVoid(str_idArg, C.ImGuiPopupFlags(popup_flags)) == C.bool(true)
 }
@@ -1440,7 +1406,6 @@ func BeginPopupContextWindowV(str_id string, popup_flags PopupFlags) bool {
 
 	defer func() {
 		str_idFin()
-
 	}()
 	return C.igBeginPopupContextWindow(str_idArg, C.ImGuiPopupFlags(popup_flags)) == C.bool(true)
 }
@@ -1455,7 +1420,6 @@ func BeginPopupModalV(name string, p_open *bool, flags WindowFlags) bool {
 	defer func() {
 		nameFin()
 		p_openFin()
-
 	}()
 	return C.igBeginPopupModal(nameArg, p_openArg, C.ImGuiWindowFlags(flags)) == C.bool(true)
 }
@@ -1467,7 +1431,6 @@ func BeginTabBarV(str_id string, flags TabBarFlags) bool {
 
 	defer func() {
 		str_idFin()
-
 	}()
 	return C.igBeginTabBar(str_idArg, C.ImGuiTabBarFlags(flags)) == C.bool(true)
 }
@@ -1482,7 +1445,6 @@ func BeginTabItemV(label string, p_open *bool, flags TabItemFlags) bool {
 	defer func() {
 		labelFin()
 		p_openFin()
-
 	}()
 	return C.igBeginTabItem(labelArg, p_openArg, C.ImGuiTabItemFlags(flags)) == C.bool(true)
 }
@@ -1496,7 +1458,6 @@ func BeginTableV(str_id string, column int32, flags TableFlags, outer_size Vec2,
 
 	defer func() {
 		str_idFin()
-
 	}()
 	return C.igBeginTable(str_idArg, C.int(column), C.ImGuiTableFlags(flags), outer_size.toC(), C.float(inner_width)) == C.bool(true)
 }
@@ -1514,7 +1475,6 @@ func BulletText(fmt string) {
 	C.wrap_igBulletText(fmtArg)
 
 	fmtFin()
-
 }
 
 // ButtonV parameter default value hint:
@@ -1524,7 +1484,6 @@ func ButtonV(label string, size Vec2) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.igButton(labelArg, size.toC()) == C.bool(true)
 }
@@ -1557,7 +1516,6 @@ func Checkbox(label string, v *bool) bool {
 	defer func() {
 		labelFin()
 		vFin()
-
 	}()
 	return C.igCheckbox(labelArg, vArg) == C.bool(true)
 }
@@ -1569,7 +1527,6 @@ func CheckboxFlagsIntPtr(label string, flags *int32, flags_value int32) bool {
 	defer func() {
 		labelFin()
 		flagsFin()
-
 	}()
 	return C.igCheckboxFlags_IntPtr(labelArg, flagsArg, C.int(flags_value)) == C.bool(true)
 }
@@ -1581,7 +1538,6 @@ func CheckboxFlagsUintPtr(label string, flags *uint32, flags_value uint32) bool 
 	defer func() {
 		labelFin()
 		flagsFin()
-
 	}()
 	return C.igCheckboxFlags_UintPtr(labelArg, flagsArg, C.uint(flags_value)) == C.bool(true)
 }
@@ -1599,7 +1555,6 @@ func CollapsingHeaderBoolPtrV(label string, p_visible *bool, flags TreeNodeFlags
 	defer func() {
 		labelFin()
 		p_visibleFin()
-
 	}()
 	return C.igCollapsingHeader_BoolPtr(labelArg, p_visibleArg, C.ImGuiTreeNodeFlags(flags)) == C.bool(true)
 }
@@ -1611,7 +1566,6 @@ func CollapsingHeaderTreeNodeFlagsV(label string, flags TreeNodeFlags) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.igCollapsingHeader_TreeNodeFlags(labelArg, C.ImGuiTreeNodeFlags(flags)) == C.bool(true)
 }
@@ -1624,7 +1578,6 @@ func ColorButtonV(desc_id string, col Vec4, flags ColorEditFlags, size Vec2) boo
 
 	defer func() {
 		desc_idFin()
-
 	}()
 	return C.igColorButton(desc_idArg, col.toC(), C.ImGuiColorEditFlags(flags), size.toC()) == C.bool(true)
 }
@@ -1642,7 +1595,6 @@ func ColorConvertHSVtoRGB(h float32, s float32, v float32, out_r *float32, out_g
 	out_rFin()
 	out_gFin()
 	out_bFin()
-
 }
 
 func ColorConvertRGBtoHSV(r float32, g float32, b float32, out_h *float32, out_s *float32, out_v *float32) {
@@ -1654,7 +1606,6 @@ func ColorConvertRGBtoHSV(r float32, g float32, b float32, out_h *float32, out_s
 	out_hFin()
 	out_sFin()
 	out_vFin()
-
 }
 
 func ColorConvertU32ToFloat4(in uint32) Vec4 {
@@ -1684,7 +1635,6 @@ func ColorEdit3V(label string, col *[3]float32, flags ColorEditFlags) bool {
 		for i, colV := range colArg {
 			(*col)[i] = float32(colV)
 		}
-
 	}()
 	return C.igColorEdit3(labelArg, (*C.float)(&colArg[0]), C.ImGuiColorEditFlags(flags)) == C.bool(true)
 }
@@ -1705,7 +1655,6 @@ func ColorEdit4V(label string, col *[4]float32, flags ColorEditFlags) bool {
 		for i, colV := range colArg {
 			(*col)[i] = float32(colV)
 		}
-
 	}()
 	return C.igColorEdit4(labelArg, (*C.float)(&colArg[0]), C.ImGuiColorEditFlags(flags)) == C.bool(true)
 }
@@ -1726,7 +1675,6 @@ func ColorPicker3V(label string, col *[3]float32, flags ColorEditFlags) bool {
 		for i, colV := range colArg {
 			(*col)[i] = float32(colV)
 		}
-
 	}()
 	return C.igColorPicker3(labelArg, (*C.float)(&colArg[0]), C.ImGuiColorEditFlags(flags)) == C.bool(true)
 }
@@ -1748,7 +1696,6 @@ func ColorPicker4V(label string, col *[4]float32, flags ColorEditFlags, ref_col 
 		for i, colV := range colArg {
 			(*col)[i] = float32(colV)
 		}
-
 	}()
 	return C.igColorPicker4(labelArg, (*C.float)(&colArg[0]), C.ImGuiColorEditFlags(flags), (*C.float)(&(ref_col[0]))) == C.bool(true)
 }
@@ -1762,7 +1709,6 @@ func ColumnsV(count int32, id string, border bool) {
 	C.igColumns(C.int(count), idArg, C.bool(border))
 
 	idFin()
-
 }
 
 // ComboStrV parameter default value hint:
@@ -1776,7 +1722,6 @@ func ComboStrV(label string, current_item *int32, items_separated_by_zeros strin
 		labelFin()
 		current_itemFin()
 		items_separated_by_zerosFin()
-
 	}()
 	return C.igCombo_Str(labelArg, current_itemArg, items_separated_by_zerosArg, C.int(popup_max_height_in_items)) == C.bool(true)
 }
@@ -1792,7 +1737,6 @@ func ComboStrarrV(label string, current_item *int32, items []string, items_count
 		labelFin()
 		current_itemFin()
 		itemsFin()
-
 	}()
 	return C.igCombo_Str_arr(labelArg, current_itemArg, itemsArg, C.int(items_count), C.int(popup_max_height_in_items)) == C.bool(true)
 }
@@ -1808,7 +1752,6 @@ func DebugCheckVersionAndDataLayout(version_str string, sz_io uint64, sz_style u
 
 	defer func() {
 		version_strFin()
-
 	}()
 	return C.igDebugCheckVersionAndDataLayout(version_strArg, C.xulong(sz_io), C.xulong(sz_style), C.xulong(sz_vec2), C.xulong(sz_vec4), C.xulong(sz_drawvert), C.xulong(sz_drawidx)) == C.bool(true)
 }
@@ -1818,7 +1761,6 @@ func DebugTextEncoding(text string) {
 	C.igDebugTextEncoding(textArg)
 
 	textFin()
-
 }
 
 // DestroyContextV parameter default value hint:
@@ -1862,7 +1804,6 @@ func DragFloatV(label string, v *float32, v_speed float32, v_min float32, v_max 
 		labelFin()
 		vFin()
 		formatFin()
-
 	}()
 	return C.igDragFloat(labelArg, vArg, C.float(v_speed), C.float(v_min), C.float(v_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -1890,7 +1831,6 @@ func DragFloat2V(label string, v *[2]float32, v_speed float32, v_min float32, v_
 		}
 
 		formatFin()
-
 	}()
 	return C.igDragFloat2(labelArg, (*C.float)(&vArg[0]), C.float(v_speed), C.float(v_min), C.float(v_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -1918,7 +1858,6 @@ func DragFloat3V(label string, v *[3]float32, v_speed float32, v_min float32, v_
 		}
 
 		formatFin()
-
 	}()
 	return C.igDragFloat3(labelArg, (*C.float)(&vArg[0]), C.float(v_speed), C.float(v_min), C.float(v_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -1946,7 +1885,6 @@ func DragFloat4V(label string, v *[4]float32, v_speed float32, v_min float32, v_
 		}
 
 		formatFin()
-
 	}()
 	return C.igDragFloat4(labelArg, (*C.float)(&vArg[0]), C.float(v_speed), C.float(v_min), C.float(v_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -1971,7 +1909,6 @@ func DragFloatRange2V(label string, v_current_min *float32, v_current_max *float
 		v_current_maxFin()
 		formatFin()
 		format_maxFin()
-
 	}()
 	return C.igDragFloatRange2(labelArg, v_current_minArg, v_current_maxArg, C.float(v_speed), C.float(v_min), C.float(v_max), formatArg, format_maxArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -1991,7 +1928,6 @@ func DragIntV(label string, v *int32, v_speed float32, v_min int32, v_max int32,
 		labelFin()
 		vFin()
 		formatFin()
-
 	}()
 	return C.igDragInt(labelArg, vArg, C.float(v_speed), C.int(v_min), C.int(v_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -2019,7 +1955,6 @@ func DragInt2V(label string, v *[2]int32, v_speed float32, v_min int32, v_max in
 		}
 
 		formatFin()
-
 	}()
 	return C.igDragInt2(labelArg, (*C.int)(&vArg[0]), C.float(v_speed), C.int(v_min), C.int(v_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -2047,7 +1982,6 @@ func DragInt3V(label string, v *[3]int32, v_speed float32, v_min int32, v_max in
 		}
 
 		formatFin()
-
 	}()
 	return C.igDragInt3(labelArg, (*C.int)(&vArg[0]), C.float(v_speed), C.int(v_min), C.int(v_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -2075,7 +2009,6 @@ func DragInt4V(label string, v *[4]int32, v_speed float32, v_min int32, v_max in
 		}
 
 		formatFin()
-
 	}()
 	return C.igDragInt4(labelArg, (*C.int)(&vArg[0]), C.float(v_speed), C.int(v_min), C.int(v_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -2100,7 +2033,6 @@ func DragIntRange2V(label string, v_current_min *int32, v_current_max *int32, v_
 		v_current_maxFin()
 		formatFin()
 		format_maxFin()
-
 	}()
 	return C.igDragIntRange2(labelArg, v_current_minArg, v_current_maxArg, C.float(v_speed), C.int(v_min), C.int(v_max), formatArg, format_maxArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -2118,7 +2050,6 @@ func DragScalarV(label string, data_type DataType, p_data unsafe.Pointer, v_spee
 	defer func() {
 		labelFin()
 		formatFin()
-
 	}()
 	return C.igDragScalar(labelArg, C.ImGuiDataType(data_type), (p_data), C.float(v_speed), (p_min), (p_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -2136,7 +2067,6 @@ func DragScalarNV(label string, data_type DataType, p_data unsafe.Pointer, compo
 	defer func() {
 		labelFin()
 		formatFin()
-
 	}()
 	return C.igDragScalarN(labelArg, C.ImGuiDataType(data_type), (p_data), C.int(components), C.float(v_speed), (p_min), (p_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -2398,7 +2328,6 @@ func IDStr(str_id string) ID {
 
 	defer func() {
 		str_idFin()
-
 	}()
 	return ID(C.igGetID_Str(str_idArg))
 }
@@ -2410,7 +2339,6 @@ func IDStrStr(str_id_begin string, str_id_end string) ID {
 	defer func() {
 		str_id_beginFin()
 		str_id_endFin()
-
 	}()
 	return ID(C.igGetID_StrStr(str_id_beginArg, str_id_endArg))
 }
@@ -2657,7 +2585,6 @@ func ImageButtonV(str_id string, user_texture_id TextureID, size Vec2, uv0 Vec2,
 
 	defer func() {
 		str_idFin()
-
 	}()
 	return C.igImageButton(str_idArg, C.ImTextureID(user_texture_id), size.toC(), uv0.toC(), uv1.toC(), bg_col.toC(), tint_col.toC()) == C.bool(true)
 }
@@ -2682,7 +2609,6 @@ func InputDoubleV(label string, v *float64, step float64, step_fast float64, for
 		labelFin()
 		vFin()
 		formatFin()
-
 	}()
 	return C.igInputDouble(labelArg, vArg, C.double(step), C.double(step_fast), formatArg, C.ImGuiInputTextFlags(flags)) == C.bool(true)
 }
@@ -2701,7 +2627,6 @@ func InputFloatV(label string, v *float32, step float32, step_fast float32, form
 		labelFin()
 		vFin()
 		formatFin()
-
 	}()
 	return C.igInputFloat(labelArg, vArg, C.float(step), C.float(step_fast), formatArg, C.ImGuiInputTextFlags(flags)) == C.bool(true)
 }
@@ -2726,7 +2651,6 @@ func InputFloat2V(label string, v *[2]float32, format string, flags InputTextFla
 		}
 
 		formatFin()
-
 	}()
 	return C.igInputFloat2(labelArg, (*C.float)(&vArg[0]), formatArg, C.ImGuiInputTextFlags(flags)) == C.bool(true)
 }
@@ -2751,7 +2675,6 @@ func InputFloat3V(label string, v *[3]float32, format string, flags InputTextFla
 		}
 
 		formatFin()
-
 	}()
 	return C.igInputFloat3(labelArg, (*C.float)(&vArg[0]), formatArg, C.ImGuiInputTextFlags(flags)) == C.bool(true)
 }
@@ -2776,7 +2699,6 @@ func InputFloat4V(label string, v *[4]float32, format string, flags InputTextFla
 		}
 
 		formatFin()
-
 	}()
 	return C.igInputFloat4(labelArg, (*C.float)(&vArg[0]), formatArg, C.ImGuiInputTextFlags(flags)) == C.bool(true)
 }
@@ -2792,7 +2714,6 @@ func InputIntV(label string, v *int32, step int32, step_fast int32, flags InputT
 	defer func() {
 		labelFin()
 		vFin()
-
 	}()
 	return C.igInputInt(labelArg, vArg, C.int(step), C.int(step_fast), C.ImGuiInputTextFlags(flags)) == C.bool(true)
 }
@@ -2813,7 +2734,6 @@ func InputInt2V(label string, v *[2]int32, flags InputTextFlags) bool {
 		for i, vV := range vArg {
 			(*v)[i] = int32(vV)
 		}
-
 	}()
 	return C.igInputInt2(labelArg, (*C.int)(&vArg[0]), C.ImGuiInputTextFlags(flags)) == C.bool(true)
 }
@@ -2834,7 +2754,6 @@ func InputInt3V(label string, v *[3]int32, flags InputTextFlags) bool {
 		for i, vV := range vArg {
 			(*v)[i] = int32(vV)
 		}
-
 	}()
 	return C.igInputInt3(labelArg, (*C.int)(&vArg[0]), C.ImGuiInputTextFlags(flags)) == C.bool(true)
 }
@@ -2855,7 +2774,6 @@ func InputInt4V(label string, v *[4]int32, flags InputTextFlags) bool {
 		for i, vV := range vArg {
 			(*v)[i] = int32(vV)
 		}
-
 	}()
 	return C.igInputInt4(labelArg, (*C.int)(&vArg[0]), C.ImGuiInputTextFlags(flags)) == C.bool(true)
 }
@@ -2872,7 +2790,6 @@ func InputScalarV(label string, data_type DataType, p_data unsafe.Pointer, p_ste
 	defer func() {
 		labelFin()
 		formatFin()
-
 	}()
 	return C.igInputScalar(labelArg, C.ImGuiDataType(data_type), (p_data), (p_step), (p_step_fast), formatArg, C.ImGuiInputTextFlags(flags)) == C.bool(true)
 }
@@ -2889,7 +2806,6 @@ func InputScalarNV(label string, data_type DataType, p_data unsafe.Pointer, comp
 	defer func() {
 		labelFin()
 		formatFin()
-
 	}()
 	return C.igInputScalarN(labelArg, C.ImGuiDataType(data_type), (p_data), C.int(components), (p_step), (p_step_fast), formatArg, C.ImGuiInputTextFlags(flags)) == C.bool(true)
 }
@@ -2901,7 +2817,6 @@ func InvisibleButtonV(str_id string, size Vec2, flags ButtonFlags) bool {
 
 	defer func() {
 		str_idFin()
-
 	}()
 	return C.igInvisibleButton(str_idArg, size.toC(), C.ImGuiButtonFlags(flags)) == C.bool(true)
 }
@@ -3013,7 +2928,6 @@ func IsMousePosValidV(mouse_pos *Vec2) bool {
 
 	defer func() {
 		mouse_posFin()
-
 	}()
 	return C.igIsMousePosValid(mouse_posArg) == C.bool(true)
 }
@@ -3029,7 +2943,6 @@ func IsPopupOpenStrV(str_id string, flags PopupFlags) bool {
 
 	defer func() {
 		str_idFin()
-
 	}()
 	return C.igIsPopupOpen_Str(str_idArg, C.ImGuiPopupFlags(flags)) == C.bool(true)
 }
@@ -3073,7 +2986,6 @@ func LabelText(label string, fmt string) {
 
 	labelFin()
 	fmtFin()
-
 }
 
 // ListBoxStrarrV parameter default value hint:
@@ -3087,7 +2999,6 @@ func ListBoxStrarrV(label string, current_item *int32, items []string, items_cou
 		labelFin()
 		current_itemFin()
 		itemsFin()
-
 	}()
 	return C.igListBox_Str_arr(labelArg, current_itemArg, itemsArg, C.int(items_count), C.int(height_in_items)) == C.bool(true)
 }
@@ -3097,7 +3008,6 @@ func LoadIniSettingsFromDisk(ini_filename string) {
 	C.igLoadIniSettingsFromDisk(ini_filenameArg)
 
 	ini_filenameFin()
-
 }
 
 // LoadIniSettingsFromMemoryV parameter default value hint:
@@ -3107,7 +3017,6 @@ func LoadIniSettingsFromMemoryV(ini_data string, ini_size uint64) {
 	C.igLoadIniSettingsFromMemory(ini_dataArg, C.xulong(ini_size))
 
 	ini_dataFin()
-
 }
 
 func LogButtons() {
@@ -3123,7 +3032,6 @@ func LogText(fmt string) {
 	C.wrap_igLogText(fmtArg)
 
 	fmtFin()
-
 }
 
 // LogToClipboardV parameter default value hint:
@@ -3140,7 +3048,6 @@ func LogToFileV(auto_open_depth int32, filename string) {
 	C.igLogToFile(C.int(auto_open_depth), filenameArg)
 
 	filenameFin()
-
 }
 
 // LogToTTYV parameter default value hint:
@@ -3168,7 +3075,6 @@ func MenuItemBoolV(label string, shortcut string, selected bool, enabled bool) b
 	defer func() {
 		labelFin()
 		shortcutFin()
-
 	}()
 	return C.igMenuItem_Bool(labelArg, shortcutArg, C.bool(selected), C.bool(enabled)) == C.bool(true)
 }
@@ -3184,7 +3090,6 @@ func MenuItemBoolPtrV(label string, shortcut string, p_selected *bool, enabled b
 		labelFin()
 		shortcutFin()
 		p_selectedFin()
-
 	}()
 	return C.igMenuItem_BoolPtr(labelArg, shortcutArg, p_selectedArg, C.bool(enabled)) == C.bool(true)
 }
@@ -3209,7 +3114,6 @@ func OpenPopupOnItemClickV(str_id string, popup_flags PopupFlags) {
 	C.igOpenPopupOnItemClick(str_idArg, C.ImGuiPopupFlags(popup_flags))
 
 	str_idFin()
-
 }
 
 // OpenPopupIDV parameter default value hint:
@@ -3225,7 +3129,6 @@ func OpenPopupStrV(str_id string, popup_flags PopupFlags) {
 	C.igOpenPopup_Str(str_idArg, C.ImGuiPopupFlags(popup_flags))
 
 	str_idFin()
-
 }
 
 // PlotHistogramFloatPtrV parameter default value hint:
@@ -3242,7 +3145,6 @@ func PlotHistogramFloatPtrV(label string, values []float32, values_count int32, 
 
 	labelFin()
 	overlay_textFin()
-
 }
 
 // PlotLinesFloatPtrV parameter default value hint:
@@ -3259,7 +3161,6 @@ func PlotLinesFloatPtrV(label string, values []float32, values_count int32, valu
 
 	labelFin()
 	overlay_textFin()
-
 }
 
 func PopAllowKeyboardFocus() {
@@ -3310,7 +3211,6 @@ func ProgressBarV(fraction float32, size_arg Vec2, overlay string) {
 	C.igProgressBar(C.float(fraction), size_arg.toC(), overlayArg)
 
 	overlayFin()
-
 }
 
 func PushAllowKeyboardFocus(allow_keyboard_focus bool) {
@@ -3342,7 +3242,6 @@ func PushIDStr(str_id string) {
 	C.igPushID_Str(str_idArg)
 
 	str_idFin()
-
 }
 
 func PushIDStrStr(str_id_begin string, str_id_end string) {
@@ -3352,7 +3251,6 @@ func PushIDStrStr(str_id_begin string, str_id_end string) {
 
 	str_id_beginFin()
 	str_id_endFin()
-
 }
 
 func PushItemWidth(item_width float32) {
@@ -3386,7 +3284,6 @@ func RadioButtonBool(label string, active bool) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.igRadioButton_Bool(labelArg, C.bool(active)) == C.bool(true)
 }
@@ -3398,7 +3295,6 @@ func RadioButtonIntPtr(label string, v *int32, v_button int32) bool {
 	defer func() {
 		labelFin()
 		vFin()
-
 	}()
 	return C.igRadioButton_IntPtr(labelArg, vArg, C.int(v_button)) == C.bool(true)
 }
@@ -3432,7 +3328,6 @@ func SaveIniSettingsToDisk(ini_filename string) {
 	C.igSaveIniSettingsToDisk(ini_filenameArg)
 
 	ini_filenameFin()
-
 }
 
 // SaveIniSettingsToMemoryV parameter default value hint:
@@ -3450,7 +3345,6 @@ func SelectableBoolV(label string, selected bool, flags SelectableFlags, size Ve
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.igSelectable_Bool(labelArg, C.bool(selected), C.ImGuiSelectableFlags(flags), size.toC()) == C.bool(true)
 }
@@ -3465,7 +3359,6 @@ func SelectableBoolPtrV(label string, p_selected *bool, flags SelectableFlags, s
 	defer func() {
 		labelFin()
 		p_selectedFin()
-
 	}()
 	return C.igSelectable_BoolPtr(labelArg, p_selectedArg, C.ImGuiSelectableFlags(flags), size.toC()) == C.bool(true)
 }
@@ -3479,7 +3372,6 @@ func SeparatorText(label string) {
 	C.igSeparatorText(labelArg)
 
 	labelFin()
-
 }
 
 func SetClipboardText(text string) {
@@ -3487,7 +3379,6 @@ func SetClipboardText(text string) {
 	C.igSetClipboardText(textArg)
 
 	textFin()
-
 }
 
 func SetColorEditOptions(flags ColorEditFlags) {
@@ -3529,7 +3420,6 @@ func SetDragDropPayloadV(typeArg string, data unsafe.Pointer, sz uint64, cond Co
 
 	defer func() {
 		typeArgFin()
-
 	}()
 	return C.igSetDragDropPayload(typeArgArg, (data), C.xulong(sz), C.ImGuiCond(cond)) == C.bool(true)
 }
@@ -3656,7 +3546,6 @@ func SetTabItemClosed(tab_or_docked_window_label string) {
 	C.igSetTabItemClosed(tab_or_docked_window_labelArg)
 
 	tab_or_docked_window_labelFin()
-
 }
 
 func SetTooltip(fmt string) {
@@ -3664,7 +3553,6 @@ func SetTooltip(fmt string) {
 	C.wrap_igSetTooltip(fmtArg)
 
 	fmtFin()
-
 }
 
 // SetWindowCollapsedBoolV parameter default value hint:
@@ -3680,7 +3568,6 @@ func SetWindowCollapsedStrV(name string, collapsed bool, cond Cond) {
 	C.igSetWindowCollapsed_Str(nameArg, C.bool(collapsed), C.ImGuiCond(cond))
 
 	nameFin()
-
 }
 
 func SetWindowFocusNil() {
@@ -3692,7 +3579,6 @@ func SetWindowFocusStr(name string) {
 	C.igSetWindowFocus_Str(nameArg)
 
 	nameFin()
-
 }
 
 func SetWindowFontScale(scale float32) {
@@ -3706,7 +3592,6 @@ func SetWindowPosStrV(name string, pos Vec2, cond Cond) {
 	C.igSetWindowPos_Str(nameArg, pos.toC(), C.ImGuiCond(cond))
 
 	nameFin()
-
 }
 
 // SetWindowPosVec2V parameter default value hint:
@@ -3722,7 +3607,6 @@ func SetWindowSizeStrV(name string, size Vec2, cond Cond) {
 	C.igSetWindowSize_Str(nameArg, size.toC(), C.ImGuiCond(cond))
 
 	nameFin()
-
 }
 
 // SetWindowSizeVec2V parameter default value hint:
@@ -3738,7 +3622,6 @@ func ShowAboutWindowV(p_open *bool) {
 	C.igShowAboutWindow(p_openArg)
 
 	p_openFin()
-
 }
 
 // ShowDebugLogWindowV parameter default value hint:
@@ -3748,7 +3631,6 @@ func ShowDebugLogWindowV(p_open *bool) {
 	C.igShowDebugLogWindow(p_openArg)
 
 	p_openFin()
-
 }
 
 // ShowDemoWindowV parameter default value hint:
@@ -3758,7 +3640,6 @@ func ShowDemoWindowV(p_open *bool) {
 	C.igShowDemoWindow(p_openArg)
 
 	p_openFin()
-
 }
 
 func ShowFontSelector(label string) {
@@ -3766,7 +3647,6 @@ func ShowFontSelector(label string) {
 	C.igShowFontSelector(labelArg)
 
 	labelFin()
-
 }
 
 // ShowMetricsWindowV parameter default value hint:
@@ -3776,7 +3656,6 @@ func ShowMetricsWindowV(p_open *bool) {
 	C.igShowMetricsWindow(p_openArg)
 
 	p_openFin()
-
 }
 
 // ShowStackToolWindowV parameter default value hint:
@@ -3786,7 +3665,6 @@ func ShowStackToolWindowV(p_open *bool) {
 	C.igShowStackToolWindow(p_openArg)
 
 	p_openFin()
-
 }
 
 // ShowStyleEditorV parameter default value hint:
@@ -3800,7 +3678,6 @@ func ShowStyleSelector(label string) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.igShowStyleSelector(labelArg) == C.bool(true)
 }
@@ -3823,7 +3700,6 @@ func SliderAngleV(label string, v_rad *float32, v_degrees_min float32, v_degrees
 		labelFin()
 		v_radFin()
 		formatFin()
-
 	}()
 	return C.igSliderAngle(labelArg, v_radArg, C.float(v_degrees_min), C.float(v_degrees_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -3840,7 +3716,6 @@ func SliderFloatV(label string, v *float32, v_min float32, v_max float32, format
 		labelFin()
 		vFin()
 		formatFin()
-
 	}()
 	return C.igSliderFloat(labelArg, vArg, C.float(v_min), C.float(v_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -3865,7 +3740,6 @@ func SliderFloat2V(label string, v *[2]float32, v_min float32, v_max float32, fo
 		}
 
 		formatFin()
-
 	}()
 	return C.igSliderFloat2(labelArg, (*C.float)(&vArg[0]), C.float(v_min), C.float(v_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -3890,7 +3764,6 @@ func SliderFloat3V(label string, v *[3]float32, v_min float32, v_max float32, fo
 		}
 
 		formatFin()
-
 	}()
 	return C.igSliderFloat3(labelArg, (*C.float)(&vArg[0]), C.float(v_min), C.float(v_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -3915,7 +3788,6 @@ func SliderFloat4V(label string, v *[4]float32, v_min float32, v_max float32, fo
 		}
 
 		formatFin()
-
 	}()
 	return C.igSliderFloat4(labelArg, (*C.float)(&vArg[0]), C.float(v_min), C.float(v_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -3932,7 +3804,6 @@ func SliderIntV(label string, v *int32, v_min int32, v_max int32, format string,
 		labelFin()
 		vFin()
 		formatFin()
-
 	}()
 	return C.igSliderInt(labelArg, vArg, C.int(v_min), C.int(v_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -3957,7 +3828,6 @@ func SliderInt2V(label string, v *[2]int32, v_min int32, v_max int32, format str
 		}
 
 		formatFin()
-
 	}()
 	return C.igSliderInt2(labelArg, (*C.int)(&vArg[0]), C.int(v_min), C.int(v_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -3982,7 +3852,6 @@ func SliderInt3V(label string, v *[3]int32, v_min int32, v_max int32, format str
 		}
 
 		formatFin()
-
 	}()
 	return C.igSliderInt3(labelArg, (*C.int)(&vArg[0]), C.int(v_min), C.int(v_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -4007,7 +3876,6 @@ func SliderInt4V(label string, v *[4]int32, v_min int32, v_max int32, format str
 		}
 
 		formatFin()
-
 	}()
 	return C.igSliderInt4(labelArg, (*C.int)(&vArg[0]), C.int(v_min), C.int(v_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -4022,7 +3890,6 @@ func SliderScalarV(label string, data_type DataType, p_data unsafe.Pointer, p_mi
 	defer func() {
 		labelFin()
 		formatFin()
-
 	}()
 	return C.igSliderScalar(labelArg, C.ImGuiDataType(data_type), (p_data), (p_min), (p_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -4037,7 +3904,6 @@ func SliderScalarNV(label string, data_type DataType, p_data unsafe.Pointer, com
 	defer func() {
 		labelFin()
 		formatFin()
-
 	}()
 	return C.igSliderScalarN(labelArg, C.ImGuiDataType(data_type), (p_data), C.int(components), (p_min), (p_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -4047,7 +3913,6 @@ func SmallButton(label string) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.igSmallButton(labelArg) == C.bool(true)
 }
@@ -4081,7 +3946,6 @@ func TabItemButtonV(label string, flags TabItemFlags) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.igTabItemButton(labelArg, C.ImGuiTabItemFlags(flags)) == C.bool(true)
 }
@@ -4119,7 +3983,6 @@ func TableHeader(label string) {
 	C.igTableHeader(labelArg)
 
 	labelFin()
-
 }
 
 func TableHeadersRow() {
@@ -4160,7 +4023,6 @@ func TableSetupColumnV(label string, flags TableColumnFlags, init_width_or_weigh
 	C.igTableSetupColumn(labelArg, C.ImGuiTableColumnFlags(flags), C.float(init_width_or_weight), C.ImGuiID(user_id))
 
 	labelFin()
-
 }
 
 func TableSetupScrollFreeze(cols int32, rows int32) {
@@ -4172,7 +4034,6 @@ func Text(fmt string) {
 	C.wrap_igText(fmtArg)
 
 	fmtFin()
-
 }
 
 func TextColored(col Vec4, fmt string) {
@@ -4180,7 +4041,6 @@ func TextColored(col Vec4, fmt string) {
 	C.wrap_igTextColored(col.toC(), fmtArg)
 
 	fmtFin()
-
 }
 
 func TextDisabled(fmt string) {
@@ -4188,7 +4048,6 @@ func TextDisabled(fmt string) {
 	C.wrap_igTextDisabled(fmtArg)
 
 	fmtFin()
-
 }
 
 // TextUnformattedV parameter default value hint:
@@ -4198,7 +4057,6 @@ func TextUnformattedV(text string) {
 	C.wrap_igTextUnformattedV(textArg)
 
 	textFin()
-
 }
 
 func TextWrapped(fmt string) {
@@ -4206,7 +4064,6 @@ func TextWrapped(fmt string) {
 	C.wrap_igTextWrapped(fmtArg)
 
 	fmtFin()
-
 }
 
 func TreeNodeExPtr(ptr_id unsafe.Pointer, flags TreeNodeFlags, fmt string) bool {
@@ -4214,7 +4071,6 @@ func TreeNodeExPtr(ptr_id unsafe.Pointer, flags TreeNodeFlags, fmt string) bool 
 
 	defer func() {
 		fmtFin()
-
 	}()
 	return C.wrap_igTreeNodeEx_Ptr((ptr_id), C.ImGuiTreeNodeFlags(flags), fmtArg) == C.bool(true)
 }
@@ -4226,7 +4082,6 @@ func TreeNodeExStrV(label string, flags TreeNodeFlags) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.igTreeNodeEx_Str(labelArg, C.ImGuiTreeNodeFlags(flags)) == C.bool(true)
 }
@@ -4238,7 +4093,6 @@ func TreeNodeExStrStr(str_id string, flags TreeNodeFlags, fmt string) bool {
 	defer func() {
 		str_idFin()
 		fmtFin()
-
 	}()
 	return C.wrap_igTreeNodeEx_StrStr(str_idArg, C.ImGuiTreeNodeFlags(flags), fmtArg) == C.bool(true)
 }
@@ -4248,7 +4102,6 @@ func TreeNodePtr(ptr_id unsafe.Pointer, fmt string) bool {
 
 	defer func() {
 		fmtFin()
-
 	}()
 	return C.wrap_igTreeNode_Ptr((ptr_id), fmtArg) == C.bool(true)
 }
@@ -4258,7 +4111,6 @@ func TreeNodeStr(label string) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.igTreeNode_Str(labelArg) == C.bool(true)
 }
@@ -4270,7 +4122,6 @@ func TreeNodeStrStr(str_id string, fmt string) bool {
 	defer func() {
 		str_idFin()
 		fmtFin()
-
 	}()
 	return C.wrap_igTreeNode_StrStr(str_idArg, fmtArg) == C.bool(true)
 }
@@ -4288,7 +4139,6 @@ func TreePushStr(str_id string) {
 	C.igTreePush_Str(str_idArg)
 
 	str_idFin()
-
 }
 
 // UnindentV parameter default value hint:
@@ -4313,7 +4163,6 @@ func VSliderFloatV(label string, size Vec2, v *float32, v_min float32, v_max flo
 		labelFin()
 		vFin()
 		formatFin()
-
 	}()
 	return C.igVSliderFloat(labelArg, size.toC(), vArg, C.float(v_min), C.float(v_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -4330,7 +4179,6 @@ func VSliderIntV(label string, size Vec2, v *int32, v_min int32, v_max int32, fo
 		labelFin()
 		vFin()
 		formatFin()
-
 	}()
 	return C.igVSliderInt(labelArg, size.toC(), vArg, C.int(v_min), C.int(v_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -4345,7 +4193,6 @@ func VSliderScalarV(label string, size Vec2, data_type DataType, p_data unsafe.P
 	defer func() {
 		labelFin()
 		formatFin()
-
 	}()
 	return C.igVSliderScalar(labelArg, size.toC(), C.ImGuiDataType(data_type), (p_data), (p_min), (p_max), formatArg, C.ImGuiSliderFlags(flags)) == C.bool(true)
 }
@@ -4355,7 +4202,6 @@ func ValueBool(prefix string, b bool) {
 	C.igValue_Bool(prefixArg, C.bool(b))
 
 	prefixFin()
-
 }
 
 // ValueFloatV parameter default value hint:
@@ -4367,7 +4213,6 @@ func ValueFloatV(prefix string, v float32, float_format string) {
 
 	prefixFin()
 	float_formatFin()
-
 }
 
 func ValueInt(prefix string, v int32) {
@@ -4375,7 +4220,6 @@ func ValueInt(prefix string, v int32) {
 	C.igValue_Int(prefixArg, C.int(v))
 
 	prefixFin()
-
 }
 
 func ValueUint(prefix string, v uint32) {
@@ -4383,7 +4227,6 @@ func ValueUint(prefix string, v uint32) {
 	C.igValue_Uint(prefixArg, C.uint(v))
 
 	prefixFin()
-
 }
 
 func ColorHSV(h float32, s float32, v float32) Color {
@@ -4402,7 +4245,6 @@ func (self *Color) SetHSV(h float32, s float32, v float32) {
 	C.wrap_ImColor_SetHSV(selfArg, C.float(h), C.float(s), C.float(v))
 
 	selfFin()
-
 }
 
 func (self DrawList) AddBezierCubic(p1 Vec2, p2 Vec2, p3 Vec2, p4 Vec2, col uint32, thickness float32) {
@@ -4458,7 +4300,6 @@ func (self DrawList) AddTextFontPtr(font Font, font_size float32, pos Vec2, col 
 	C.wrap_ImDrawList_AddText_FontPtr(self.handle(), font.handle(), C.float(font_size), pos.toC(), C.ImU32(col), text_beginArg)
 
 	text_beginFin()
-
 }
 
 func (self DrawList) AddTextVec2(pos Vec2, col uint32, text_begin string) {
@@ -4466,7 +4307,6 @@ func (self DrawList) AddTextVec2(pos Vec2, col uint32, text_begin string) {
 	C.wrap_ImDrawList_AddText_Vec2(self.handle(), pos.toC(), C.ImU32(col), text_beginArg)
 
 	text_beginFin()
-
 }
 
 func (self DrawList) AddTriangle(p1 Vec2, p2 Vec2, p3 Vec2, col uint32) {
@@ -4510,7 +4350,6 @@ func (self FontAtlas) AddFontFromFileTTF(filename string, size_pixels float32) F
 
 	defer func() {
 		filenameFin()
-
 	}()
 	return (Font)(unsafe.Pointer(C.wrap_ImFontAtlas_AddFontFromFileTTF(self.handle(), filenameArg, C.float(size_pixels))))
 }
@@ -4520,7 +4359,6 @@ func (self FontAtlas) AddFontFromMemoryCompressedBase85TTF(compressed_font_data_
 
 	defer func() {
 		compressed_font_data_base85Fin()
-
 	}()
 	return (Font)(unsafe.Pointer(C.wrap_ImFontAtlas_AddFontFromMemoryCompressedBase85TTF(self.handle(), compressed_font_data_base85Arg, C.float(size_pixels))))
 }
@@ -4538,7 +4376,6 @@ func (self FontGlyphRangesBuilder) AddText(text string) {
 	C.wrap_ImFontGlyphRangesBuilder_AddText(self.handle(), textArg)
 
 	textFin()
-
 }
 
 func (self Font) AddRemapChar(dst Wchar, src Wchar) {
@@ -4563,7 +4400,6 @@ func (self Font) RenderText(draw_list DrawList, size float32, pos Vec2, col uint
 	C.wrap_ImFont_RenderText(self.handle(), draw_list.handle(), C.float(size), pos.toC(), C.ImU32(col), clip_rect.toC(), text_beginArg)
 
 	text_beginFin()
-
 }
 
 func (self IO) SetKeyEventNativeData(key Key, native_keycode int32, native_scancode int32) {
@@ -4575,7 +4411,6 @@ func (self InputTextCallbackData) InsertChars(pos int32, text string) {
 	C.wrap_ImGuiInputTextCallbackData_InsertChars(self.handle(), C.int(pos), textArg)
 
 	textFin()
-
 }
 
 func (self ListClipper) Begin(items_count int32) {
@@ -4587,7 +4422,6 @@ func (self TextBuffer) Append(str string) {
 	C.wrap_ImGuiTextBuffer_Append(self.handle(), strArg)
 
 	strFin()
-
 }
 
 func (self TextFilter) Draw() bool {
@@ -4599,7 +4433,6 @@ func (self TextFilter) PassFilter(text string) bool {
 
 	defer func() {
 		textFin()
-
 	}()
 	return C.wrap_ImGuiTextFilter_PassFilter(self.handle(), textArg) == C.bool(true)
 }
@@ -4609,7 +4442,6 @@ func AcceptDragDropPayload(typeArg string) Payload {
 
 	defer func() {
 		typeArgFin()
-
 	}()
 	return (Payload)(unsafe.Pointer(C.wrap_igAcceptDragDropPayload(typeArgArg)))
 }
@@ -4619,7 +4451,6 @@ func Begin(name string) bool {
 
 	defer func() {
 		nameFin()
-
 	}()
 	return C.wrap_igBegin(nameArg) == C.bool(true)
 }
@@ -4637,7 +4468,6 @@ func BeginChildStr(str_id string) bool {
 
 	defer func() {
 		str_idFin()
-
 	}()
 	return C.wrap_igBeginChild_Str(str_idArg) == C.bool(true)
 }
@@ -4649,7 +4479,6 @@ func BeginCombo(label string, preview_value string) bool {
 	defer func() {
 		labelFin()
 		preview_valueFin()
-
 	}()
 	return C.wrap_igBeginCombo(labelArg, preview_valueArg) == C.bool(true)
 }
@@ -4667,7 +4496,6 @@ func BeginListBox(label string) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.wrap_igBeginListBox(labelArg) == C.bool(true)
 }
@@ -4677,7 +4505,6 @@ func BeginMenu(label string) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.wrap_igBeginMenu(labelArg) == C.bool(true)
 }
@@ -4687,7 +4514,6 @@ func BeginPopup(str_id string) bool {
 
 	defer func() {
 		str_idFin()
-
 	}()
 	return C.wrap_igBeginPopup(str_idArg) == C.bool(true)
 }
@@ -4709,7 +4535,6 @@ func BeginPopupModal(name string) bool {
 
 	defer func() {
 		nameFin()
-
 	}()
 	return C.wrap_igBeginPopupModal(nameArg) == C.bool(true)
 }
@@ -4719,7 +4544,6 @@ func BeginTabBar(str_id string) bool {
 
 	defer func() {
 		str_idFin()
-
 	}()
 	return C.wrap_igBeginTabBar(str_idArg) == C.bool(true)
 }
@@ -4729,7 +4553,6 @@ func BeginTabItem(label string) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.wrap_igBeginTabItem(labelArg) == C.bool(true)
 }
@@ -4739,7 +4562,6 @@ func BeginTable(str_id string, column int32) bool {
 
 	defer func() {
 		str_idFin()
-
 	}()
 	return C.wrap_igBeginTable(str_idArg, C.int(column)) == C.bool(true)
 }
@@ -4749,7 +4571,6 @@ func Button(label string) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.wrap_igButton(labelArg) == C.bool(true)
 }
@@ -4774,7 +4595,6 @@ func CollapsingHeaderBoolPtr(label string, p_visible *bool) bool {
 	defer func() {
 		labelFin()
 		p_visibleFin()
-
 	}()
 	return C.wrap_igCollapsingHeader_BoolPtr(labelArg, p_visibleArg) == C.bool(true)
 }
@@ -4784,7 +4604,6 @@ func CollapsingHeaderTreeNodeFlags(label string) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.wrap_igCollapsingHeader_TreeNodeFlags(labelArg) == C.bool(true)
 }
@@ -4794,7 +4613,6 @@ func ColorButton(desc_id string, col Vec4) bool {
 
 	defer func() {
 		desc_idFin()
-
 	}()
 	return C.wrap_igColorButton(desc_idArg, col.toC()) == C.bool(true)
 }
@@ -4813,7 +4631,6 @@ func ColorEdit3(label string, col *[3]float32) bool {
 		for i, colV := range colArg {
 			(*col)[i] = float32(colV)
 		}
-
 	}()
 	return C.wrap_igColorEdit3(labelArg, (*C.float)(&colArg[0])) == C.bool(true)
 }
@@ -4832,7 +4649,6 @@ func ColorEdit4(label string, col *[4]float32) bool {
 		for i, colV := range colArg {
 			(*col)[i] = float32(colV)
 		}
-
 	}()
 	return C.wrap_igColorEdit4(labelArg, (*C.float)(&colArg[0])) == C.bool(true)
 }
@@ -4851,7 +4667,6 @@ func ColorPicker3(label string, col *[3]float32) bool {
 		for i, colV := range colArg {
 			(*col)[i] = float32(colV)
 		}
-
 	}()
 	return C.wrap_igColorPicker3(labelArg, (*C.float)(&colArg[0])) == C.bool(true)
 }
@@ -4870,7 +4685,6 @@ func ColorPicker4(label string, col *[4]float32) bool {
 		for i, colV := range colArg {
 			(*col)[i] = float32(colV)
 		}
-
 	}()
 	return C.wrap_igColorPicker4(labelArg, (*C.float)(&colArg[0])) == C.bool(true)
 }
@@ -4888,7 +4702,6 @@ func ComboStr(label string, current_item *int32, items_separated_by_zeros string
 		labelFin()
 		current_itemFin()
 		items_separated_by_zerosFin()
-
 	}()
 	return C.wrap_igCombo_Str(labelArg, current_itemArg, items_separated_by_zerosArg) == C.bool(true)
 }
@@ -4902,7 +4715,6 @@ func ComboStrarr(label string, current_item *int32, items []string, items_count 
 		labelFin()
 		current_itemFin()
 		itemsFin()
-
 	}()
 	return C.wrap_igCombo_Str_arr(labelArg, current_itemArg, itemsArg, C.int(items_count)) == C.bool(true)
 }
@@ -4930,7 +4742,6 @@ func DragFloat(label string, v *float32) bool {
 	defer func() {
 		labelFin()
 		vFin()
-
 	}()
 	return C.wrap_igDragFloat(labelArg, vArg) == C.bool(true)
 }
@@ -4949,7 +4760,6 @@ func DragFloat2(label string, v *[2]float32) bool {
 		for i, vV := range vArg {
 			(*v)[i] = float32(vV)
 		}
-
 	}()
 	return C.wrap_igDragFloat2(labelArg, (*C.float)(&vArg[0])) == C.bool(true)
 }
@@ -4968,7 +4778,6 @@ func DragFloat3(label string, v *[3]float32) bool {
 		for i, vV := range vArg {
 			(*v)[i] = float32(vV)
 		}
-
 	}()
 	return C.wrap_igDragFloat3(labelArg, (*C.float)(&vArg[0])) == C.bool(true)
 }
@@ -4987,7 +4796,6 @@ func DragFloat4(label string, v *[4]float32) bool {
 		for i, vV := range vArg {
 			(*v)[i] = float32(vV)
 		}
-
 	}()
 	return C.wrap_igDragFloat4(labelArg, (*C.float)(&vArg[0])) == C.bool(true)
 }
@@ -5001,7 +4809,6 @@ func DragFloatRange2(label string, v_current_min *float32, v_current_max *float3
 		labelFin()
 		v_current_minFin()
 		v_current_maxFin()
-
 	}()
 	return C.wrap_igDragFloatRange2(labelArg, v_current_minArg, v_current_maxArg) == C.bool(true)
 }
@@ -5013,7 +4820,6 @@ func DragInt(label string, v *int32) bool {
 	defer func() {
 		labelFin()
 		vFin()
-
 	}()
 	return C.wrap_igDragInt(labelArg, vArg) == C.bool(true)
 }
@@ -5032,7 +4838,6 @@ func DragInt2(label string, v *[2]int32) bool {
 		for i, vV := range vArg {
 			(*v)[i] = int32(vV)
 		}
-
 	}()
 	return C.wrap_igDragInt2(labelArg, (*C.int)(&vArg[0])) == C.bool(true)
 }
@@ -5051,7 +4856,6 @@ func DragInt3(label string, v *[3]int32) bool {
 		for i, vV := range vArg {
 			(*v)[i] = int32(vV)
 		}
-
 	}()
 	return C.wrap_igDragInt3(labelArg, (*C.int)(&vArg[0])) == C.bool(true)
 }
@@ -5070,7 +4874,6 @@ func DragInt4(label string, v *[4]int32) bool {
 		for i, vV := range vArg {
 			(*v)[i] = int32(vV)
 		}
-
 	}()
 	return C.wrap_igDragInt4(labelArg, (*C.int)(&vArg[0])) == C.bool(true)
 }
@@ -5084,7 +4887,6 @@ func DragIntRange2(label string, v_current_min *int32, v_current_max *int32) boo
 		labelFin()
 		v_current_minFin()
 		v_current_maxFin()
-
 	}()
 	return C.wrap_igDragIntRange2(labelArg, v_current_minArg, v_current_maxArg) == C.bool(true)
 }
@@ -5094,7 +4896,6 @@ func DragScalar(label string, data_type DataType, p_data unsafe.Pointer) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.wrap_igDragScalar(labelArg, C.ImGuiDataType(data_type), (p_data)) == C.bool(true)
 }
@@ -5104,7 +4905,6 @@ func DragScalarN(label string, data_type DataType, p_data unsafe.Pointer, compon
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.wrap_igDragScalarN(labelArg, C.ImGuiDataType(data_type), (p_data), C.int(components)) == C.bool(true)
 }
@@ -5141,7 +4941,6 @@ func ImageButton(str_id string, user_texture_id TextureID, size Vec2) bool {
 
 	defer func() {
 		str_idFin()
-
 	}()
 	return C.wrap_igImageButton(str_idArg, C.ImTextureID(user_texture_id), size.toC()) == C.bool(true)
 }
@@ -5157,7 +4956,6 @@ func InputDouble(label string, v *float64) bool {
 	defer func() {
 		labelFin()
 		vFin()
-
 	}()
 	return C.wrap_igInputDouble(labelArg, vArg) == C.bool(true)
 }
@@ -5169,7 +4967,6 @@ func InputFloat(label string, v *float32) bool {
 	defer func() {
 		labelFin()
 		vFin()
-
 	}()
 	return C.wrap_igInputFloat(labelArg, vArg) == C.bool(true)
 }
@@ -5188,7 +4985,6 @@ func InputFloat2(label string, v *[2]float32) bool {
 		for i, vV := range vArg {
 			(*v)[i] = float32(vV)
 		}
-
 	}()
 	return C.wrap_igInputFloat2(labelArg, (*C.float)(&vArg[0])) == C.bool(true)
 }
@@ -5207,7 +5003,6 @@ func InputFloat3(label string, v *[3]float32) bool {
 		for i, vV := range vArg {
 			(*v)[i] = float32(vV)
 		}
-
 	}()
 	return C.wrap_igInputFloat3(labelArg, (*C.float)(&vArg[0])) == C.bool(true)
 }
@@ -5226,7 +5021,6 @@ func InputFloat4(label string, v *[4]float32) bool {
 		for i, vV := range vArg {
 			(*v)[i] = float32(vV)
 		}
-
 	}()
 	return C.wrap_igInputFloat4(labelArg, (*C.float)(&vArg[0])) == C.bool(true)
 }
@@ -5238,7 +5032,6 @@ func InputInt(label string, v *int32) bool {
 	defer func() {
 		labelFin()
 		vFin()
-
 	}()
 	return C.wrap_igInputInt(labelArg, vArg) == C.bool(true)
 }
@@ -5257,7 +5050,6 @@ func InputInt2(label string, v *[2]int32) bool {
 		for i, vV := range vArg {
 			(*v)[i] = int32(vV)
 		}
-
 	}()
 	return C.wrap_igInputInt2(labelArg, (*C.int)(&vArg[0])) == C.bool(true)
 }
@@ -5276,7 +5068,6 @@ func InputInt3(label string, v *[3]int32) bool {
 		for i, vV := range vArg {
 			(*v)[i] = int32(vV)
 		}
-
 	}()
 	return C.wrap_igInputInt3(labelArg, (*C.int)(&vArg[0])) == C.bool(true)
 }
@@ -5295,7 +5086,6 @@ func InputInt4(label string, v *[4]int32) bool {
 		for i, vV := range vArg {
 			(*v)[i] = int32(vV)
 		}
-
 	}()
 	return C.wrap_igInputInt4(labelArg, (*C.int)(&vArg[0])) == C.bool(true)
 }
@@ -5305,7 +5095,6 @@ func InputScalar(label string, data_type DataType, p_data unsafe.Pointer) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.wrap_igInputScalar(labelArg, C.ImGuiDataType(data_type), (p_data)) == C.bool(true)
 }
@@ -5315,7 +5104,6 @@ func InputScalarN(label string, data_type DataType, p_data unsafe.Pointer, compo
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.wrap_igInputScalarN(labelArg, C.ImGuiDataType(data_type), (p_data), C.int(components)) == C.bool(true)
 }
@@ -5325,7 +5113,6 @@ func InvisibleButton(str_id string, size Vec2) bool {
 
 	defer func() {
 		str_idFin()
-
 	}()
 	return C.wrap_igInvisibleButton(str_idArg, size.toC()) == C.bool(true)
 }
@@ -5363,7 +5150,6 @@ func IsPopupOpenStr(str_id string) bool {
 
 	defer func() {
 		str_idFin()
-
 	}()
 	return C.wrap_igIsPopupOpen_Str(str_idArg) == C.bool(true)
 }
@@ -5385,7 +5171,6 @@ func ListBoxStrarr(label string, current_item *int32, items []string, items_coun
 		labelFin()
 		current_itemFin()
 		itemsFin()
-
 	}()
 	return C.wrap_igListBox_Str_arr(labelArg, current_itemArg, itemsArg, C.int(items_count)) == C.bool(true)
 }
@@ -5395,7 +5180,6 @@ func LoadIniSettingsFromMemory(ini_data string) {
 	C.wrap_igLoadIniSettingsFromMemory(ini_dataArg)
 
 	ini_dataFin()
-
 }
 
 func LogToClipboard() {
@@ -5415,7 +5199,6 @@ func MenuItemBool(label string) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.wrap_igMenuItem_Bool(labelArg) == C.bool(true)
 }
@@ -5429,7 +5212,6 @@ func MenuItemBoolPtr(label string, shortcut string, p_selected *bool) bool {
 		labelFin()
 		shortcutFin()
 		p_selectedFin()
-
 	}()
 	return C.wrap_igMenuItem_BoolPtr(labelArg, shortcutArg, p_selectedArg) == C.bool(true)
 }
@@ -5447,7 +5229,6 @@ func OpenPopupStr(str_id string) {
 	C.wrap_igOpenPopup_Str(str_idArg)
 
 	str_idFin()
-
 }
 
 func PlotHistogramFloatPtr(label string, values []float32, values_count int32) {
@@ -5455,7 +5236,6 @@ func PlotHistogramFloatPtr(label string, values []float32, values_count int32) {
 	C.wrap_igPlotHistogram_FloatPtr(labelArg, (*C.float)(&(values[0])), C.int(values_count))
 
 	labelFin()
-
 }
 
 func PlotLinesFloatPtr(label string, values []float32, values_count int32) {
@@ -5463,7 +5243,6 @@ func PlotLinesFloatPtr(label string, values []float32, values_count int32) {
 	C.wrap_igPlotLines_FloatPtr(labelArg, (*C.float)(&(values[0])), C.int(values_count))
 
 	labelFin()
-
 }
 
 func PopStyleColor() {
@@ -5503,7 +5282,6 @@ func SelectableBool(label string) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.wrap_igSelectable_Bool(labelArg) == C.bool(true)
 }
@@ -5515,7 +5293,6 @@ func SelectableBoolPtr(label string, p_selected *bool) bool {
 	defer func() {
 		labelFin()
 		p_selectedFin()
-
 	}()
 	return C.wrap_igSelectable_BoolPtr(labelArg, p_selectedArg) == C.bool(true)
 }
@@ -5525,7 +5302,6 @@ func SetDragDropPayload(typeArg string, data unsafe.Pointer, sz uint64) bool {
 
 	defer func() {
 		typeArgFin()
-
 	}()
 	return C.wrap_igSetDragDropPayload(typeArgArg, (data), C.xulong(sz)) == C.bool(true)
 }
@@ -5583,7 +5359,6 @@ func SetWindowCollapsedStr(name string, collapsed bool) {
 	C.wrap_igSetWindowCollapsed_Str(nameArg, C.bool(collapsed))
 
 	nameFin()
-
 }
 
 func SetWindowPosStr(name string, pos Vec2) {
@@ -5591,7 +5366,6 @@ func SetWindowPosStr(name string, pos Vec2) {
 	C.wrap_igSetWindowPos_Str(nameArg, pos.toC())
 
 	nameFin()
-
 }
 
 func SetWindowPosVec2(pos Vec2) {
@@ -5603,7 +5377,6 @@ func SetWindowSizeStr(name string, size Vec2) {
 	C.wrap_igSetWindowSize_Str(nameArg, size.toC())
 
 	nameFin()
-
 }
 
 func SetWindowSizeVec2(size Vec2) {
@@ -5641,7 +5414,6 @@ func SliderAngle(label string, v_rad *float32) bool {
 	defer func() {
 		labelFin()
 		v_radFin()
-
 	}()
 	return C.wrap_igSliderAngle(labelArg, v_radArg) == C.bool(true)
 }
@@ -5653,7 +5425,6 @@ func SliderFloat(label string, v *float32, v_min float32, v_max float32) bool {
 	defer func() {
 		labelFin()
 		vFin()
-
 	}()
 	return C.wrap_igSliderFloat(labelArg, vArg, C.float(v_min), C.float(v_max)) == C.bool(true)
 }
@@ -5672,7 +5443,6 @@ func SliderFloat2(label string, v *[2]float32, v_min float32, v_max float32) boo
 		for i, vV := range vArg {
 			(*v)[i] = float32(vV)
 		}
-
 	}()
 	return C.wrap_igSliderFloat2(labelArg, (*C.float)(&vArg[0]), C.float(v_min), C.float(v_max)) == C.bool(true)
 }
@@ -5691,7 +5461,6 @@ func SliderFloat3(label string, v *[3]float32, v_min float32, v_max float32) boo
 		for i, vV := range vArg {
 			(*v)[i] = float32(vV)
 		}
-
 	}()
 	return C.wrap_igSliderFloat3(labelArg, (*C.float)(&vArg[0]), C.float(v_min), C.float(v_max)) == C.bool(true)
 }
@@ -5710,7 +5479,6 @@ func SliderFloat4(label string, v *[4]float32, v_min float32, v_max float32) boo
 		for i, vV := range vArg {
 			(*v)[i] = float32(vV)
 		}
-
 	}()
 	return C.wrap_igSliderFloat4(labelArg, (*C.float)(&vArg[0]), C.float(v_min), C.float(v_max)) == C.bool(true)
 }
@@ -5722,7 +5490,6 @@ func SliderInt(label string, v *int32, v_min int32, v_max int32) bool {
 	defer func() {
 		labelFin()
 		vFin()
-
 	}()
 	return C.wrap_igSliderInt(labelArg, vArg, C.int(v_min), C.int(v_max)) == C.bool(true)
 }
@@ -5741,7 +5508,6 @@ func SliderInt2(label string, v *[2]int32, v_min int32, v_max int32) bool {
 		for i, vV := range vArg {
 			(*v)[i] = int32(vV)
 		}
-
 	}()
 	return C.wrap_igSliderInt2(labelArg, (*C.int)(&vArg[0]), C.int(v_min), C.int(v_max)) == C.bool(true)
 }
@@ -5760,7 +5526,6 @@ func SliderInt3(label string, v *[3]int32, v_min int32, v_max int32) bool {
 		for i, vV := range vArg {
 			(*v)[i] = int32(vV)
 		}
-
 	}()
 	return C.wrap_igSliderInt3(labelArg, (*C.int)(&vArg[0]), C.int(v_min), C.int(v_max)) == C.bool(true)
 }
@@ -5779,7 +5544,6 @@ func SliderInt4(label string, v *[4]int32, v_min int32, v_max int32) bool {
 		for i, vV := range vArg {
 			(*v)[i] = int32(vV)
 		}
-
 	}()
 	return C.wrap_igSliderInt4(labelArg, (*C.int)(&vArg[0]), C.int(v_min), C.int(v_max)) == C.bool(true)
 }
@@ -5789,7 +5553,6 @@ func SliderScalar(label string, data_type DataType, p_data unsafe.Pointer, p_min
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.wrap_igSliderScalar(labelArg, C.ImGuiDataType(data_type), (p_data), (p_min), (p_max)) == C.bool(true)
 }
@@ -5799,7 +5562,6 @@ func SliderScalarN(label string, data_type DataType, p_data unsafe.Pointer, comp
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.wrap_igSliderScalarN(labelArg, C.ImGuiDataType(data_type), (p_data), C.int(components), (p_min), (p_max)) == C.bool(true)
 }
@@ -5821,7 +5583,6 @@ func TabItemButton(label string) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.wrap_igTabItemButton(labelArg) == C.bool(true)
 }
@@ -5847,7 +5608,6 @@ func TableSetupColumn(label string) {
 	C.wrap_igTableSetupColumn(labelArg)
 
 	labelFin()
-
 }
 
 func TextUnformatted(text string) {
@@ -5855,7 +5615,6 @@ func TextUnformatted(text string) {
 	C.wrap_igTextUnformatted(textArg)
 
 	textFin()
-
 }
 
 func TreeNodeExStr(label string) bool {
@@ -5863,7 +5622,6 @@ func TreeNodeExStr(label string) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.wrap_igTreeNodeEx_Str(labelArg) == C.bool(true)
 }
@@ -5879,7 +5637,6 @@ func VSliderFloat(label string, size Vec2, v *float32, v_min float32, v_max floa
 	defer func() {
 		labelFin()
 		vFin()
-
 	}()
 	return C.wrap_igVSliderFloat(labelArg, size.toC(), vArg, C.float(v_min), C.float(v_max)) == C.bool(true)
 }
@@ -5891,7 +5648,6 @@ func VSliderInt(label string, size Vec2, v *int32, v_min int32, v_max int32) boo
 	defer func() {
 		labelFin()
 		vFin()
-
 	}()
 	return C.wrap_igVSliderInt(labelArg, size.toC(), vArg, C.int(v_min), C.int(v_max)) == C.bool(true)
 }
@@ -5901,7 +5657,6 @@ func VSliderScalar(label string, size Vec2, data_type DataType, p_data unsafe.Po
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.wrap_igVSliderScalar(labelArg, size.toC(), C.ImGuiDataType(data_type), (p_data), (p_min), (p_max)) == C.bool(true)
 }
@@ -5911,7 +5666,6 @@ func ValueFloat(prefix string, v float32) {
 	C.wrap_igValue_Float(prefixArg, C.float(v))
 
 	prefixFin()
-
 }
 
 func (self DrawCmd) SetClipRect(v Vec4) {
@@ -6089,7 +5843,6 @@ func (self DrawList) SetOwnerName(v string) {
 	C.wrap_ImDrawList_Set_OwnerName(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self DrawList) OwnerName() string {
@@ -6193,7 +5946,6 @@ func (self DrawListSharedData) SetTexUvLines(v *Vec4) {
 	C.wrap_ImDrawListSharedData_SetTexUvLines(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self DrawListSharedData) TexUvLines() *Vec4 {
@@ -6435,7 +6187,6 @@ func (self FontAtlas) SetTexPixelsRGBA32(v *uint32) {
 	C.wrap_ImFontAtlas_SetTexPixelsRGBA32(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self FontAtlas) SetTexWidth(v int32) {
@@ -8293,7 +8044,6 @@ func (self Context) SetLogNextPrefix(v string) {
 	C.wrap_ImGuiContext_SetLogNextPrefix(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self Context) LogNextPrefix() string {
@@ -8305,7 +8055,6 @@ func (self Context) SetLogNextSuffix(v string) {
 	C.wrap_ImGuiContext_SetLogNextSuffix(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self Context) LogNextSuffix() string {
@@ -8509,7 +8258,6 @@ func (self DataTypeInfo) SetName(v string) {
 	C.wrap_ImGuiDataTypeInfo_SetName(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self DataTypeInfo) Name() string {
@@ -8521,7 +8269,6 @@ func (self DataTypeInfo) SetPrintFmt(v string) {
 	C.wrap_ImGuiDataTypeInfo_SetPrintFmt(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self DataTypeInfo) PrintFmt() string {
@@ -8533,7 +8280,6 @@ func (self DataTypeInfo) SetScanFmt(v string) {
 	C.wrap_ImGuiDataTypeInfo_SetScanFmt(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self DataTypeInfo) ScanFmt() string {
@@ -8983,7 +8729,6 @@ func (self IO) SetIniFilename(v string) {
 	C.wrap_ImGuiIO_SetIniFilename(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self IO) IniFilename() string {
@@ -8995,7 +8740,6 @@ func (self IO) SetLogFilename(v string) {
 	C.wrap_ImGuiIO_SetLogFilename(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self IO) LogFilename() string {
@@ -9249,7 +8993,6 @@ func (self IO) SetBackendPlatformName(v string) {
 	C.wrap_ImGuiIO_SetBackendPlatformName(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self IO) BackendPlatformName() string {
@@ -9261,7 +9004,6 @@ func (self IO) SetBackendRendererName(v string) {
 	C.wrap_ImGuiIO_SetBackendRendererName(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self IO) BackendRendererName() string {
@@ -9703,7 +9445,6 @@ func (self InputTextCallbackData) SetBuf(v string) {
 	C.wrap_ImGuiInputTextCallbackData_SetBuf(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self InputTextCallbackData) Buf() string {
@@ -10137,7 +9878,6 @@ func (self LocEntry) SetText(v string) {
 	C.wrap_ImGuiLocEntry_SetText(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self LocEntry) Text() string {
@@ -10947,7 +10687,6 @@ func (self SettingsHandler) SetTypeName(v string) {
 	C.wrap_ImGuiSettingsHandler_SetTypeName(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self SettingsHandler) TypeName() string {
@@ -13343,7 +13082,6 @@ func (self TextRange) Setb(v string) {
 	C.wrap_ImGuiTextRange_Setb(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self TextRange) b() string {
@@ -13355,7 +13093,6 @@ func (self TextRange) Sete(v string) {
 	C.wrap_ImGuiTextRange_Sete(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self TextRange) e() string {
@@ -13667,7 +13404,6 @@ func (self Window) SetName(v string) {
 	C.wrap_ImGuiWindow_SetName(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self Window) Name() string {

--- a/cimplot_funcs.go
+++ b/cimplot_funcs.go
@@ -36,7 +36,6 @@ func (self PlotAlignmentData) Update(pad_a *float32, pad_b *float32, delta_a *fl
 	pad_bFin()
 	delta_aFin()
 	delta_bFin()
-
 }
 
 func (self PlotAlignmentData) Destroy() {
@@ -48,7 +47,6 @@ func (self PlotAnnotationCollection) Append(pos Vec2, off Vec2, bg uint32, fg ui
 	C.wrap_ImPlotAnnotationCollection_Append(self.handle(), pos.toC(), off.toC(), C.ImU32(bg), C.ImU32(fg), C.bool(clamp), fmtArg)
 
 	fmtFin()
-
 }
 
 func (self PlotAnnotationCollection) Text(idx int32) string {
@@ -240,7 +238,6 @@ func (self PlotColormapData) Append(name string, keys *[]uint32, count int32, qu
 		for i, keysV := range keysArg {
 			(*keys)[i] = uint32(keysV)
 		}
-
 	}()
 	return int(C.ImPlotColormapData_Append(self.handle(), nameArg, (*C.ImU32)(&keysArg[0]), C.int(count), C.bool(qual)))
 }
@@ -250,7 +247,6 @@ func (self PlotColormapData) Index(name string) PlotColormap {
 
 	defer func() {
 		nameFin()
-
 	}()
 	return PlotColormap(C.ImPlotColormapData_GetIndex(self.handle(), nameArg))
 }
@@ -335,7 +331,6 @@ func (self PlotItemGroup) ItemID(label_id string) ID {
 
 	defer func() {
 		label_idFin()
-
 	}()
 	return ID(C.ImPlotItemGroup_GetItemID(self.handle(), label_idArg))
 }
@@ -353,7 +348,6 @@ func (self PlotItemGroup) ItemStr(label_id string) PlotItem {
 
 	defer func() {
 		label_idFin()
-
 	}()
 	return (PlotItem)(unsafe.Pointer(C.ImPlotItemGroup_GetItem_Str(self.handle(), label_idArg)))
 }
@@ -463,7 +457,6 @@ func (self PlotPlot) SetAxisLabel(axis PlotAxis, label string) {
 	C.ImPlotPlot_SetAxisLabel(self.handle(), axis.handle(), labelArg)
 
 	labelFin()
-
 }
 
 func (self PlotPlot) SetTitle(title string) {
@@ -471,7 +464,6 @@ func (self PlotPlot) SetTitle(title string) {
 	C.ImPlotPlot_SetTitle(self.handle(), titleArg)
 
 	titleFin()
-
 }
 
 func (self PlotPlot) XAxisNil(i int32) PlotAxis {
@@ -499,7 +491,6 @@ func (self *PlotPoint) Destroy() {
 	C.ImPlotPoint_destroy(selfArg)
 
 	selfFin()
-
 }
 
 func (self PlotRange) Clamp(value float64) float64 {
@@ -622,7 +613,6 @@ func (self PlotTagCollection) Append(axis PlotAxisEnum, value float64, bg uint32
 	C.wrap_ImPlotTagCollection_Append(self.handle(), C.ImAxis(axis), C.double(value), C.ImU32(bg), C.ImU32(fg), fmtArg)
 
 	fmtFin()
-
 }
 
 func (self PlotTagCollection) Text(idx int32) string {
@@ -654,7 +644,6 @@ func (self PlotTicker) AddTickdoubleStr(value float64, major bool, level int32, 
 
 	defer func() {
 		labelFin()
-
 	}()
 	return (PlotTick)(unsafe.Pointer(C.ImPlotTicker_AddTick_doubleStr(self.handle(), C.double(value), C.bool(major), C.int(level), C.bool(show_label), labelArg)))
 }
@@ -699,7 +688,6 @@ func (self *PlotTime) RollOver() {
 	C.ImPlotTime_RollOver(selfArg)
 
 	selfFin()
-
 }
 
 func (self *PlotTime) ToDouble() float64 {
@@ -707,7 +695,6 @@ func (self *PlotTime) ToDouble() float64 {
 
 	defer func() {
 		selfFin()
-
 	}()
 	return float64(C.ImPlotTime_ToDouble(selfArg))
 }
@@ -717,7 +704,6 @@ func (self *PlotTime) Destroy() {
 	C.ImPlotTime_destroy(selfArg)
 
 	selfFin()
-
 }
 
 // PlotAddColormapU32PtrV parameter default value hint:
@@ -735,7 +721,6 @@ func PlotAddColormapU32PtrV(name string, cols *[]uint32, size int32, qual bool) 
 		for i, colsV := range colsArg {
 			(*cols)[i] = uint32(colsV)
 		}
-
 	}()
 	return PlotColormap(C.ImPlot_AddColormap_U32Ptr(nameArg, (*C.ImU32)(&colsArg[0]), C.int(size), C.bool(qual)))
 }
@@ -749,7 +734,6 @@ func PlotAddColormapVec4PtrV(name string, cols *Vec4, size int32, qual bool) Plo
 	defer func() {
 		nameFin()
 		colsFin()
-
 	}()
 	return PlotColormap(C.ImPlot_AddColormap_Vec4Ptr(nameArg, colsArg, C.int(size), C.bool(qual)))
 }
@@ -761,7 +745,6 @@ func PlotAddTextCenteredV(DrawList DrawList, top_center Vec2, col uint32, text_b
 	C.wrap_ImPlot_AddTextCenteredV(DrawList.handle(), top_center.toC(), C.ImU32(col), text_beginArg)
 
 	text_beginFin()
-
 }
 
 // PlotAddTextVerticalV parameter default value hint:
@@ -771,7 +754,6 @@ func PlotAddTextVerticalV(DrawList DrawList, pos Vec2, col uint32, text_begin st
 	C.wrap_ImPlot_AddTextVerticalV(DrawList.handle(), pos.toC(), C.ImU32(col), text_beginArg)
 
 	text_beginFin()
-
 }
 
 func PlotAddTime(t PlotTime, unit PlotTimeUnit, count int32) PlotTime {
@@ -800,7 +782,6 @@ func PlotAnnotationStr(x float64, y float64, col Vec4, pix_offset Vec2, clamp bo
 	C.wrap_ImPlot_Annotation_Str(C.double(x), C.double(y), col.toC(), pix_offset.toC(), C.bool(clamp), fmtArg)
 
 	fmtFin()
-
 }
 
 func PlotAnyAxesHeld(axes PlotAxis, count int32) bool {
@@ -822,7 +803,6 @@ func PlotBeginAlignedPlotsV(group_id string, vertical bool) bool {
 
 	defer func() {
 		group_idFin()
-
 	}()
 	return C.ImPlot_BeginAlignedPlots(group_idArg, C.bool(vertical)) == C.bool(true)
 }
@@ -847,7 +827,6 @@ func PlotBeginItemV(label_id string, flags PlotItemFlags, recolor_from PlotCol) 
 
 	defer func() {
 		label_idFin()
-
 	}()
 	return C.ImPlot_BeginItem(label_idArg, C.ImPlotItemFlags(flags), C.ImPlotCol(recolor_from)) == C.bool(true)
 }
@@ -860,7 +839,6 @@ func PlotBeginPlotV(title_id string, size Vec2, flags PlotFlags) bool {
 
 	defer func() {
 		title_idFin()
-
 	}()
 	return C.ImPlot_BeginPlot(title_idArg, size.toC(), C.ImPlotFlags(flags)) == C.bool(true)
 }
@@ -878,7 +856,6 @@ func PlotBeginSubplotsV(title_id string, rows int32, cols int32, size Vec2, flag
 		title_idFin()
 		row_ratiosFin()
 		col_ratiosFin()
-
 	}()
 	return C.ImPlot_BeginSubplots(title_idArg, C.int(rows), C.int(cols), size.toC(), C.ImPlotSubplotFlags(flags), row_ratiosArg, col_ratiosArg) == C.bool(true)
 }
@@ -890,7 +867,6 @@ func PlotBustColorCacheV(plot_title_id string) {
 	C.ImPlot_BustColorCache(plot_title_idArg)
 
 	plot_title_idFin()
-
 }
 
 func PlotBustItemCache() {
@@ -971,7 +947,6 @@ func PlotColormapButtonV(label string, size Vec2, cmap PlotColormap) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.ImPlot_ColormapButton(labelArg, size.toC(), C.ImPlotColormap(cmap)) == C.bool(true)
 }
@@ -992,7 +967,6 @@ func PlotColormapScaleV(label string, scale_min float64, scale_max float64, size
 
 	labelFin()
 	formatFin()
-
 }
 
 // PlotColormapSliderV parameter default value hint:
@@ -1010,7 +984,6 @@ func PlotColormapSliderV(label string, t *float32, out *Vec4, format string, cma
 		tFin()
 		outFin()
 		formatFin()
-
 	}()
 	return C.ImPlot_ColormapSlider(labelArg, tArg, outArg, formatArg, C.ImPlotColormap(cmap)) == C.bool(true)
 }
@@ -1044,7 +1017,6 @@ func PlotDragLineXV(id int32, x *float64, col Vec4, thickness float32, flags Plo
 
 	defer func() {
 		xFin()
-
 	}()
 	return C.ImPlot_DragLineX(C.int(id), xArg, col.toC(), C.float(thickness), C.ImPlotDragToolFlags(flags)) == C.bool(true)
 }
@@ -1057,7 +1029,6 @@ func PlotDragLineYV(id int32, y *float64, col Vec4, thickness float32, flags Plo
 
 	defer func() {
 		yFin()
-
 	}()
 	return C.ImPlot_DragLineY(C.int(id), yArg, col.toC(), C.float(thickness), C.ImPlotDragToolFlags(flags)) == C.bool(true)
 }
@@ -1072,7 +1043,6 @@ func PlotDragPointV(id int32, x *float64, y *float64, col Vec4, size float32, fl
 	defer func() {
 		xFin()
 		yFin()
-
 	}()
 	return C.ImPlot_DragPoint(C.int(id), xArg, yArg, col.toC(), C.float(size), C.ImPlotDragToolFlags(flags)) == C.bool(true)
 }
@@ -1090,7 +1060,6 @@ func PlotDragRectV(id int32, x1 *float64, y1 *float64, x2 *float64, y2 *float64,
 		y1Fin()
 		x2Fin()
 		y2Fin()
-
 	}()
 	return C.ImPlot_DragRect(C.int(id), x1Arg, y1Arg, x2Arg, y2Arg, col.toC(), C.ImPlotDragToolFlags(flags)) == C.bool(true)
 }
@@ -1155,7 +1124,6 @@ func PlotFormatDate(t PlotTime, buffer string, size int32, fmt PlotDateFmt, use_
 
 	defer func() {
 		bufferFin()
-
 	}()
 	return int(C.ImPlot_FormatDate(t.toC(), bufferArg, C.int(size), C.ImPlotDateFmt(fmt), C.bool(use_iso_8601)))
 }
@@ -1165,7 +1133,6 @@ func PlotFormatTime(t PlotTime, buffer string, size int32, fmt PlotTimeFmt, use_
 
 	defer func() {
 		bufferFin()
-
 	}()
 	return int(C.ImPlot_FormatTime(t.toC(), bufferArg, C.int(size), C.ImPlotTimeFmt(fmt), C.bool(use_24_hr_clk)))
 }
@@ -1175,7 +1142,6 @@ func PlotFormatterDefault(value float64, buff string, size int32, data unsafe.Po
 
 	defer func() {
 		buffFin()
-
 	}()
 	return int(C.ImPlot_Formatter_Default(C.double(value), buffArg, C.int(size), (data)))
 }
@@ -1185,7 +1151,6 @@ func PlotFormatterLogit(value float64, buff string, size int32, noname1 unsafe.P
 
 	defer func() {
 		buffFin()
-
 	}()
 	return int(C.ImPlot_Formatter_Logit(C.double(value), buffArg, C.int(size), (noname1)))
 }
@@ -1195,7 +1160,6 @@ func PlotFormatterTime(noname1 float64, buff string, size int32, data unsafe.Poi
 
 	defer func() {
 		buffFin()
-
 	}()
 	return int(C.ImPlot_Formatter_Time(C.double(noname1), buffArg, C.int(size), (data)))
 }
@@ -1237,7 +1201,6 @@ func PlotGetColormapIndex(name string) PlotColormap {
 
 	defer func() {
 		nameFin()
-
 	}()
 	return PlotColormap(C.ImPlot_GetColormapIndex(nameArg))
 }
@@ -1277,7 +1240,6 @@ func PlotGetItem(label_id string) PlotItem {
 
 	defer func() {
 		label_idFin()
-
 	}()
 	return (PlotItem)(unsafe.Pointer(C.ImPlot_GetItem(label_idArg)))
 }
@@ -1306,7 +1268,6 @@ func PlotGetPlot(title string) PlotPlot {
 
 	defer func() {
 		titleFin()
-
 	}()
 	return (PlotPlot)(unsafe.Pointer(C.ImPlot_GetPlot(titleArg)))
 }
@@ -1426,11 +1387,9 @@ func PlotImLerpU32(colors *[]uint32, size int32, t float32) uint32 {
 	}
 
 	defer func() {
-
 		for i, colorsV := range colorsArg {
 			(*colors)[i] = uint32(colorsV)
 		}
-
 	}()
 	return uint32(C.ImPlot_ImLerpU32((*C.ImU32)(&colorsArg[0]), C.int(size), C.float(t)))
 }
@@ -1454,11 +1413,9 @@ func PlotImMaxArrayS16Ptr(values *[]int, count int32) int {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = int(valuesV)
 		}
-
 	}()
 	return int(C.ImPlot_ImMaxArray_S16Ptr((*C.ImS16)(&valuesArg[0]), C.int(count)))
 }
@@ -1470,11 +1427,9 @@ func PlotImMaxArrayS32Ptr(values *[]int32, count int32) int {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = int32(valuesV)
 		}
-
 	}()
 	return int(C.ImPlot_ImMaxArray_S32Ptr((*C.ImS32)(&valuesArg[0]), C.int(count)))
 }
@@ -1486,11 +1441,9 @@ func PlotImMaxArrayS8Ptr(values *[]int8, count int32) int {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = int8(valuesV)
 		}
-
 	}()
 	return int(C.ImPlot_ImMaxArray_S8Ptr((*C.ImS8)(&valuesArg[0]), C.int(count)))
 }
@@ -1502,11 +1455,9 @@ func PlotImMaxArrayU16Ptr(values *[]uint16, count int32) uint32 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = uint16(valuesV)
 		}
-
 	}()
 	return uint32(C.ImPlot_ImMaxArray_U16Ptr((*C.ImU16)(&valuesArg[0]), C.int(count)))
 }
@@ -1518,11 +1469,9 @@ func PlotImMaxArrayU32Ptr(values *[]uint32, count int32) uint32 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = uint32(valuesV)
 		}
-
 	}()
 	return uint32(C.ImPlot_ImMaxArray_U32Ptr((*C.ImU32)(&valuesArg[0]), C.int(count)))
 }
@@ -1538,11 +1487,9 @@ func PlotImMaxArrayU8Ptr(values *[]byte, count int32) uint32 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = byte(valuesV)
 		}
-
 	}()
 	return uint32(C.ImPlot_ImMaxArray_U8Ptr((*C.ImU8)(&valuesArg[0]), C.int(count)))
 }
@@ -1554,11 +1501,9 @@ func PlotImMaxArraydoublePtr(values *[]float64, count int32) float64 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = float64(valuesV)
 		}
-
 	}()
 	return float64(C.ImPlot_ImMaxArray_doublePtr((*C.double)(&valuesArg[0]), C.int(count)))
 }
@@ -1574,11 +1519,9 @@ func PlotImMeanS16Ptr(values *[]int, count int32) float64 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = int(valuesV)
 		}
-
 	}()
 	return float64(C.ImPlot_ImMean_S16Ptr((*C.ImS16)(&valuesArg[0]), C.int(count)))
 }
@@ -1590,11 +1533,9 @@ func PlotImMeanS32Ptr(values *[]int32, count int32) float64 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = int32(valuesV)
 		}
-
 	}()
 	return float64(C.ImPlot_ImMean_S32Ptr((*C.ImS32)(&valuesArg[0]), C.int(count)))
 }
@@ -1610,11 +1551,9 @@ func PlotImMeanS8Ptr(values *[]int8, count int32) float64 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = int8(valuesV)
 		}
-
 	}()
 	return float64(C.ImPlot_ImMean_S8Ptr((*C.ImS8)(&valuesArg[0]), C.int(count)))
 }
@@ -1626,11 +1565,9 @@ func PlotImMeanU16Ptr(values *[]uint16, count int32) float64 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = uint16(valuesV)
 		}
-
 	}()
 	return float64(C.ImPlot_ImMean_U16Ptr((*C.ImU16)(&valuesArg[0]), C.int(count)))
 }
@@ -1642,11 +1579,9 @@ func PlotImMeanU32Ptr(values *[]uint32, count int32) float64 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = uint32(valuesV)
 		}
-
 	}()
 	return float64(C.ImPlot_ImMean_U32Ptr((*C.ImU32)(&valuesArg[0]), C.int(count)))
 }
@@ -1662,11 +1597,9 @@ func PlotImMeanU8Ptr(values *[]byte, count int32) float64 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = byte(valuesV)
 		}
-
 	}()
 	return float64(C.ImPlot_ImMean_U8Ptr((*C.ImU8)(&valuesArg[0]), C.int(count)))
 }
@@ -1678,11 +1611,9 @@ func PlotImMeandoublePtr(values *[]float64, count int32) float64 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = float64(valuesV)
 		}
-
 	}()
 	return float64(C.ImPlot_ImMean_doublePtr((*C.double)(&valuesArg[0]), C.int(count)))
 }
@@ -1698,11 +1629,9 @@ func PlotImMinArrayS16Ptr(values *[]int, count int32) int {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = int(valuesV)
 		}
-
 	}()
 	return int(C.ImPlot_ImMinArray_S16Ptr((*C.ImS16)(&valuesArg[0]), C.int(count)))
 }
@@ -1714,11 +1643,9 @@ func PlotImMinArrayS32Ptr(values *[]int32, count int32) int {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = int32(valuesV)
 		}
-
 	}()
 	return int(C.ImPlot_ImMinArray_S32Ptr((*C.ImS32)(&valuesArg[0]), C.int(count)))
 }
@@ -1730,11 +1657,9 @@ func PlotImMinArrayS8Ptr(values *[]int8, count int32) int {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = int8(valuesV)
 		}
-
 	}()
 	return int(C.ImPlot_ImMinArray_S8Ptr((*C.ImS8)(&valuesArg[0]), C.int(count)))
 }
@@ -1746,11 +1671,9 @@ func PlotImMinArrayU16Ptr(values *[]uint16, count int32) uint32 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = uint16(valuesV)
 		}
-
 	}()
 	return uint32(C.ImPlot_ImMinArray_U16Ptr((*C.ImU16)(&valuesArg[0]), C.int(count)))
 }
@@ -1762,11 +1685,9 @@ func PlotImMinArrayU32Ptr(values *[]uint32, count int32) uint32 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = uint32(valuesV)
 		}
-
 	}()
 	return uint32(C.ImPlot_ImMinArray_U32Ptr((*C.ImU32)(&valuesArg[0]), C.int(count)))
 }
@@ -1782,11 +1703,9 @@ func PlotImMinArrayU8Ptr(values *[]byte, count int32) uint32 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = byte(valuesV)
 		}
-
 	}()
 	return uint32(C.ImPlot_ImMinArray_U8Ptr((*C.ImU8)(&valuesArg[0]), C.int(count)))
 }
@@ -1798,11 +1717,9 @@ func PlotImMinArraydoublePtr(values *[]float64, count int32) float64 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = float64(valuesV)
 		}
-
 	}()
 	return float64(C.ImPlot_ImMinArray_doublePtr((*C.double)(&valuesArg[0]), C.int(count)))
 }
@@ -1814,7 +1731,6 @@ func PlotImMinMaxArrayFloatPtr(values []float32, count int32, min_out *float32, 
 
 	min_outFin()
 	max_outFin()
-
 }
 
 func PlotImMinMaxArraydoublePtr(values *[]float64, count int32, min_out *float64, max_out *float64) {
@@ -1833,7 +1749,6 @@ func PlotImMinMaxArraydoublePtr(values *[]float64, count int32, min_out *float64
 
 	min_outFin()
 	max_outFin()
-
 }
 
 func PlotImMixU32(a uint32, b uint32, s uint32) uint32 {
@@ -1979,11 +1894,9 @@ func PlotImStdDevS16Ptr(values *[]int, count int32) float64 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = int(valuesV)
 		}
-
 	}()
 	return float64(C.ImPlot_ImStdDev_S16Ptr((*C.ImS16)(&valuesArg[0]), C.int(count)))
 }
@@ -1995,11 +1908,9 @@ func PlotImStdDevS32Ptr(values *[]int32, count int32) float64 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = int32(valuesV)
 		}
-
 	}()
 	return float64(C.ImPlot_ImStdDev_S32Ptr((*C.ImS32)(&valuesArg[0]), C.int(count)))
 }
@@ -2015,11 +1926,9 @@ func PlotImStdDevS8Ptr(values *[]int8, count int32) float64 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = int8(valuesV)
 		}
-
 	}()
 	return float64(C.ImPlot_ImStdDev_S8Ptr((*C.ImS8)(&valuesArg[0]), C.int(count)))
 }
@@ -2031,11 +1940,9 @@ func PlotImStdDevU16Ptr(values *[]uint16, count int32) float64 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = uint16(valuesV)
 		}
-
 	}()
 	return float64(C.ImPlot_ImStdDev_U16Ptr((*C.ImU16)(&valuesArg[0]), C.int(count)))
 }
@@ -2047,11 +1954,9 @@ func PlotImStdDevU32Ptr(values *[]uint32, count int32) float64 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = uint32(valuesV)
 		}
-
 	}()
 	return float64(C.ImPlot_ImStdDev_U32Ptr((*C.ImU32)(&valuesArg[0]), C.int(count)))
 }
@@ -2067,11 +1972,9 @@ func PlotImStdDevU8Ptr(values *[]byte, count int32) float64 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = byte(valuesV)
 		}
-
 	}()
 	return float64(C.ImPlot_ImStdDev_U8Ptr((*C.ImU8)(&valuesArg[0]), C.int(count)))
 }
@@ -2083,11 +1986,9 @@ func PlotImStdDevdoublePtr(values *[]float64, count int32) float64 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = float64(valuesV)
 		}
-
 	}()
 	return float64(C.ImPlot_ImStdDev_doublePtr((*C.double)(&valuesArg[0]), C.int(count)))
 }
@@ -2103,11 +2004,9 @@ func PlotImSumS16Ptr(values *[]int, count int32) int {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = int(valuesV)
 		}
-
 	}()
 	return int(C.ImPlot_ImSum_S16Ptr((*C.ImS16)(&valuesArg[0]), C.int(count)))
 }
@@ -2119,11 +2018,9 @@ func PlotImSumS32Ptr(values *[]int32, count int32) int {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = int32(valuesV)
 		}
-
 	}()
 	return int(C.ImPlot_ImSum_S32Ptr((*C.ImS32)(&valuesArg[0]), C.int(count)))
 }
@@ -2135,11 +2032,9 @@ func PlotImSumS8Ptr(values *[]int8, count int32) int {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = int8(valuesV)
 		}
-
 	}()
 	return int(C.ImPlot_ImSum_S8Ptr((*C.ImS8)(&valuesArg[0]), C.int(count)))
 }
@@ -2151,11 +2046,9 @@ func PlotImSumU16Ptr(values *[]uint16, count int32) uint32 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = uint16(valuesV)
 		}
-
 	}()
 	return uint32(C.ImPlot_ImSum_U16Ptr((*C.ImU16)(&valuesArg[0]), C.int(count)))
 }
@@ -2167,11 +2060,9 @@ func PlotImSumU32Ptr(values *[]uint32, count int32) uint32 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = uint32(valuesV)
 		}
-
 	}()
 	return uint32(C.ImPlot_ImSum_U32Ptr((*C.ImU32)(&valuesArg[0]), C.int(count)))
 }
@@ -2187,11 +2078,9 @@ func PlotImSumU8Ptr(values *[]byte, count int32) uint32 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = byte(valuesV)
 		}
-
 	}()
 	return uint32(C.ImPlot_ImSum_U8Ptr((*C.ImU8)(&valuesArg[0]), C.int(count)))
 }
@@ -2203,11 +2092,9 @@ func PlotImSumdoublePtr(values *[]float64, count int32) float64 {
 	}
 
 	defer func() {
-
 		for i, valuesV := range valuesArg {
 			(*values)[i] = float64(valuesV)
 		}
-
 	}()
 	return float64(C.ImPlot_ImSum_doublePtr((*C.double)(&valuesArg[0]), C.int(count)))
 }
@@ -2248,7 +2135,6 @@ func PlotIsLegendEntryHovered(label_id string) bool {
 
 	defer func() {
 		label_idFin()
-
 	}()
 	return C.ImPlot_IsLegendEntryHovered(label_idArg) == C.bool(true)
 }
@@ -2349,7 +2235,6 @@ func PlotPlotBarGroupsFloatPtrV(label_ids []string, values []float32, item_count
 	C.ImPlot_PlotBarGroups_FloatPtr(label_idsArg, (*C.float)(&(values[0])), C.int(item_count), C.int(group_count), C.double(group_size), C.double(shift), C.ImPlotBarGroupsFlags(flags))
 
 	label_idsFin()
-
 }
 
 // PlotPlotBarGroupsS16PtrV parameter default value hint:
@@ -2370,7 +2255,6 @@ func PlotPlotBarGroupsS16PtrV(label_ids []string, values *[]int, item_count int3
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int(valuesV)
 	}
-
 }
 
 // PlotPlotBarGroupsS32PtrV parameter default value hint:
@@ -2391,7 +2275,6 @@ func PlotPlotBarGroupsS32PtrV(label_ids []string, values *[]int32, item_count in
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int32(valuesV)
 	}
-
 }
 
 // PlotPlotBarGroupsS64PtrV parameter default value hint:
@@ -2403,7 +2286,6 @@ func PlotPlotBarGroupsS64PtrV(label_ids []string, values []int64, item_count int
 	C.ImPlot_PlotBarGroups_S64Ptr(label_idsArg, (*C.longlong)(&(values[0])), C.int(item_count), C.int(group_count), C.double(group_size), C.double(shift), C.ImPlotBarGroupsFlags(flags))
 
 	label_idsFin()
-
 }
 
 // PlotPlotBarGroupsS8PtrV parameter default value hint:
@@ -2424,7 +2306,6 @@ func PlotPlotBarGroupsS8PtrV(label_ids []string, values *[]int8, item_count int3
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int8(valuesV)
 	}
-
 }
 
 // PlotPlotBarGroupsU16PtrV parameter default value hint:
@@ -2445,7 +2326,6 @@ func PlotPlotBarGroupsU16PtrV(label_ids []string, values *[]uint16, item_count i
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint16(valuesV)
 	}
-
 }
 
 // PlotPlotBarGroupsU32PtrV parameter default value hint:
@@ -2466,7 +2346,6 @@ func PlotPlotBarGroupsU32PtrV(label_ids []string, values *[]uint32, item_count i
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint32(valuesV)
 	}
-
 }
 
 // PlotPlotBarGroupsU64PtrV parameter default value hint:
@@ -2478,7 +2357,6 @@ func PlotPlotBarGroupsU64PtrV(label_ids []string, values []uint64, item_count in
 	C.ImPlot_PlotBarGroups_U64Ptr(label_idsArg, (*C.ulonglong)(&(values[0])), C.int(item_count), C.int(group_count), C.double(group_size), C.double(shift), C.ImPlotBarGroupsFlags(flags))
 
 	label_idsFin()
-
 }
 
 // PlotPlotBarGroupsU8PtrV parameter default value hint:
@@ -2499,7 +2377,6 @@ func PlotPlotBarGroupsU8PtrV(label_ids []string, values *[]byte, item_count int3
 	for i, valuesV := range valuesArg {
 		(*values)[i] = byte(valuesV)
 	}
-
 }
 
 // PlotPlotBarGroupsdoublePtrV parameter default value hint:
@@ -2520,7 +2397,6 @@ func PlotPlotBarGroupsdoublePtrV(label_ids []string, values *[]float64, item_cou
 	for i, valuesV := range valuesArg {
 		(*values)[i] = float64(valuesV)
 	}
-
 }
 
 // PlotPlotBarsFloatPtrFloatPtrV parameter default value hint:
@@ -2532,7 +2408,6 @@ func PlotPlotBarsFloatPtrFloatPtrV(label_id string, xs []float32, ys []float32, 
 	C.ImPlot_PlotBars_FloatPtrFloatPtr(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), C.int(count), C.double(bar_size), C.ImPlotBarsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotBarsFloatPtrIntV parameter default value hint:
@@ -2546,7 +2421,6 @@ func PlotPlotBarsFloatPtrIntV(label_id string, values []float32, count int32, ba
 	C.ImPlot_PlotBars_FloatPtrInt(label_idArg, (*C.float)(&(values[0])), C.int(count), C.double(bar_size), C.double(shift), C.ImPlotBarsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotBarsS16PtrIntV parameter default value hint:
@@ -2569,7 +2443,6 @@ func PlotPlotBarsS16PtrIntV(label_id string, values *[]int, count int32, bar_siz
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int(valuesV)
 	}
-
 }
 
 // PlotPlotBarsS16PtrS16PtrV parameter default value hint:
@@ -2599,7 +2472,6 @@ func PlotPlotBarsS16PtrS16PtrV(label_id string, xs *[]int, ys *[]int, count int3
 	for i, ysV := range ysArg {
 		(*ys)[i] = int(ysV)
 	}
-
 }
 
 // PlotPlotBarsS32PtrIntV parameter default value hint:
@@ -2622,7 +2494,6 @@ func PlotPlotBarsS32PtrIntV(label_id string, values *[]int32, count int32, bar_s
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int32(valuesV)
 	}
-
 }
 
 // PlotPlotBarsS32PtrS32PtrV parameter default value hint:
@@ -2652,7 +2523,6 @@ func PlotPlotBarsS32PtrS32PtrV(label_id string, xs *[]int32, ys *[]int32, count 
 	for i, ysV := range ysArg {
 		(*ys)[i] = int32(ysV)
 	}
-
 }
 
 // PlotPlotBarsS64PtrIntV parameter default value hint:
@@ -2666,7 +2536,6 @@ func PlotPlotBarsS64PtrIntV(label_id string, values []int64, count int32, bar_si
 	C.ImPlot_PlotBars_S64PtrInt(label_idArg, (*C.longlong)(&(values[0])), C.int(count), C.double(bar_size), C.double(shift), C.ImPlotBarsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotBarsS64PtrS64PtrV parameter default value hint:
@@ -2678,7 +2547,6 @@ func PlotPlotBarsS64PtrS64PtrV(label_id string, xs []int64, ys []int64, count in
 	C.ImPlot_PlotBars_S64PtrS64Ptr(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), C.int(count), C.double(bar_size), C.ImPlotBarsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotBarsS8PtrIntV parameter default value hint:
@@ -2701,7 +2569,6 @@ func PlotPlotBarsS8PtrIntV(label_id string, values *[]int8, count int32, bar_siz
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int8(valuesV)
 	}
-
 }
 
 // PlotPlotBarsS8PtrS8PtrV parameter default value hint:
@@ -2731,7 +2598,6 @@ func PlotPlotBarsS8PtrS8PtrV(label_id string, xs *[]int8, ys *[]int8, count int3
 	for i, ysV := range ysArg {
 		(*ys)[i] = int8(ysV)
 	}
-
 }
 
 // PlotPlotBarsU16PtrIntV parameter default value hint:
@@ -2754,7 +2620,6 @@ func PlotPlotBarsU16PtrIntV(label_id string, values *[]uint16, count int32, bar_
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint16(valuesV)
 	}
-
 }
 
 // PlotPlotBarsU16PtrU16PtrV parameter default value hint:
@@ -2784,7 +2649,6 @@ func PlotPlotBarsU16PtrU16PtrV(label_id string, xs *[]uint16, ys *[]uint16, coun
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint16(ysV)
 	}
-
 }
 
 // PlotPlotBarsU32PtrIntV parameter default value hint:
@@ -2807,7 +2671,6 @@ func PlotPlotBarsU32PtrIntV(label_id string, values *[]uint32, count int32, bar_
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint32(valuesV)
 	}
-
 }
 
 // PlotPlotBarsU32PtrU32PtrV parameter default value hint:
@@ -2837,7 +2700,6 @@ func PlotPlotBarsU32PtrU32PtrV(label_id string, xs *[]uint32, ys *[]uint32, coun
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint32(ysV)
 	}
-
 }
 
 // PlotPlotBarsU64PtrIntV parameter default value hint:
@@ -2851,7 +2713,6 @@ func PlotPlotBarsU64PtrIntV(label_id string, values []uint64, count int32, bar_s
 	C.ImPlot_PlotBars_U64PtrInt(label_idArg, (*C.ulonglong)(&(values[0])), C.int(count), C.double(bar_size), C.double(shift), C.ImPlotBarsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotBarsU64PtrU64PtrV parameter default value hint:
@@ -2863,7 +2724,6 @@ func PlotPlotBarsU64PtrU64PtrV(label_id string, xs []uint64, ys []uint64, count 
 	C.ImPlot_PlotBars_U64PtrU64Ptr(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), C.int(count), C.double(bar_size), C.ImPlotBarsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotBarsU8PtrIntV parameter default value hint:
@@ -2886,7 +2746,6 @@ func PlotPlotBarsU8PtrIntV(label_id string, values *[]byte, count int32, bar_siz
 	for i, valuesV := range valuesArg {
 		(*values)[i] = byte(valuesV)
 	}
-
 }
 
 // PlotPlotBarsU8PtrU8PtrV parameter default value hint:
@@ -2916,7 +2775,6 @@ func PlotPlotBarsU8PtrU8PtrV(label_id string, xs *[]byte, ys *[]byte, count int3
 	for i, ysV := range ysArg {
 		(*ys)[i] = byte(ysV)
 	}
-
 }
 
 // PlotPlotBarsdoublePtrIntV parameter default value hint:
@@ -2939,7 +2797,6 @@ func PlotPlotBarsdoublePtrIntV(label_id string, values *[]float64, count int32, 
 	for i, valuesV := range valuesArg {
 		(*values)[i] = float64(valuesV)
 	}
-
 }
 
 // PlotPlotBarsdoublePtrdoublePtrV parameter default value hint:
@@ -2969,7 +2826,6 @@ func PlotPlotBarsdoublePtrdoublePtrV(label_id string, xs *[]float64, ys *[]float
 	for i, ysV := range ysArg {
 		(*ys)[i] = float64(ysV)
 	}
-
 }
 
 // PlotPlotDigitalFloatPtrV parameter default value hint:
@@ -2981,7 +2837,6 @@ func PlotPlotDigitalFloatPtrV(label_id string, xs []float32, ys []float32, count
 	C.ImPlot_PlotDigital_FloatPtr(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), C.int(count), C.ImPlotDigitalFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotDigitalS16PtrV parameter default value hint:
@@ -3011,7 +2866,6 @@ func PlotPlotDigitalS16PtrV(label_id string, xs *[]int, ys *[]int, count int32, 
 	for i, ysV := range ysArg {
 		(*ys)[i] = int(ysV)
 	}
-
 }
 
 // PlotPlotDigitalS32PtrV parameter default value hint:
@@ -3041,7 +2895,6 @@ func PlotPlotDigitalS32PtrV(label_id string, xs *[]int32, ys *[]int32, count int
 	for i, ysV := range ysArg {
 		(*ys)[i] = int32(ysV)
 	}
-
 }
 
 // PlotPlotDigitalS64PtrV parameter default value hint:
@@ -3053,7 +2906,6 @@ func PlotPlotDigitalS64PtrV(label_id string, xs []int64, ys []int64, count int32
 	C.ImPlot_PlotDigital_S64Ptr(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), C.int(count), C.ImPlotDigitalFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotDigitalS8PtrV parameter default value hint:
@@ -3083,7 +2935,6 @@ func PlotPlotDigitalS8PtrV(label_id string, xs *[]int8, ys *[]int8, count int32,
 	for i, ysV := range ysArg {
 		(*ys)[i] = int8(ysV)
 	}
-
 }
 
 // PlotPlotDigitalU16PtrV parameter default value hint:
@@ -3113,7 +2964,6 @@ func PlotPlotDigitalU16PtrV(label_id string, xs *[]uint16, ys *[]uint16, count i
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint16(ysV)
 	}
-
 }
 
 // PlotPlotDigitalU32PtrV parameter default value hint:
@@ -3143,7 +2993,6 @@ func PlotPlotDigitalU32PtrV(label_id string, xs *[]uint32, ys *[]uint32, count i
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint32(ysV)
 	}
-
 }
 
 // PlotPlotDigitalU64PtrV parameter default value hint:
@@ -3155,7 +3004,6 @@ func PlotPlotDigitalU64PtrV(label_id string, xs []uint64, ys []uint64, count int
 	C.ImPlot_PlotDigital_U64Ptr(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), C.int(count), C.ImPlotDigitalFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotDigitalU8PtrV parameter default value hint:
@@ -3185,7 +3033,6 @@ func PlotPlotDigitalU8PtrV(label_id string, xs *[]byte, ys *[]byte, count int32,
 	for i, ysV := range ysArg {
 		(*ys)[i] = byte(ysV)
 	}
-
 }
 
 // PlotPlotDigitaldoublePtrV parameter default value hint:
@@ -3215,7 +3062,6 @@ func PlotPlotDigitaldoublePtrV(label_id string, xs *[]float64, ys *[]float64, co
 	for i, ysV := range ysArg {
 		(*ys)[i] = float64(ysV)
 	}
-
 }
 
 // PlotPlotDummyV parameter default value hint:
@@ -3225,7 +3071,6 @@ func PlotPlotDummyV(label_id string, flags PlotDummyFlags) {
 	C.ImPlot_PlotDummy(label_idArg, C.ImPlotDummyFlags(flags))
 
 	label_idFin()
-
 }
 
 // PlotPlotErrorBarsFloatPtrFloatPtrFloatPtrFloatPtrV parameter default value hint:
@@ -3237,7 +3082,6 @@ func PlotPlotErrorBarsFloatPtrFloatPtrFloatPtrFloatPtrV(label_id string, xs []fl
 	C.ImPlot_PlotErrorBars_FloatPtrFloatPtrFloatPtrFloatPtr(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), (*C.float)(&(neg[0])), (*C.float)(&(pos[0])), C.int(count), C.ImPlotErrorBarsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotErrorBarsFloatPtrFloatPtrFloatPtrIntV parameter default value hint:
@@ -3249,7 +3093,6 @@ func PlotPlotErrorBarsFloatPtrFloatPtrFloatPtrIntV(label_id string, xs []float32
 	C.ImPlot_PlotErrorBars_FloatPtrFloatPtrFloatPtrInt(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), (*C.float)(&(err[0])), C.int(count), C.ImPlotErrorBarsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotErrorBarsS16PtrS16PtrS16PtrIntV parameter default value hint:
@@ -3288,7 +3131,6 @@ func PlotPlotErrorBarsS16PtrS16PtrS16PtrIntV(label_id string, xs *[]int, ys *[]i
 	for i, errV := range errArg {
 		(*err)[i] = int(errV)
 	}
-
 }
 
 // PlotPlotErrorBarsS16PtrS16PtrS16PtrS16PtrV parameter default value hint:
@@ -3336,7 +3178,6 @@ func PlotPlotErrorBarsS16PtrS16PtrS16PtrS16PtrV(label_id string, xs *[]int, ys *
 	for i, posV := range posArg {
 		(*pos)[i] = int(posV)
 	}
-
 }
 
 // PlotPlotErrorBarsS32PtrS32PtrS32PtrIntV parameter default value hint:
@@ -3375,7 +3216,6 @@ func PlotPlotErrorBarsS32PtrS32PtrS32PtrIntV(label_id string, xs *[]int32, ys *[
 	for i, errV := range errArg {
 		(*err)[i] = int32(errV)
 	}
-
 }
 
 // PlotPlotErrorBarsS32PtrS32PtrS32PtrS32PtrV parameter default value hint:
@@ -3423,7 +3263,6 @@ func PlotPlotErrorBarsS32PtrS32PtrS32PtrS32PtrV(label_id string, xs *[]int32, ys
 	for i, posV := range posArg {
 		(*pos)[i] = int32(posV)
 	}
-
 }
 
 // PlotPlotErrorBarsS64PtrS64PtrS64PtrIntV parameter default value hint:
@@ -3435,7 +3274,6 @@ func PlotPlotErrorBarsS64PtrS64PtrS64PtrIntV(label_id string, xs []int64, ys []i
 	C.ImPlot_PlotErrorBars_S64PtrS64PtrS64PtrInt(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), (*C.longlong)(&(err[0])), C.int(count), C.ImPlotErrorBarsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotErrorBarsS64PtrS64PtrS64PtrS64PtrV parameter default value hint:
@@ -3447,7 +3285,6 @@ func PlotPlotErrorBarsS64PtrS64PtrS64PtrS64PtrV(label_id string, xs []int64, ys 
 	C.ImPlot_PlotErrorBars_S64PtrS64PtrS64PtrS64Ptr(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), (*C.longlong)(&(neg[0])), (*C.longlong)(&(pos[0])), C.int(count), C.ImPlotErrorBarsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotErrorBarsS8PtrS8PtrS8PtrIntV parameter default value hint:
@@ -3486,7 +3323,6 @@ func PlotPlotErrorBarsS8PtrS8PtrS8PtrIntV(label_id string, xs *[]int8, ys *[]int
 	for i, errV := range errArg {
 		(*err)[i] = int8(errV)
 	}
-
 }
 
 // PlotPlotErrorBarsS8PtrS8PtrS8PtrS8PtrV parameter default value hint:
@@ -3534,7 +3370,6 @@ func PlotPlotErrorBarsS8PtrS8PtrS8PtrS8PtrV(label_id string, xs *[]int8, ys *[]i
 	for i, posV := range posArg {
 		(*pos)[i] = int8(posV)
 	}
-
 }
 
 // PlotPlotErrorBarsU16PtrU16PtrU16PtrIntV parameter default value hint:
@@ -3573,7 +3408,6 @@ func PlotPlotErrorBarsU16PtrU16PtrU16PtrIntV(label_id string, xs *[]uint16, ys *
 	for i, errV := range errArg {
 		(*err)[i] = uint16(errV)
 	}
-
 }
 
 // PlotPlotErrorBarsU16PtrU16PtrU16PtrU16PtrV parameter default value hint:
@@ -3621,7 +3455,6 @@ func PlotPlotErrorBarsU16PtrU16PtrU16PtrU16PtrV(label_id string, xs *[]uint16, y
 	for i, posV := range posArg {
 		(*pos)[i] = uint16(posV)
 	}
-
 }
 
 // PlotPlotErrorBarsU32PtrU32PtrU32PtrIntV parameter default value hint:
@@ -3660,7 +3493,6 @@ func PlotPlotErrorBarsU32PtrU32PtrU32PtrIntV(label_id string, xs *[]uint32, ys *
 	for i, errV := range errArg {
 		(*err)[i] = uint32(errV)
 	}
-
 }
 
 // PlotPlotErrorBarsU32PtrU32PtrU32PtrU32PtrV parameter default value hint:
@@ -3708,7 +3540,6 @@ func PlotPlotErrorBarsU32PtrU32PtrU32PtrU32PtrV(label_id string, xs *[]uint32, y
 	for i, posV := range posArg {
 		(*pos)[i] = uint32(posV)
 	}
-
 }
 
 // PlotPlotErrorBarsU64PtrU64PtrU64PtrIntV parameter default value hint:
@@ -3720,7 +3551,6 @@ func PlotPlotErrorBarsU64PtrU64PtrU64PtrIntV(label_id string, xs []uint64, ys []
 	C.ImPlot_PlotErrorBars_U64PtrU64PtrU64PtrInt(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), (*C.ulonglong)(&(err[0])), C.int(count), C.ImPlotErrorBarsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotErrorBarsU64PtrU64PtrU64PtrU64PtrV parameter default value hint:
@@ -3732,7 +3562,6 @@ func PlotPlotErrorBarsU64PtrU64PtrU64PtrU64PtrV(label_id string, xs []uint64, ys
 	C.ImPlot_PlotErrorBars_U64PtrU64PtrU64PtrU64Ptr(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), (*C.ulonglong)(&(neg[0])), (*C.ulonglong)(&(pos[0])), C.int(count), C.ImPlotErrorBarsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotErrorBarsU8PtrU8PtrU8PtrIntV parameter default value hint:
@@ -3771,7 +3600,6 @@ func PlotPlotErrorBarsU8PtrU8PtrU8PtrIntV(label_id string, xs *[]byte, ys *[]byt
 	for i, errV := range errArg {
 		(*err)[i] = byte(errV)
 	}
-
 }
 
 // PlotPlotErrorBarsU8PtrU8PtrU8PtrU8PtrV parameter default value hint:
@@ -3819,7 +3647,6 @@ func PlotPlotErrorBarsU8PtrU8PtrU8PtrU8PtrV(label_id string, xs *[]byte, ys *[]b
 	for i, posV := range posArg {
 		(*pos)[i] = byte(posV)
 	}
-
 }
 
 // PlotPlotErrorBarsdoublePtrdoublePtrdoublePtrIntV parameter default value hint:
@@ -3858,7 +3685,6 @@ func PlotPlotErrorBarsdoublePtrdoublePtrdoublePtrIntV(label_id string, xs *[]flo
 	for i, errV := range errArg {
 		(*err)[i] = float64(errV)
 	}
-
 }
 
 // PlotPlotErrorBarsdoublePtrdoublePtrdoublePtrdoublePtrV parameter default value hint:
@@ -3906,7 +3732,6 @@ func PlotPlotErrorBarsdoublePtrdoublePtrdoublePtrdoublePtrV(label_id string, xs 
 	for i, posV := range posArg {
 		(*pos)[i] = float64(posV)
 	}
-
 }
 
 // PlotPlotHeatmapFloatPtrV parameter default value hint:
@@ -3923,7 +3748,6 @@ func PlotPlotHeatmapFloatPtrV(label_id string, values []float32, rows int32, col
 
 	label_idFin()
 	label_fmtFin()
-
 }
 
 // PlotPlotHeatmapS16PtrV parameter default value hint:
@@ -3950,7 +3774,6 @@ func PlotPlotHeatmapS16PtrV(label_id string, values *[]int, rows int32, cols int
 	}
 
 	label_fmtFin()
-
 }
 
 // PlotPlotHeatmapS32PtrV parameter default value hint:
@@ -3977,7 +3800,6 @@ func PlotPlotHeatmapS32PtrV(label_id string, values *[]int32, rows int32, cols i
 	}
 
 	label_fmtFin()
-
 }
 
 // PlotPlotHeatmapS64PtrV parameter default value hint:
@@ -3994,7 +3816,6 @@ func PlotPlotHeatmapS64PtrV(label_id string, values []int64, rows int32, cols in
 
 	label_idFin()
 	label_fmtFin()
-
 }
 
 // PlotPlotHeatmapS8PtrV parameter default value hint:
@@ -4021,7 +3842,6 @@ func PlotPlotHeatmapS8PtrV(label_id string, values *[]int8, rows int32, cols int
 	}
 
 	label_fmtFin()
-
 }
 
 // PlotPlotHeatmapU16PtrV parameter default value hint:
@@ -4048,7 +3868,6 @@ func PlotPlotHeatmapU16PtrV(label_id string, values *[]uint16, rows int32, cols 
 	}
 
 	label_fmtFin()
-
 }
 
 // PlotPlotHeatmapU32PtrV parameter default value hint:
@@ -4075,7 +3894,6 @@ func PlotPlotHeatmapU32PtrV(label_id string, values *[]uint32, rows int32, cols 
 	}
 
 	label_fmtFin()
-
 }
 
 // PlotPlotHeatmapU64PtrV parameter default value hint:
@@ -4092,7 +3910,6 @@ func PlotPlotHeatmapU64PtrV(label_id string, values []uint64, rows int32, cols i
 
 	label_idFin()
 	label_fmtFin()
-
 }
 
 // PlotPlotHeatmapU8PtrV parameter default value hint:
@@ -4119,7 +3936,6 @@ func PlotPlotHeatmapU8PtrV(label_id string, values *[]byte, rows int32, cols int
 	}
 
 	label_fmtFin()
-
 }
 
 // PlotPlotHeatmapdoublePtrV parameter default value hint:
@@ -4146,7 +3962,6 @@ func PlotPlotHeatmapdoublePtrV(label_id string, values *[]float64, rows int32, c
 	}
 
 	label_fmtFin()
-
 }
 
 // PlotPlotImageV parameter default value hint:
@@ -4159,7 +3974,6 @@ func PlotPlotImageV(label_id string, user_texture_id TextureID, bounds_min PlotP
 	C.ImPlot_PlotImage(label_idArg, C.ImTextureID(user_texture_id), bounds_min.toC(), bounds_max.toC(), uv0.toC(), uv1.toC(), tint_col.toC(), C.ImPlotImageFlags(flags))
 
 	label_idFin()
-
 }
 
 // PlotPlotInfLinesFloatPtrV parameter default value hint:
@@ -4171,7 +3985,6 @@ func PlotPlotInfLinesFloatPtrV(label_id string, values []float32, count int32, f
 	C.ImPlot_PlotInfLines_FloatPtr(label_idArg, (*C.float)(&(values[0])), C.int(count), C.ImPlotInfLinesFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotInfLinesS16PtrV parameter default value hint:
@@ -4192,7 +4005,6 @@ func PlotPlotInfLinesS16PtrV(label_id string, values *[]int, count int32, flags 
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int(valuesV)
 	}
-
 }
 
 // PlotPlotInfLinesS32PtrV parameter default value hint:
@@ -4213,7 +4025,6 @@ func PlotPlotInfLinesS32PtrV(label_id string, values *[]int32, count int32, flag
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int32(valuesV)
 	}
-
 }
 
 // PlotPlotInfLinesS64PtrV parameter default value hint:
@@ -4225,7 +4036,6 @@ func PlotPlotInfLinesS64PtrV(label_id string, values []int64, count int32, flags
 	C.ImPlot_PlotInfLines_S64Ptr(label_idArg, (*C.longlong)(&(values[0])), C.int(count), C.ImPlotInfLinesFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotInfLinesS8PtrV parameter default value hint:
@@ -4246,7 +4056,6 @@ func PlotPlotInfLinesS8PtrV(label_id string, values *[]int8, count int32, flags 
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int8(valuesV)
 	}
-
 }
 
 // PlotPlotInfLinesU16PtrV parameter default value hint:
@@ -4267,7 +4076,6 @@ func PlotPlotInfLinesU16PtrV(label_id string, values *[]uint16, count int32, fla
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint16(valuesV)
 	}
-
 }
 
 // PlotPlotInfLinesU32PtrV parameter default value hint:
@@ -4288,7 +4096,6 @@ func PlotPlotInfLinesU32PtrV(label_id string, values *[]uint32, count int32, fla
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint32(valuesV)
 	}
-
 }
 
 // PlotPlotInfLinesU64PtrV parameter default value hint:
@@ -4300,7 +4107,6 @@ func PlotPlotInfLinesU64PtrV(label_id string, values []uint64, count int32, flag
 	C.ImPlot_PlotInfLines_U64Ptr(label_idArg, (*C.ulonglong)(&(values[0])), C.int(count), C.ImPlotInfLinesFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotInfLinesU8PtrV parameter default value hint:
@@ -4321,7 +4127,6 @@ func PlotPlotInfLinesU8PtrV(label_id string, values *[]byte, count int32, flags 
 	for i, valuesV := range valuesArg {
 		(*values)[i] = byte(valuesV)
 	}
-
 }
 
 // PlotPlotInfLinesdoublePtrV parameter default value hint:
@@ -4342,7 +4147,6 @@ func PlotPlotInfLinesdoublePtrV(label_id string, values *[]float64, count int32,
 	for i, valuesV := range valuesArg {
 		(*values)[i] = float64(valuesV)
 	}
-
 }
 
 // PlotPlotLineFloatPtrFloatPtrV parameter default value hint:
@@ -4354,7 +4158,6 @@ func PlotPlotLineFloatPtrFloatPtrV(label_id string, xs []float32, ys []float32, 
 	C.ImPlot_PlotLine_FloatPtrFloatPtr(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), C.int(count), C.ImPlotLineFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotLineFloatPtrIntV parameter default value hint:
@@ -4368,7 +4171,6 @@ func PlotPlotLineFloatPtrIntV(label_id string, values []float32, count int32, xs
 	C.ImPlot_PlotLine_FloatPtrInt(label_idArg, (*C.float)(&(values[0])), C.int(count), C.double(xscale), C.double(xstart), C.ImPlotLineFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotLineS16PtrIntV parameter default value hint:
@@ -4391,7 +4193,6 @@ func PlotPlotLineS16PtrIntV(label_id string, values *[]int, count int32, xscale 
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int(valuesV)
 	}
-
 }
 
 // PlotPlotLineS16PtrS16PtrV parameter default value hint:
@@ -4421,7 +4222,6 @@ func PlotPlotLineS16PtrS16PtrV(label_id string, xs *[]int, ys *[]int, count int3
 	for i, ysV := range ysArg {
 		(*ys)[i] = int(ysV)
 	}
-
 }
 
 // PlotPlotLineS32PtrIntV parameter default value hint:
@@ -4444,7 +4244,6 @@ func PlotPlotLineS32PtrIntV(label_id string, values *[]int32, count int32, xscal
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int32(valuesV)
 	}
-
 }
 
 // PlotPlotLineS32PtrS32PtrV parameter default value hint:
@@ -4474,7 +4273,6 @@ func PlotPlotLineS32PtrS32PtrV(label_id string, xs *[]int32, ys *[]int32, count 
 	for i, ysV := range ysArg {
 		(*ys)[i] = int32(ysV)
 	}
-
 }
 
 // PlotPlotLineS64PtrIntV parameter default value hint:
@@ -4488,7 +4286,6 @@ func PlotPlotLineS64PtrIntV(label_id string, values []int64, count int32, xscale
 	C.ImPlot_PlotLine_S64PtrInt(label_idArg, (*C.longlong)(&(values[0])), C.int(count), C.double(xscale), C.double(xstart), C.ImPlotLineFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotLineS64PtrS64PtrV parameter default value hint:
@@ -4500,7 +4297,6 @@ func PlotPlotLineS64PtrS64PtrV(label_id string, xs []int64, ys []int64, count in
 	C.ImPlot_PlotLine_S64PtrS64Ptr(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), C.int(count), C.ImPlotLineFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotLineS8PtrIntV parameter default value hint:
@@ -4523,7 +4319,6 @@ func PlotPlotLineS8PtrIntV(label_id string, values *[]int8, count int32, xscale 
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int8(valuesV)
 	}
-
 }
 
 // PlotPlotLineS8PtrS8PtrV parameter default value hint:
@@ -4553,7 +4348,6 @@ func PlotPlotLineS8PtrS8PtrV(label_id string, xs *[]int8, ys *[]int8, count int3
 	for i, ysV := range ysArg {
 		(*ys)[i] = int8(ysV)
 	}
-
 }
 
 // PlotPlotLineU16PtrIntV parameter default value hint:
@@ -4576,7 +4370,6 @@ func PlotPlotLineU16PtrIntV(label_id string, values *[]uint16, count int32, xsca
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint16(valuesV)
 	}
-
 }
 
 // PlotPlotLineU16PtrU16PtrV parameter default value hint:
@@ -4606,7 +4399,6 @@ func PlotPlotLineU16PtrU16PtrV(label_id string, xs *[]uint16, ys *[]uint16, coun
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint16(ysV)
 	}
-
 }
 
 // PlotPlotLineU32PtrIntV parameter default value hint:
@@ -4629,7 +4421,6 @@ func PlotPlotLineU32PtrIntV(label_id string, values *[]uint32, count int32, xsca
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint32(valuesV)
 	}
-
 }
 
 // PlotPlotLineU32PtrU32PtrV parameter default value hint:
@@ -4659,7 +4450,6 @@ func PlotPlotLineU32PtrU32PtrV(label_id string, xs *[]uint32, ys *[]uint32, coun
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint32(ysV)
 	}
-
 }
 
 // PlotPlotLineU64PtrIntV parameter default value hint:
@@ -4673,7 +4463,6 @@ func PlotPlotLineU64PtrIntV(label_id string, values []uint64, count int32, xscal
 	C.ImPlot_PlotLine_U64PtrInt(label_idArg, (*C.ulonglong)(&(values[0])), C.int(count), C.double(xscale), C.double(xstart), C.ImPlotLineFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotLineU64PtrU64PtrV parameter default value hint:
@@ -4685,7 +4474,6 @@ func PlotPlotLineU64PtrU64PtrV(label_id string, xs []uint64, ys []uint64, count 
 	C.ImPlot_PlotLine_U64PtrU64Ptr(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), C.int(count), C.ImPlotLineFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotLineU8PtrIntV parameter default value hint:
@@ -4708,7 +4496,6 @@ func PlotPlotLineU8PtrIntV(label_id string, values *[]byte, count int32, xscale 
 	for i, valuesV := range valuesArg {
 		(*values)[i] = byte(valuesV)
 	}
-
 }
 
 // PlotPlotLineU8PtrU8PtrV parameter default value hint:
@@ -4738,7 +4525,6 @@ func PlotPlotLineU8PtrU8PtrV(label_id string, xs *[]byte, ys *[]byte, count int3
 	for i, ysV := range ysArg {
 		(*ys)[i] = byte(ysV)
 	}
-
 }
 
 // PlotPlotLinedoublePtrIntV parameter default value hint:
@@ -4761,7 +4547,6 @@ func PlotPlotLinedoublePtrIntV(label_id string, values *[]float64, count int32, 
 	for i, valuesV := range valuesArg {
 		(*values)[i] = float64(valuesV)
 	}
-
 }
 
 // PlotPlotLinedoublePtrdoublePtrV parameter default value hint:
@@ -4791,7 +4576,6 @@ func PlotPlotLinedoublePtrdoublePtrV(label_id string, xs *[]float64, ys *[]float
 	for i, ysV := range ysArg {
 		(*ys)[i] = float64(ysV)
 	}
-
 }
 
 // PlotPlotPieChartFloatPtrV parameter default value hint:
@@ -4805,7 +4589,6 @@ func PlotPlotPieChartFloatPtrV(label_ids []string, values []float32, count int32
 
 	label_idsFin()
 	label_fmtFin()
-
 }
 
 // PlotPlotPieChartS16PtrV parameter default value hint:
@@ -4829,7 +4612,6 @@ func PlotPlotPieChartS16PtrV(label_ids []string, values *[]int, count int32, x f
 	}
 
 	label_fmtFin()
-
 }
 
 // PlotPlotPieChartS32PtrV parameter default value hint:
@@ -4853,7 +4635,6 @@ func PlotPlotPieChartS32PtrV(label_ids []string, values *[]int32, count int32, x
 	}
 
 	label_fmtFin()
-
 }
 
 // PlotPlotPieChartS64PtrV parameter default value hint:
@@ -4867,7 +4648,6 @@ func PlotPlotPieChartS64PtrV(label_ids []string, values []int64, count int32, x 
 
 	label_idsFin()
 	label_fmtFin()
-
 }
 
 // PlotPlotPieChartS8PtrV parameter default value hint:
@@ -4891,7 +4671,6 @@ func PlotPlotPieChartS8PtrV(label_ids []string, values *[]int8, count int32, x f
 	}
 
 	label_fmtFin()
-
 }
 
 // PlotPlotPieChartU16PtrV parameter default value hint:
@@ -4915,7 +4694,6 @@ func PlotPlotPieChartU16PtrV(label_ids []string, values *[]uint16, count int32, 
 	}
 
 	label_fmtFin()
-
 }
 
 // PlotPlotPieChartU32PtrV parameter default value hint:
@@ -4939,7 +4717,6 @@ func PlotPlotPieChartU32PtrV(label_ids []string, values *[]uint32, count int32, 
 	}
 
 	label_fmtFin()
-
 }
 
 // PlotPlotPieChartU64PtrV parameter default value hint:
@@ -4953,7 +4730,6 @@ func PlotPlotPieChartU64PtrV(label_ids []string, values []uint64, count int32, x
 
 	label_idsFin()
 	label_fmtFin()
-
 }
 
 // PlotPlotPieChartU8PtrV parameter default value hint:
@@ -4977,7 +4753,6 @@ func PlotPlotPieChartU8PtrV(label_ids []string, values *[]byte, count int32, x f
 	}
 
 	label_fmtFin()
-
 }
 
 // PlotPlotPieChartdoublePtrV parameter default value hint:
@@ -5001,7 +4776,6 @@ func PlotPlotPieChartdoublePtrV(label_ids []string, values *[]float64, count int
 	}
 
 	label_fmtFin()
-
 }
 
 // PlotPlotScatterFloatPtrFloatPtrV parameter default value hint:
@@ -5013,7 +4787,6 @@ func PlotPlotScatterFloatPtrFloatPtrV(label_id string, xs []float32, ys []float3
 	C.ImPlot_PlotScatter_FloatPtrFloatPtr(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), C.int(count), C.ImPlotScatterFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotScatterFloatPtrIntV parameter default value hint:
@@ -5027,7 +4800,6 @@ func PlotPlotScatterFloatPtrIntV(label_id string, values []float32, count int32,
 	C.ImPlot_PlotScatter_FloatPtrInt(label_idArg, (*C.float)(&(values[0])), C.int(count), C.double(xscale), C.double(xstart), C.ImPlotScatterFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotScatterS16PtrIntV parameter default value hint:
@@ -5050,7 +4822,6 @@ func PlotPlotScatterS16PtrIntV(label_id string, values *[]int, count int32, xsca
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int(valuesV)
 	}
-
 }
 
 // PlotPlotScatterS16PtrS16PtrV parameter default value hint:
@@ -5080,7 +4851,6 @@ func PlotPlotScatterS16PtrS16PtrV(label_id string, xs *[]int, ys *[]int, count i
 	for i, ysV := range ysArg {
 		(*ys)[i] = int(ysV)
 	}
-
 }
 
 // PlotPlotScatterS32PtrIntV parameter default value hint:
@@ -5103,7 +4873,6 @@ func PlotPlotScatterS32PtrIntV(label_id string, values *[]int32, count int32, xs
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int32(valuesV)
 	}
-
 }
 
 // PlotPlotScatterS32PtrS32PtrV parameter default value hint:
@@ -5133,7 +4902,6 @@ func PlotPlotScatterS32PtrS32PtrV(label_id string, xs *[]int32, ys *[]int32, cou
 	for i, ysV := range ysArg {
 		(*ys)[i] = int32(ysV)
 	}
-
 }
 
 // PlotPlotScatterS64PtrIntV parameter default value hint:
@@ -5147,7 +4915,6 @@ func PlotPlotScatterS64PtrIntV(label_id string, values []int64, count int32, xsc
 	C.ImPlot_PlotScatter_S64PtrInt(label_idArg, (*C.longlong)(&(values[0])), C.int(count), C.double(xscale), C.double(xstart), C.ImPlotScatterFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotScatterS64PtrS64PtrV parameter default value hint:
@@ -5159,7 +4926,6 @@ func PlotPlotScatterS64PtrS64PtrV(label_id string, xs []int64, ys []int64, count
 	C.ImPlot_PlotScatter_S64PtrS64Ptr(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), C.int(count), C.ImPlotScatterFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotScatterS8PtrIntV parameter default value hint:
@@ -5182,7 +4948,6 @@ func PlotPlotScatterS8PtrIntV(label_id string, values *[]int8, count int32, xsca
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int8(valuesV)
 	}
-
 }
 
 // PlotPlotScatterS8PtrS8PtrV parameter default value hint:
@@ -5212,7 +4977,6 @@ func PlotPlotScatterS8PtrS8PtrV(label_id string, xs *[]int8, ys *[]int8, count i
 	for i, ysV := range ysArg {
 		(*ys)[i] = int8(ysV)
 	}
-
 }
 
 // PlotPlotScatterU16PtrIntV parameter default value hint:
@@ -5235,7 +4999,6 @@ func PlotPlotScatterU16PtrIntV(label_id string, values *[]uint16, count int32, x
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint16(valuesV)
 	}
-
 }
 
 // PlotPlotScatterU16PtrU16PtrV parameter default value hint:
@@ -5265,7 +5028,6 @@ func PlotPlotScatterU16PtrU16PtrV(label_id string, xs *[]uint16, ys *[]uint16, c
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint16(ysV)
 	}
-
 }
 
 // PlotPlotScatterU32PtrIntV parameter default value hint:
@@ -5288,7 +5050,6 @@ func PlotPlotScatterU32PtrIntV(label_id string, values *[]uint32, count int32, x
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint32(valuesV)
 	}
-
 }
 
 // PlotPlotScatterU32PtrU32PtrV parameter default value hint:
@@ -5318,7 +5079,6 @@ func PlotPlotScatterU32PtrU32PtrV(label_id string, xs *[]uint32, ys *[]uint32, c
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint32(ysV)
 	}
-
 }
 
 // PlotPlotScatterU64PtrIntV parameter default value hint:
@@ -5332,7 +5092,6 @@ func PlotPlotScatterU64PtrIntV(label_id string, values []uint64, count int32, xs
 	C.ImPlot_PlotScatter_U64PtrInt(label_idArg, (*C.ulonglong)(&(values[0])), C.int(count), C.double(xscale), C.double(xstart), C.ImPlotScatterFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotScatterU64PtrU64PtrV parameter default value hint:
@@ -5344,7 +5103,6 @@ func PlotPlotScatterU64PtrU64PtrV(label_id string, xs []uint64, ys []uint64, cou
 	C.ImPlot_PlotScatter_U64PtrU64Ptr(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), C.int(count), C.ImPlotScatterFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotScatterU8PtrIntV parameter default value hint:
@@ -5367,7 +5125,6 @@ func PlotPlotScatterU8PtrIntV(label_id string, values *[]byte, count int32, xsca
 	for i, valuesV := range valuesArg {
 		(*values)[i] = byte(valuesV)
 	}
-
 }
 
 // PlotPlotScatterU8PtrU8PtrV parameter default value hint:
@@ -5397,7 +5154,6 @@ func PlotPlotScatterU8PtrU8PtrV(label_id string, xs *[]byte, ys *[]byte, count i
 	for i, ysV := range ysArg {
 		(*ys)[i] = byte(ysV)
 	}
-
 }
 
 // PlotPlotScatterdoublePtrIntV parameter default value hint:
@@ -5420,7 +5176,6 @@ func PlotPlotScatterdoublePtrIntV(label_id string, values *[]float64, count int3
 	for i, valuesV := range valuesArg {
 		(*values)[i] = float64(valuesV)
 	}
-
 }
 
 // PlotPlotScatterdoublePtrdoublePtrV parameter default value hint:
@@ -5450,7 +5205,6 @@ func PlotPlotScatterdoublePtrdoublePtrV(label_id string, xs *[]float64, ys *[]fl
 	for i, ysV := range ysArg {
 		(*ys)[i] = float64(ysV)
 	}
-
 }
 
 // PlotPlotShadedFloatPtrFloatPtrFloatPtrV parameter default value hint:
@@ -5462,7 +5216,6 @@ func PlotPlotShadedFloatPtrFloatPtrFloatPtrV(label_id string, xs []float32, ys1 
 	C.ImPlot_PlotShaded_FloatPtrFloatPtrFloatPtr(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys1[0])), (*C.float)(&(ys2[0])), C.int(count), C.ImPlotShadedFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotShadedFloatPtrFloatPtrIntV parameter default value hint:
@@ -5475,7 +5228,6 @@ func PlotPlotShadedFloatPtrFloatPtrIntV(label_id string, xs []float32, ys []floa
 	C.ImPlot_PlotShaded_FloatPtrFloatPtrInt(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), C.int(count), C.double(yref), C.ImPlotShadedFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotShadedFloatPtrIntV parameter default value hint:
@@ -5490,7 +5242,6 @@ func PlotPlotShadedFloatPtrIntV(label_id string, values []float32, count int32, 
 	C.ImPlot_PlotShaded_FloatPtrInt(label_idArg, (*C.float)(&(values[0])), C.int(count), C.double(yref), C.double(xscale), C.double(xstart), C.ImPlotShadedFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotShadedS16PtrIntV parameter default value hint:
@@ -5514,7 +5265,6 @@ func PlotPlotShadedS16PtrIntV(label_id string, values *[]int, count int32, yref 
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int(valuesV)
 	}
-
 }
 
 // PlotPlotShadedS16PtrS16PtrIntV parameter default value hint:
@@ -5545,7 +5295,6 @@ func PlotPlotShadedS16PtrS16PtrIntV(label_id string, xs *[]int, ys *[]int, count
 	for i, ysV := range ysArg {
 		(*ys)[i] = int(ysV)
 	}
-
 }
 
 // PlotPlotShadedS16PtrS16PtrS16PtrV parameter default value hint:
@@ -5584,7 +5333,6 @@ func PlotPlotShadedS16PtrS16PtrS16PtrV(label_id string, xs *[]int, ys1 *[]int, y
 	for i, ys2V := range ys2Arg {
 		(*ys2)[i] = int(ys2V)
 	}
-
 }
 
 // PlotPlotShadedS32PtrIntV parameter default value hint:
@@ -5608,7 +5356,6 @@ func PlotPlotShadedS32PtrIntV(label_id string, values *[]int32, count int32, yre
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int32(valuesV)
 	}
-
 }
 
 // PlotPlotShadedS32PtrS32PtrIntV parameter default value hint:
@@ -5639,7 +5386,6 @@ func PlotPlotShadedS32PtrS32PtrIntV(label_id string, xs *[]int32, ys *[]int32, c
 	for i, ysV := range ysArg {
 		(*ys)[i] = int32(ysV)
 	}
-
 }
 
 // PlotPlotShadedS32PtrS32PtrS32PtrV parameter default value hint:
@@ -5678,7 +5424,6 @@ func PlotPlotShadedS32PtrS32PtrS32PtrV(label_id string, xs *[]int32, ys1 *[]int3
 	for i, ys2V := range ys2Arg {
 		(*ys2)[i] = int32(ys2V)
 	}
-
 }
 
 // PlotPlotShadedS64PtrIntV parameter default value hint:
@@ -5693,7 +5438,6 @@ func PlotPlotShadedS64PtrIntV(label_id string, values []int64, count int32, yref
 	C.ImPlot_PlotShaded_S64PtrInt(label_idArg, (*C.longlong)(&(values[0])), C.int(count), C.double(yref), C.double(xscale), C.double(xstart), C.ImPlotShadedFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotShadedS64PtrS64PtrIntV parameter default value hint:
@@ -5706,7 +5450,6 @@ func PlotPlotShadedS64PtrS64PtrIntV(label_id string, xs []int64, ys []int64, cou
 	C.ImPlot_PlotShaded_S64PtrS64PtrInt(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), C.int(count), C.double(yref), C.ImPlotShadedFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotShadedS64PtrS64PtrS64PtrV parameter default value hint:
@@ -5718,7 +5461,6 @@ func PlotPlotShadedS64PtrS64PtrS64PtrV(label_id string, xs []int64, ys1 []int64,
 	C.ImPlot_PlotShaded_S64PtrS64PtrS64Ptr(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys1[0])), (*C.longlong)(&(ys2[0])), C.int(count), C.ImPlotShadedFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotShadedS8PtrIntV parameter default value hint:
@@ -5742,7 +5484,6 @@ func PlotPlotShadedS8PtrIntV(label_id string, values *[]int8, count int32, yref 
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int8(valuesV)
 	}
-
 }
 
 // PlotPlotShadedS8PtrS8PtrIntV parameter default value hint:
@@ -5773,7 +5514,6 @@ func PlotPlotShadedS8PtrS8PtrIntV(label_id string, xs *[]int8, ys *[]int8, count
 	for i, ysV := range ysArg {
 		(*ys)[i] = int8(ysV)
 	}
-
 }
 
 // PlotPlotShadedS8PtrS8PtrS8PtrV parameter default value hint:
@@ -5812,7 +5552,6 @@ func PlotPlotShadedS8PtrS8PtrS8PtrV(label_id string, xs *[]int8, ys1 *[]int8, ys
 	for i, ys2V := range ys2Arg {
 		(*ys2)[i] = int8(ys2V)
 	}
-
 }
 
 // PlotPlotShadedU16PtrIntV parameter default value hint:
@@ -5836,7 +5575,6 @@ func PlotPlotShadedU16PtrIntV(label_id string, values *[]uint16, count int32, yr
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint16(valuesV)
 	}
-
 }
 
 // PlotPlotShadedU16PtrU16PtrIntV parameter default value hint:
@@ -5867,7 +5605,6 @@ func PlotPlotShadedU16PtrU16PtrIntV(label_id string, xs *[]uint16, ys *[]uint16,
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint16(ysV)
 	}
-
 }
 
 // PlotPlotShadedU16PtrU16PtrU16PtrV parameter default value hint:
@@ -5906,7 +5643,6 @@ func PlotPlotShadedU16PtrU16PtrU16PtrV(label_id string, xs *[]uint16, ys1 *[]uin
 	for i, ys2V := range ys2Arg {
 		(*ys2)[i] = uint16(ys2V)
 	}
-
 }
 
 // PlotPlotShadedU32PtrIntV parameter default value hint:
@@ -5930,7 +5666,6 @@ func PlotPlotShadedU32PtrIntV(label_id string, values *[]uint32, count int32, yr
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint32(valuesV)
 	}
-
 }
 
 // PlotPlotShadedU32PtrU32PtrIntV parameter default value hint:
@@ -5961,7 +5696,6 @@ func PlotPlotShadedU32PtrU32PtrIntV(label_id string, xs *[]uint32, ys *[]uint32,
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint32(ysV)
 	}
-
 }
 
 // PlotPlotShadedU32PtrU32PtrU32PtrV parameter default value hint:
@@ -6000,7 +5734,6 @@ func PlotPlotShadedU32PtrU32PtrU32PtrV(label_id string, xs *[]uint32, ys1 *[]uin
 	for i, ys2V := range ys2Arg {
 		(*ys2)[i] = uint32(ys2V)
 	}
-
 }
 
 // PlotPlotShadedU64PtrIntV parameter default value hint:
@@ -6015,7 +5748,6 @@ func PlotPlotShadedU64PtrIntV(label_id string, values []uint64, count int32, yre
 	C.ImPlot_PlotShaded_U64PtrInt(label_idArg, (*C.ulonglong)(&(values[0])), C.int(count), C.double(yref), C.double(xscale), C.double(xstart), C.ImPlotShadedFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotShadedU64PtrU64PtrIntV parameter default value hint:
@@ -6028,7 +5760,6 @@ func PlotPlotShadedU64PtrU64PtrIntV(label_id string, xs []uint64, ys []uint64, c
 	C.ImPlot_PlotShaded_U64PtrU64PtrInt(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), C.int(count), C.double(yref), C.ImPlotShadedFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotShadedU64PtrU64PtrU64PtrV parameter default value hint:
@@ -6040,7 +5771,6 @@ func PlotPlotShadedU64PtrU64PtrU64PtrV(label_id string, xs []uint64, ys1 []uint6
 	C.ImPlot_PlotShaded_U64PtrU64PtrU64Ptr(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys1[0])), (*C.ulonglong)(&(ys2[0])), C.int(count), C.ImPlotShadedFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotShadedU8PtrIntV parameter default value hint:
@@ -6064,7 +5794,6 @@ func PlotPlotShadedU8PtrIntV(label_id string, values *[]byte, count int32, yref 
 	for i, valuesV := range valuesArg {
 		(*values)[i] = byte(valuesV)
 	}
-
 }
 
 // PlotPlotShadedU8PtrU8PtrIntV parameter default value hint:
@@ -6095,7 +5824,6 @@ func PlotPlotShadedU8PtrU8PtrIntV(label_id string, xs *[]byte, ys *[]byte, count
 	for i, ysV := range ysArg {
 		(*ys)[i] = byte(ysV)
 	}
-
 }
 
 // PlotPlotShadedU8PtrU8PtrU8PtrV parameter default value hint:
@@ -6134,7 +5862,6 @@ func PlotPlotShadedU8PtrU8PtrU8PtrV(label_id string, xs *[]byte, ys1 *[]byte, ys
 	for i, ys2V := range ys2Arg {
 		(*ys2)[i] = byte(ys2V)
 	}
-
 }
 
 // PlotPlotShadeddoublePtrIntV parameter default value hint:
@@ -6158,7 +5885,6 @@ func PlotPlotShadeddoublePtrIntV(label_id string, values *[]float64, count int32
 	for i, valuesV := range valuesArg {
 		(*values)[i] = float64(valuesV)
 	}
-
 }
 
 // PlotPlotShadeddoublePtrdoublePtrIntV parameter default value hint:
@@ -6189,7 +5915,6 @@ func PlotPlotShadeddoublePtrdoublePtrIntV(label_id string, xs *[]float64, ys *[]
 	for i, ysV := range ysArg {
 		(*ys)[i] = float64(ysV)
 	}
-
 }
 
 // PlotPlotShadeddoublePtrdoublePtrdoublePtrV parameter default value hint:
@@ -6228,7 +5953,6 @@ func PlotPlotShadeddoublePtrdoublePtrdoublePtrV(label_id string, xs *[]float64, 
 	for i, ys2V := range ys2Arg {
 		(*ys2)[i] = float64(ys2V)
 	}
-
 }
 
 // PlotPlotStairsFloatPtrFloatPtrV parameter default value hint:
@@ -6240,7 +5964,6 @@ func PlotPlotStairsFloatPtrFloatPtrV(label_id string, xs []float32, ys []float32
 	C.ImPlot_PlotStairs_FloatPtrFloatPtr(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), C.int(count), C.ImPlotStairsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotStairsFloatPtrIntV parameter default value hint:
@@ -6254,7 +5977,6 @@ func PlotPlotStairsFloatPtrIntV(label_id string, values []float32, count int32, 
 	C.ImPlot_PlotStairs_FloatPtrInt(label_idArg, (*C.float)(&(values[0])), C.int(count), C.double(xscale), C.double(xstart), C.ImPlotStairsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotStairsS16PtrIntV parameter default value hint:
@@ -6277,7 +5999,6 @@ func PlotPlotStairsS16PtrIntV(label_id string, values *[]int, count int32, xscal
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int(valuesV)
 	}
-
 }
 
 // PlotPlotStairsS16PtrS16PtrV parameter default value hint:
@@ -6307,7 +6028,6 @@ func PlotPlotStairsS16PtrS16PtrV(label_id string, xs *[]int, ys *[]int, count in
 	for i, ysV := range ysArg {
 		(*ys)[i] = int(ysV)
 	}
-
 }
 
 // PlotPlotStairsS32PtrIntV parameter default value hint:
@@ -6330,7 +6050,6 @@ func PlotPlotStairsS32PtrIntV(label_id string, values *[]int32, count int32, xsc
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int32(valuesV)
 	}
-
 }
 
 // PlotPlotStairsS32PtrS32PtrV parameter default value hint:
@@ -6360,7 +6079,6 @@ func PlotPlotStairsS32PtrS32PtrV(label_id string, xs *[]int32, ys *[]int32, coun
 	for i, ysV := range ysArg {
 		(*ys)[i] = int32(ysV)
 	}
-
 }
 
 // PlotPlotStairsS64PtrIntV parameter default value hint:
@@ -6374,7 +6092,6 @@ func PlotPlotStairsS64PtrIntV(label_id string, values []int64, count int32, xsca
 	C.ImPlot_PlotStairs_S64PtrInt(label_idArg, (*C.longlong)(&(values[0])), C.int(count), C.double(xscale), C.double(xstart), C.ImPlotStairsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotStairsS64PtrS64PtrV parameter default value hint:
@@ -6386,7 +6103,6 @@ func PlotPlotStairsS64PtrS64PtrV(label_id string, xs []int64, ys []int64, count 
 	C.ImPlot_PlotStairs_S64PtrS64Ptr(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), C.int(count), C.ImPlotStairsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotStairsS8PtrIntV parameter default value hint:
@@ -6409,7 +6125,6 @@ func PlotPlotStairsS8PtrIntV(label_id string, values *[]int8, count int32, xscal
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int8(valuesV)
 	}
-
 }
 
 // PlotPlotStairsS8PtrS8PtrV parameter default value hint:
@@ -6439,7 +6154,6 @@ func PlotPlotStairsS8PtrS8PtrV(label_id string, xs *[]int8, ys *[]int8, count in
 	for i, ysV := range ysArg {
 		(*ys)[i] = int8(ysV)
 	}
-
 }
 
 // PlotPlotStairsU16PtrIntV parameter default value hint:
@@ -6462,7 +6176,6 @@ func PlotPlotStairsU16PtrIntV(label_id string, values *[]uint16, count int32, xs
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint16(valuesV)
 	}
-
 }
 
 // PlotPlotStairsU16PtrU16PtrV parameter default value hint:
@@ -6492,7 +6205,6 @@ func PlotPlotStairsU16PtrU16PtrV(label_id string, xs *[]uint16, ys *[]uint16, co
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint16(ysV)
 	}
-
 }
 
 // PlotPlotStairsU32PtrIntV parameter default value hint:
@@ -6515,7 +6227,6 @@ func PlotPlotStairsU32PtrIntV(label_id string, values *[]uint32, count int32, xs
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint32(valuesV)
 	}
-
 }
 
 // PlotPlotStairsU32PtrU32PtrV parameter default value hint:
@@ -6545,7 +6256,6 @@ func PlotPlotStairsU32PtrU32PtrV(label_id string, xs *[]uint32, ys *[]uint32, co
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint32(ysV)
 	}
-
 }
 
 // PlotPlotStairsU64PtrIntV parameter default value hint:
@@ -6559,7 +6269,6 @@ func PlotPlotStairsU64PtrIntV(label_id string, values []uint64, count int32, xsc
 	C.ImPlot_PlotStairs_U64PtrInt(label_idArg, (*C.ulonglong)(&(values[0])), C.int(count), C.double(xscale), C.double(xstart), C.ImPlotStairsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotStairsU64PtrU64PtrV parameter default value hint:
@@ -6571,7 +6280,6 @@ func PlotPlotStairsU64PtrU64PtrV(label_id string, xs []uint64, ys []uint64, coun
 	C.ImPlot_PlotStairs_U64PtrU64Ptr(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), C.int(count), C.ImPlotStairsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotStairsU8PtrIntV parameter default value hint:
@@ -6594,7 +6302,6 @@ func PlotPlotStairsU8PtrIntV(label_id string, values *[]byte, count int32, xscal
 	for i, valuesV := range valuesArg {
 		(*values)[i] = byte(valuesV)
 	}
-
 }
 
 // PlotPlotStairsU8PtrU8PtrV parameter default value hint:
@@ -6624,7 +6331,6 @@ func PlotPlotStairsU8PtrU8PtrV(label_id string, xs *[]byte, ys *[]byte, count in
 	for i, ysV := range ysArg {
 		(*ys)[i] = byte(ysV)
 	}
-
 }
 
 // PlotPlotStairsdoublePtrIntV parameter default value hint:
@@ -6647,7 +6353,6 @@ func PlotPlotStairsdoublePtrIntV(label_id string, values *[]float64, count int32
 	for i, valuesV := range valuesArg {
 		(*values)[i] = float64(valuesV)
 	}
-
 }
 
 // PlotPlotStairsdoublePtrdoublePtrV parameter default value hint:
@@ -6677,7 +6382,6 @@ func PlotPlotStairsdoublePtrdoublePtrV(label_id string, xs *[]float64, ys *[]flo
 	for i, ysV := range ysArg {
 		(*ys)[i] = float64(ysV)
 	}
-
 }
 
 // PlotPlotStemsFloatPtrFloatPtrV parameter default value hint:
@@ -6690,7 +6394,6 @@ func PlotPlotStemsFloatPtrFloatPtrV(label_id string, xs []float32, ys []float32,
 	C.ImPlot_PlotStems_FloatPtrFloatPtr(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), C.int(count), C.double(ref), C.ImPlotStemsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotStemsFloatPtrIntV parameter default value hint:
@@ -6705,7 +6408,6 @@ func PlotPlotStemsFloatPtrIntV(label_id string, values []float32, count int32, r
 	C.ImPlot_PlotStems_FloatPtrInt(label_idArg, (*C.float)(&(values[0])), C.int(count), C.double(ref), C.double(scale), C.double(start), C.ImPlotStemsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotStemsS16PtrIntV parameter default value hint:
@@ -6729,7 +6431,6 @@ func PlotPlotStemsS16PtrIntV(label_id string, values *[]int, count int32, ref fl
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int(valuesV)
 	}
-
 }
 
 // PlotPlotStemsS16PtrS16PtrV parameter default value hint:
@@ -6760,7 +6461,6 @@ func PlotPlotStemsS16PtrS16PtrV(label_id string, xs *[]int, ys *[]int, count int
 	for i, ysV := range ysArg {
 		(*ys)[i] = int(ysV)
 	}
-
 }
 
 // PlotPlotStemsS32PtrIntV parameter default value hint:
@@ -6784,7 +6484,6 @@ func PlotPlotStemsS32PtrIntV(label_id string, values *[]int32, count int32, ref 
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int32(valuesV)
 	}
-
 }
 
 // PlotPlotStemsS32PtrS32PtrV parameter default value hint:
@@ -6815,7 +6514,6 @@ func PlotPlotStemsS32PtrS32PtrV(label_id string, xs *[]int32, ys *[]int32, count
 	for i, ysV := range ysArg {
 		(*ys)[i] = int32(ysV)
 	}
-
 }
 
 // PlotPlotStemsS64PtrIntV parameter default value hint:
@@ -6830,7 +6528,6 @@ func PlotPlotStemsS64PtrIntV(label_id string, values []int64, count int32, ref f
 	C.ImPlot_PlotStems_S64PtrInt(label_idArg, (*C.longlong)(&(values[0])), C.int(count), C.double(ref), C.double(scale), C.double(start), C.ImPlotStemsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotStemsS64PtrS64PtrV parameter default value hint:
@@ -6843,7 +6540,6 @@ func PlotPlotStemsS64PtrS64PtrV(label_id string, xs []int64, ys []int64, count i
 	C.ImPlot_PlotStems_S64PtrS64Ptr(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), C.int(count), C.double(ref), C.ImPlotStemsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotStemsS8PtrIntV parameter default value hint:
@@ -6867,7 +6563,6 @@ func PlotPlotStemsS8PtrIntV(label_id string, values *[]int8, count int32, ref fl
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int8(valuesV)
 	}
-
 }
 
 // PlotPlotStemsS8PtrS8PtrV parameter default value hint:
@@ -6898,7 +6593,6 @@ func PlotPlotStemsS8PtrS8PtrV(label_id string, xs *[]int8, ys *[]int8, count int
 	for i, ysV := range ysArg {
 		(*ys)[i] = int8(ysV)
 	}
-
 }
 
 // PlotPlotStemsU16PtrIntV parameter default value hint:
@@ -6922,7 +6616,6 @@ func PlotPlotStemsU16PtrIntV(label_id string, values *[]uint16, count int32, ref
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint16(valuesV)
 	}
-
 }
 
 // PlotPlotStemsU16PtrU16PtrV parameter default value hint:
@@ -6953,7 +6646,6 @@ func PlotPlotStemsU16PtrU16PtrV(label_id string, xs *[]uint16, ys *[]uint16, cou
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint16(ysV)
 	}
-
 }
 
 // PlotPlotStemsU32PtrIntV parameter default value hint:
@@ -6977,7 +6669,6 @@ func PlotPlotStemsU32PtrIntV(label_id string, values *[]uint32, count int32, ref
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint32(valuesV)
 	}
-
 }
 
 // PlotPlotStemsU32PtrU32PtrV parameter default value hint:
@@ -7008,7 +6699,6 @@ func PlotPlotStemsU32PtrU32PtrV(label_id string, xs *[]uint32, ys *[]uint32, cou
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint32(ysV)
 	}
-
 }
 
 // PlotPlotStemsU64PtrIntV parameter default value hint:
@@ -7023,7 +6713,6 @@ func PlotPlotStemsU64PtrIntV(label_id string, values []uint64, count int32, ref 
 	C.ImPlot_PlotStems_U64PtrInt(label_idArg, (*C.ulonglong)(&(values[0])), C.int(count), C.double(ref), C.double(scale), C.double(start), C.ImPlotStemsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotStemsU64PtrU64PtrV parameter default value hint:
@@ -7036,7 +6725,6 @@ func PlotPlotStemsU64PtrU64PtrV(label_id string, xs []uint64, ys []uint64, count
 	C.ImPlot_PlotStems_U64PtrU64Ptr(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), C.int(count), C.double(ref), C.ImPlotStemsFlags(flags), C.int(offset), C.int(stride))
 
 	label_idFin()
-
 }
 
 // PlotPlotStemsU8PtrIntV parameter default value hint:
@@ -7060,7 +6748,6 @@ func PlotPlotStemsU8PtrIntV(label_id string, values *[]byte, count int32, ref fl
 	for i, valuesV := range valuesArg {
 		(*values)[i] = byte(valuesV)
 	}
-
 }
 
 // PlotPlotStemsU8PtrU8PtrV parameter default value hint:
@@ -7091,7 +6778,6 @@ func PlotPlotStemsU8PtrU8PtrV(label_id string, xs *[]byte, ys *[]byte, count int
 	for i, ysV := range ysArg {
 		(*ys)[i] = byte(ysV)
 	}
-
 }
 
 // PlotPlotStemsdoublePtrIntV parameter default value hint:
@@ -7115,7 +6801,6 @@ func PlotPlotStemsdoublePtrIntV(label_id string, values *[]float64, count int32,
 	for i, valuesV := range valuesArg {
 		(*values)[i] = float64(valuesV)
 	}
-
 }
 
 // PlotPlotStemsdoublePtrdoublePtrV parameter default value hint:
@@ -7146,7 +6831,6 @@ func PlotPlotStemsdoublePtrdoublePtrV(label_id string, xs *[]float64, ys *[]floa
 	for i, ysV := range ysArg {
 		(*ys)[i] = float64(ysV)
 	}
-
 }
 
 // PlotPlotTextV parameter default value hint:
@@ -7157,7 +6841,6 @@ func PlotPlotTextV(text string, x float64, y float64, pix_offset Vec2, flags Plo
 	C.ImPlot_PlotText(textArg, C.double(x), C.double(y), pix_offset.toC(), C.ImPlotTextFlags(flags))
 
 	textFin()
-
 }
 
 // PlotPlotToPixelsPlotPoIntV parameter default value hint:
@@ -7223,7 +6906,6 @@ func PlotPushColormapStr(name string) {
 	C.ImPlot_PushColormap_Str(nameArg)
 
 	nameFin()
-
 }
 
 // PlotPushPlotClipRectV parameter default value hint:
@@ -7261,7 +6943,6 @@ func PlotRegisterOrGetItemV(label_id string, flags PlotItemFlags, just_created *
 	defer func() {
 		label_idFin()
 		just_createdFin()
-
 	}()
 	return (PlotItem)(unsafe.Pointer(C.ImPlot_RegisterOrGetItem(label_idArg, C.ImPlotItemFlags(flags), just_createdArg)))
 }
@@ -7349,7 +7030,6 @@ func PlotSetNextAxisLinks(axis PlotAxisEnum, link_min *float64, link_max *float6
 
 	link_minFin()
 	link_maxFin()
-
 }
 
 func PlotSetNextAxisToFit(axis PlotAxisEnum) {
@@ -7398,7 +7078,6 @@ func PlotSetupAxesV(x_label string, y_label string, x_flags PlotAxisFlags, y_fla
 
 	x_labelFin()
 	y_labelFin()
-
 }
 
 // PlotSetupAxesLimitsV parameter default value hint:
@@ -7415,7 +7094,6 @@ func PlotSetupAxisV(axis PlotAxisEnum, label string, flags PlotAxisFlags) {
 	C.ImPlot_SetupAxis(C.ImAxis(axis), labelArg, C.ImPlotAxisFlags(flags))
 
 	labelFin()
-
 }
 
 func PlotSetupAxisFormatStr(axis PlotAxisEnum, fmt string) {
@@ -7423,7 +7101,6 @@ func PlotSetupAxisFormatStr(axis PlotAxisEnum, fmt string) {
 	C.ImPlot_SetupAxisFormat_Str(C.ImAxis(axis), fmtArg)
 
 	fmtFin()
-
 }
 
 // PlotSetupAxisLimitsV parameter default value hint:
@@ -7443,7 +7120,6 @@ func PlotSetupAxisLinks(axis PlotAxisEnum, link_min *float64, link_max *float64)
 
 	link_minFin()
 	link_maxFin()
-
 }
 
 func PlotSetupAxisScalePlotScale(axis PlotAxisEnum, scale PlotScale) {
@@ -7458,7 +7134,6 @@ func PlotSetupAxisTicksdoubleV(axis PlotAxisEnum, v_min float64, v_max float64, 
 	C.ImPlot_SetupAxisTicks_double(C.ImAxis(axis), C.double(v_min), C.double(v_max), C.int(n_ticks), labelsArg, C.bool(keep_default))
 
 	labelsFin()
-
 }
 
 // PlotSetupAxisTicksdoublePtrV parameter default value hint:
@@ -7478,7 +7153,6 @@ func PlotSetupAxisTicksdoublePtrV(axis PlotAxisEnum, values *[]float64, n_ticks 
 	}
 
 	labelsFin()
-
 }
 
 func PlotSetupAxisZoomConstraints(axis PlotAxisEnum, z_min float64, z_max float64) {
@@ -7514,7 +7188,6 @@ func PlotShowAltLegendV(title_id string, vertical bool, size Vec2, interactable 
 	C.ImPlot_ShowAltLegend(title_idArg, C.bool(vertical), size.toC(), C.bool(interactable))
 
 	title_idFin()
-
 }
 
 // PlotShowAxisContextMenuV parameter default value hint:
@@ -7528,7 +7201,6 @@ func PlotShowColormapSelector(label string) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.ImPlot_ShowColormapSelector(labelArg) == C.bool(true)
 }
@@ -7540,7 +7212,6 @@ func PlotShowDemoWindowV(p_open *bool) {
 	C.ImPlot_ShowDemoWindow(p_openArg)
 
 	p_openFin()
-
 }
 
 func PlotShowInputMapSelector(label string) bool {
@@ -7548,7 +7219,6 @@ func PlotShowInputMapSelector(label string) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.ImPlot_ShowInputMapSelector(labelArg) == C.bool(true)
 }
@@ -7564,7 +7234,6 @@ func PlotShowMetricsWindowV(p_popen *bool) {
 	C.ImPlot_ShowMetricsWindow(p_popenArg)
 
 	p_popenFin()
-
 }
 
 func PlotShowPlotContextMenu(plot PlotPlot) {
@@ -7582,7 +7251,6 @@ func PlotShowStyleSelector(label string) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.ImPlot_ShowStyleSelector(labelArg) == C.bool(true)
 }
@@ -7598,7 +7266,6 @@ func PlotShowTimePicker(id string, t *PlotTime) bool {
 	defer func() {
 		idFin()
 		tFin()
-
 	}()
 	return C.ImPlot_ShowTimePicker(idArg, tArg) == C.bool(true)
 }
@@ -7646,7 +7313,6 @@ func PlotTagXStr(x float64, col Vec4, fmt string) {
 	C.wrap_ImPlot_TagX_Str(C.double(x), col.toC(), fmtArg)
 
 	fmtFin()
-
 }
 
 // PlotTagYBoolV parameter default value hint:
@@ -7660,7 +7326,6 @@ func PlotTagYStr(y float64, col Vec4, fmt string) {
 	C.wrap_ImPlot_TagY_Str(C.double(y), col.toC(), fmtArg)
 
 	fmtFin()
-
 }
 
 func PlotTransformForwardLog10(v float64, noname1 unsafe.Pointer) float64 {
@@ -7708,7 +7373,6 @@ func PlotAddColormapU32Ptr(name string, cols *[]uint32, size int32) PlotColormap
 		for i, colsV := range colsArg {
 			(*cols)[i] = uint32(colsV)
 		}
-
 	}()
 	return PlotColormap(C.wrap_ImPlot_AddColormap_U32Ptr(nameArg, (*C.ImU32)(&colsArg[0]), C.int(size)))
 }
@@ -7720,7 +7384,6 @@ func PlotAddColormapVec4Ptr(name string, cols *Vec4, size int32) PlotColormap {
 	defer func() {
 		nameFin()
 		colsFin()
-
 	}()
 	return PlotColormap(C.wrap_ImPlot_AddColormap_Vec4Ptr(nameArg, colsArg, C.int(size)))
 }
@@ -7730,7 +7393,6 @@ func PlotAddTextCentered(DrawList DrawList, top_center Vec2, col uint32, text_be
 	C.wrap_ImPlot_AddTextCentered(DrawList.handle(), top_center.toC(), C.ImU32(col), text_beginArg)
 
 	text_beginFin()
-
 }
 
 func PlotAddTextVertical(DrawList DrawList, pos Vec2, col uint32, text_begin string) {
@@ -7738,7 +7400,6 @@ func PlotAddTextVertical(DrawList DrawList, pos Vec2, col uint32, text_begin str
 	C.wrap_ImPlot_AddTextVertical(DrawList.handle(), pos.toC(), C.ImU32(col), text_beginArg)
 
 	text_beginFin()
-
 }
 
 func PlotAnnotationBool(x float64, y float64, col Vec4, pix_offset Vec2, clamp bool) {
@@ -7750,7 +7411,6 @@ func PlotBeginAlignedPlots(group_id string) bool {
 
 	defer func() {
 		group_idFin()
-
 	}()
 	return C.wrap_ImPlot_BeginAlignedPlots(group_idArg) == C.bool(true)
 }
@@ -7764,7 +7424,6 @@ func PlotBeginDragDropSourceItem(label_id string) bool {
 
 	defer func() {
 		label_idFin()
-
 	}()
 	return C.wrap_ImPlot_BeginDragDropSourceItem(label_idArg) == C.bool(true)
 }
@@ -7778,7 +7437,6 @@ func PlotBeginItem(label_id string) bool {
 
 	defer func() {
 		label_idFin()
-
 	}()
 	return C.wrap_ImPlot_BeginItem(label_idArg) == C.bool(true)
 }
@@ -7788,7 +7446,6 @@ func PlotBeginLegendPopup(label_id string) bool {
 
 	defer func() {
 		label_idFin()
-
 	}()
 	return C.wrap_ImPlot_BeginLegendPopup(label_idArg) == C.bool(true)
 }
@@ -7798,7 +7455,6 @@ func PlotBeginPlot(title_id string) bool {
 
 	defer func() {
 		title_idFin()
-
 	}()
 	return C.wrap_ImPlot_BeginPlot(title_idArg) == C.bool(true)
 }
@@ -7808,7 +7464,6 @@ func PlotBeginSubplots(title_id string, rows int32, cols int32, size Vec2) bool 
 
 	defer func() {
 		title_idFin()
-
 	}()
 	return C.wrap_ImPlot_BeginSubplots(title_idArg, C.int(rows), C.int(cols), size.toC()) == C.bool(true)
 }
@@ -7822,7 +7477,6 @@ func PlotColormapButton(label string) bool {
 
 	defer func() {
 		labelFin()
-
 	}()
 	return C.wrap_ImPlot_ColormapButton(labelArg) == C.bool(true)
 }
@@ -7832,7 +7486,6 @@ func PlotColormapScale(label string, scale_min float64, scale_max float64) {
 	C.wrap_ImPlot_ColormapScale(labelArg, C.double(scale_min), C.double(scale_max))
 
 	labelFin()
-
 }
 
 func PlotColormapSlider(label string, t *float32) bool {
@@ -7842,7 +7495,6 @@ func PlotColormapSlider(label string, t *float32) bool {
 	defer func() {
 		labelFin()
 		tFin()
-
 	}()
 	return C.wrap_ImPlot_ColormapSlider(labelArg, tArg) == C.bool(true)
 }
@@ -7856,7 +7508,6 @@ func PlotDragLineX(id int32, x *float64, col Vec4) bool {
 
 	defer func() {
 		xFin()
-
 	}()
 	return C.wrap_ImPlot_DragLineX(C.int(id), xArg, col.toC()) == C.bool(true)
 }
@@ -7866,7 +7517,6 @@ func PlotDragLineY(id int32, y *float64, col Vec4) bool {
 
 	defer func() {
 		yFin()
-
 	}()
 	return C.wrap_ImPlot_DragLineY(C.int(id), yArg, col.toC()) == C.bool(true)
 }
@@ -7878,7 +7528,6 @@ func PlotDragPoint(id int32, x *float64, y *float64, col Vec4) bool {
 	defer func() {
 		xFin()
 		yFin()
-
 	}()
 	return C.wrap_ImPlot_DragPoint(C.int(id), xArg, yArg, col.toC()) == C.bool(true)
 }
@@ -7894,7 +7543,6 @@ func PlotDragRect(id int32, x1 *float64, y1 *float64, x2 *float64, y2 *float64, 
 		y1Fin()
 		x2Fin()
 		y2Fin()
-
 	}()
 	return C.wrap_ImPlot_DragRect(C.int(id), x1Arg, y1Arg, x2Arg, y2Arg, col.toC()) == C.bool(true)
 }
@@ -7968,7 +7616,6 @@ func PlotPlotBarGroupsFloatPtr(label_ids []string, values []float32, item_count 
 	C.wrap_ImPlot_PlotBarGroups_FloatPtr(label_idsArg, (*C.float)(&(values[0])), C.int(item_count), C.int(group_count))
 
 	label_idsFin()
-
 }
 
 func PlotPlotBarGroupsS16Ptr(label_ids []string, values *[]int, item_count int32, group_count int32) {
@@ -7985,7 +7632,6 @@ func PlotPlotBarGroupsS16Ptr(label_ids []string, values *[]int, item_count int32
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int(valuesV)
 	}
-
 }
 
 func PlotPlotBarGroupsS32Ptr(label_ids []string, values *[]int32, item_count int32, group_count int32) {
@@ -8002,7 +7648,6 @@ func PlotPlotBarGroupsS32Ptr(label_ids []string, values *[]int32, item_count int
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int32(valuesV)
 	}
-
 }
 
 func PlotPlotBarGroupsS64Ptr(label_ids []string, values []int64, item_count int32, group_count int32) {
@@ -8010,7 +7655,6 @@ func PlotPlotBarGroupsS64Ptr(label_ids []string, values []int64, item_count int3
 	C.wrap_ImPlot_PlotBarGroups_S64Ptr(label_idsArg, (*C.longlong)(&(values[0])), C.int(item_count), C.int(group_count))
 
 	label_idsFin()
-
 }
 
 func PlotPlotBarGroupsS8Ptr(label_ids []string, values *[]int8, item_count int32, group_count int32) {
@@ -8027,7 +7671,6 @@ func PlotPlotBarGroupsS8Ptr(label_ids []string, values *[]int8, item_count int32
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int8(valuesV)
 	}
-
 }
 
 func PlotPlotBarGroupsU16Ptr(label_ids []string, values *[]uint16, item_count int32, group_count int32) {
@@ -8044,7 +7687,6 @@ func PlotPlotBarGroupsU16Ptr(label_ids []string, values *[]uint16, item_count in
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint16(valuesV)
 	}
-
 }
 
 func PlotPlotBarGroupsU32Ptr(label_ids []string, values *[]uint32, item_count int32, group_count int32) {
@@ -8061,7 +7703,6 @@ func PlotPlotBarGroupsU32Ptr(label_ids []string, values *[]uint32, item_count in
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint32(valuesV)
 	}
-
 }
 
 func PlotPlotBarGroupsU64Ptr(label_ids []string, values []uint64, item_count int32, group_count int32) {
@@ -8069,7 +7710,6 @@ func PlotPlotBarGroupsU64Ptr(label_ids []string, values []uint64, item_count int
 	C.wrap_ImPlot_PlotBarGroups_U64Ptr(label_idsArg, (*C.ulonglong)(&(values[0])), C.int(item_count), C.int(group_count))
 
 	label_idsFin()
-
 }
 
 func PlotPlotBarGroupsU8Ptr(label_ids []string, values *[]byte, item_count int32, group_count int32) {
@@ -8086,7 +7726,6 @@ func PlotPlotBarGroupsU8Ptr(label_ids []string, values *[]byte, item_count int32
 	for i, valuesV := range valuesArg {
 		(*values)[i] = byte(valuesV)
 	}
-
 }
 
 func PlotPlotBarGroupsdoublePtr(label_ids []string, values *[]float64, item_count int32, group_count int32) {
@@ -8103,7 +7742,6 @@ func PlotPlotBarGroupsdoublePtr(label_ids []string, values *[]float64, item_coun
 	for i, valuesV := range valuesArg {
 		(*values)[i] = float64(valuesV)
 	}
-
 }
 
 func PlotPlotBarsFloatPtrFloatPtr(label_id string, xs []float32, ys []float32, count int32, bar_size float64) {
@@ -8111,7 +7749,6 @@ func PlotPlotBarsFloatPtrFloatPtr(label_id string, xs []float32, ys []float32, c
 	C.wrap_ImPlot_PlotBars_FloatPtrFloatPtr(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), C.int(count), C.double(bar_size))
 
 	label_idFin()
-
 }
 
 func PlotPlotBarsFloatPtrInt(label_id string, values []float32, count int32) {
@@ -8119,7 +7756,6 @@ func PlotPlotBarsFloatPtrInt(label_id string, values []float32, count int32) {
 	C.wrap_ImPlot_PlotBars_FloatPtrInt(label_idArg, (*C.float)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotBarsS16PtrInt(label_id string, values *[]int, count int32) {
@@ -8136,7 +7772,6 @@ func PlotPlotBarsS16PtrInt(label_id string, values *[]int, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int(valuesV)
 	}
-
 }
 
 func PlotPlotBarsS16PtrS16Ptr(label_id string, xs *[]int, ys *[]int, count int32, bar_size float64) {
@@ -8162,7 +7797,6 @@ func PlotPlotBarsS16PtrS16Ptr(label_id string, xs *[]int, ys *[]int, count int32
 	for i, ysV := range ysArg {
 		(*ys)[i] = int(ysV)
 	}
-
 }
 
 func PlotPlotBarsS32PtrInt(label_id string, values *[]int32, count int32) {
@@ -8179,7 +7813,6 @@ func PlotPlotBarsS32PtrInt(label_id string, values *[]int32, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int32(valuesV)
 	}
-
 }
 
 func PlotPlotBarsS32PtrS32Ptr(label_id string, xs *[]int32, ys *[]int32, count int32, bar_size float64) {
@@ -8205,7 +7838,6 @@ func PlotPlotBarsS32PtrS32Ptr(label_id string, xs *[]int32, ys *[]int32, count i
 	for i, ysV := range ysArg {
 		(*ys)[i] = int32(ysV)
 	}
-
 }
 
 func PlotPlotBarsS64PtrInt(label_id string, values []int64, count int32) {
@@ -8213,7 +7845,6 @@ func PlotPlotBarsS64PtrInt(label_id string, values []int64, count int32) {
 	C.wrap_ImPlot_PlotBars_S64PtrInt(label_idArg, (*C.longlong)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotBarsS64PtrS64Ptr(label_id string, xs []int64, ys []int64, count int32, bar_size float64) {
@@ -8221,7 +7852,6 @@ func PlotPlotBarsS64PtrS64Ptr(label_id string, xs []int64, ys []int64, count int
 	C.wrap_ImPlot_PlotBars_S64PtrS64Ptr(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), C.int(count), C.double(bar_size))
 
 	label_idFin()
-
 }
 
 func PlotPlotBarsS8PtrInt(label_id string, values *[]int8, count int32) {
@@ -8238,7 +7868,6 @@ func PlotPlotBarsS8PtrInt(label_id string, values *[]int8, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int8(valuesV)
 	}
-
 }
 
 func PlotPlotBarsS8PtrS8Ptr(label_id string, xs *[]int8, ys *[]int8, count int32, bar_size float64) {
@@ -8264,7 +7893,6 @@ func PlotPlotBarsS8PtrS8Ptr(label_id string, xs *[]int8, ys *[]int8, count int32
 	for i, ysV := range ysArg {
 		(*ys)[i] = int8(ysV)
 	}
-
 }
 
 func PlotPlotBarsU16PtrInt(label_id string, values *[]uint16, count int32) {
@@ -8281,7 +7909,6 @@ func PlotPlotBarsU16PtrInt(label_id string, values *[]uint16, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint16(valuesV)
 	}
-
 }
 
 func PlotPlotBarsU16PtrU16Ptr(label_id string, xs *[]uint16, ys *[]uint16, count int32, bar_size float64) {
@@ -8307,7 +7934,6 @@ func PlotPlotBarsU16PtrU16Ptr(label_id string, xs *[]uint16, ys *[]uint16, count
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint16(ysV)
 	}
-
 }
 
 func PlotPlotBarsU32PtrInt(label_id string, values *[]uint32, count int32) {
@@ -8324,7 +7950,6 @@ func PlotPlotBarsU32PtrInt(label_id string, values *[]uint32, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint32(valuesV)
 	}
-
 }
 
 func PlotPlotBarsU32PtrU32Ptr(label_id string, xs *[]uint32, ys *[]uint32, count int32, bar_size float64) {
@@ -8350,7 +7975,6 @@ func PlotPlotBarsU32PtrU32Ptr(label_id string, xs *[]uint32, ys *[]uint32, count
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint32(ysV)
 	}
-
 }
 
 func PlotPlotBarsU64PtrInt(label_id string, values []uint64, count int32) {
@@ -8358,7 +7982,6 @@ func PlotPlotBarsU64PtrInt(label_id string, values []uint64, count int32) {
 	C.wrap_ImPlot_PlotBars_U64PtrInt(label_idArg, (*C.ulonglong)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotBarsU64PtrU64Ptr(label_id string, xs []uint64, ys []uint64, count int32, bar_size float64) {
@@ -8366,7 +7989,6 @@ func PlotPlotBarsU64PtrU64Ptr(label_id string, xs []uint64, ys []uint64, count i
 	C.wrap_ImPlot_PlotBars_U64PtrU64Ptr(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), C.int(count), C.double(bar_size))
 
 	label_idFin()
-
 }
 
 func PlotPlotBarsU8PtrInt(label_id string, values *[]byte, count int32) {
@@ -8383,7 +8005,6 @@ func PlotPlotBarsU8PtrInt(label_id string, values *[]byte, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = byte(valuesV)
 	}
-
 }
 
 func PlotPlotBarsU8PtrU8Ptr(label_id string, xs *[]byte, ys *[]byte, count int32, bar_size float64) {
@@ -8409,7 +8030,6 @@ func PlotPlotBarsU8PtrU8Ptr(label_id string, xs *[]byte, ys *[]byte, count int32
 	for i, ysV := range ysArg {
 		(*ys)[i] = byte(ysV)
 	}
-
 }
 
 func PlotPlotBarsdoublePtrInt(label_id string, values *[]float64, count int32) {
@@ -8426,7 +8046,6 @@ func PlotPlotBarsdoublePtrInt(label_id string, values *[]float64, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = float64(valuesV)
 	}
-
 }
 
 func PlotPlotBarsdoublePtrdoublePtr(label_id string, xs *[]float64, ys *[]float64, count int32, bar_size float64) {
@@ -8452,7 +8071,6 @@ func PlotPlotBarsdoublePtrdoublePtr(label_id string, xs *[]float64, ys *[]float6
 	for i, ysV := range ysArg {
 		(*ys)[i] = float64(ysV)
 	}
-
 }
 
 func PlotPlotDigitalFloatPtr(label_id string, xs []float32, ys []float32, count int32) {
@@ -8460,7 +8078,6 @@ func PlotPlotDigitalFloatPtr(label_id string, xs []float32, ys []float32, count 
 	C.wrap_ImPlot_PlotDigital_FloatPtr(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotDigitalS16Ptr(label_id string, xs *[]int, ys *[]int, count int32) {
@@ -8486,7 +8103,6 @@ func PlotPlotDigitalS16Ptr(label_id string, xs *[]int, ys *[]int, count int32) {
 	for i, ysV := range ysArg {
 		(*ys)[i] = int(ysV)
 	}
-
 }
 
 func PlotPlotDigitalS32Ptr(label_id string, xs *[]int32, ys *[]int32, count int32) {
@@ -8512,7 +8128,6 @@ func PlotPlotDigitalS32Ptr(label_id string, xs *[]int32, ys *[]int32, count int3
 	for i, ysV := range ysArg {
 		(*ys)[i] = int32(ysV)
 	}
-
 }
 
 func PlotPlotDigitalS64Ptr(label_id string, xs []int64, ys []int64, count int32) {
@@ -8520,7 +8135,6 @@ func PlotPlotDigitalS64Ptr(label_id string, xs []int64, ys []int64, count int32)
 	C.wrap_ImPlot_PlotDigital_S64Ptr(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotDigitalS8Ptr(label_id string, xs *[]int8, ys *[]int8, count int32) {
@@ -8546,7 +8160,6 @@ func PlotPlotDigitalS8Ptr(label_id string, xs *[]int8, ys *[]int8, count int32) 
 	for i, ysV := range ysArg {
 		(*ys)[i] = int8(ysV)
 	}
-
 }
 
 func PlotPlotDigitalU16Ptr(label_id string, xs *[]uint16, ys *[]uint16, count int32) {
@@ -8572,7 +8185,6 @@ func PlotPlotDigitalU16Ptr(label_id string, xs *[]uint16, ys *[]uint16, count in
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint16(ysV)
 	}
-
 }
 
 func PlotPlotDigitalU32Ptr(label_id string, xs *[]uint32, ys *[]uint32, count int32) {
@@ -8598,7 +8210,6 @@ func PlotPlotDigitalU32Ptr(label_id string, xs *[]uint32, ys *[]uint32, count in
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint32(ysV)
 	}
-
 }
 
 func PlotPlotDigitalU64Ptr(label_id string, xs []uint64, ys []uint64, count int32) {
@@ -8606,7 +8217,6 @@ func PlotPlotDigitalU64Ptr(label_id string, xs []uint64, ys []uint64, count int3
 	C.wrap_ImPlot_PlotDigital_U64Ptr(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotDigitalU8Ptr(label_id string, xs *[]byte, ys *[]byte, count int32) {
@@ -8632,7 +8242,6 @@ func PlotPlotDigitalU8Ptr(label_id string, xs *[]byte, ys *[]byte, count int32) 
 	for i, ysV := range ysArg {
 		(*ys)[i] = byte(ysV)
 	}
-
 }
 
 func PlotPlotDigitaldoublePtr(label_id string, xs *[]float64, ys *[]float64, count int32) {
@@ -8658,7 +8267,6 @@ func PlotPlotDigitaldoublePtr(label_id string, xs *[]float64, ys *[]float64, cou
 	for i, ysV := range ysArg {
 		(*ys)[i] = float64(ysV)
 	}
-
 }
 
 func PlotPlotDummy(label_id string) {
@@ -8666,7 +8274,6 @@ func PlotPlotDummy(label_id string) {
 	C.wrap_ImPlot_PlotDummy(label_idArg)
 
 	label_idFin()
-
 }
 
 func PlotPlotErrorBarsFloatPtrFloatPtrFloatPtrFloatPtr(label_id string, xs []float32, ys []float32, neg []float32, pos []float32, count int32) {
@@ -8674,7 +8281,6 @@ func PlotPlotErrorBarsFloatPtrFloatPtrFloatPtrFloatPtr(label_id string, xs []flo
 	C.wrap_ImPlot_PlotErrorBars_FloatPtrFloatPtrFloatPtrFloatPtr(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), (*C.float)(&(neg[0])), (*C.float)(&(pos[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotErrorBarsFloatPtrFloatPtrFloatPtrInt(label_id string, xs []float32, ys []float32, err []float32, count int32) {
@@ -8682,7 +8288,6 @@ func PlotPlotErrorBarsFloatPtrFloatPtrFloatPtrInt(label_id string, xs []float32,
 	C.wrap_ImPlot_PlotErrorBars_FloatPtrFloatPtrFloatPtrInt(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), (*C.float)(&(err[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotErrorBarsS16PtrS16PtrS16PtrInt(label_id string, xs *[]int, ys *[]int, err *[]int, count int32) {
@@ -8717,7 +8322,6 @@ func PlotPlotErrorBarsS16PtrS16PtrS16PtrInt(label_id string, xs *[]int, ys *[]in
 	for i, errV := range errArg {
 		(*err)[i] = int(errV)
 	}
-
 }
 
 func PlotPlotErrorBarsS16PtrS16PtrS16PtrS16Ptr(label_id string, xs *[]int, ys *[]int, neg *[]int, pos *[]int, count int32) {
@@ -8761,7 +8365,6 @@ func PlotPlotErrorBarsS16PtrS16PtrS16PtrS16Ptr(label_id string, xs *[]int, ys *[
 	for i, posV := range posArg {
 		(*pos)[i] = int(posV)
 	}
-
 }
 
 func PlotPlotErrorBarsS32PtrS32PtrS32PtrInt(label_id string, xs *[]int32, ys *[]int32, err *[]int32, count int32) {
@@ -8796,7 +8399,6 @@ func PlotPlotErrorBarsS32PtrS32PtrS32PtrInt(label_id string, xs *[]int32, ys *[]
 	for i, errV := range errArg {
 		(*err)[i] = int32(errV)
 	}
-
 }
 
 func PlotPlotErrorBarsS32PtrS32PtrS32PtrS32Ptr(label_id string, xs *[]int32, ys *[]int32, neg *[]int32, pos *[]int32, count int32) {
@@ -8840,7 +8442,6 @@ func PlotPlotErrorBarsS32PtrS32PtrS32PtrS32Ptr(label_id string, xs *[]int32, ys 
 	for i, posV := range posArg {
 		(*pos)[i] = int32(posV)
 	}
-
 }
 
 func PlotPlotErrorBarsS64PtrS64PtrS64PtrInt(label_id string, xs []int64, ys []int64, err []int64, count int32) {
@@ -8848,7 +8449,6 @@ func PlotPlotErrorBarsS64PtrS64PtrS64PtrInt(label_id string, xs []int64, ys []in
 	C.wrap_ImPlot_PlotErrorBars_S64PtrS64PtrS64PtrInt(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), (*C.longlong)(&(err[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotErrorBarsS64PtrS64PtrS64PtrS64Ptr(label_id string, xs []int64, ys []int64, neg []int64, pos []int64, count int32) {
@@ -8856,7 +8456,6 @@ func PlotPlotErrorBarsS64PtrS64PtrS64PtrS64Ptr(label_id string, xs []int64, ys [
 	C.wrap_ImPlot_PlotErrorBars_S64PtrS64PtrS64PtrS64Ptr(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), (*C.longlong)(&(neg[0])), (*C.longlong)(&(pos[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotErrorBarsS8PtrS8PtrS8PtrInt(label_id string, xs *[]int8, ys *[]int8, err *[]int8, count int32) {
@@ -8891,7 +8490,6 @@ func PlotPlotErrorBarsS8PtrS8PtrS8PtrInt(label_id string, xs *[]int8, ys *[]int8
 	for i, errV := range errArg {
 		(*err)[i] = int8(errV)
 	}
-
 }
 
 func PlotPlotErrorBarsS8PtrS8PtrS8PtrS8Ptr(label_id string, xs *[]int8, ys *[]int8, neg *[]int8, pos *[]int8, count int32) {
@@ -8935,7 +8533,6 @@ func PlotPlotErrorBarsS8PtrS8PtrS8PtrS8Ptr(label_id string, xs *[]int8, ys *[]in
 	for i, posV := range posArg {
 		(*pos)[i] = int8(posV)
 	}
-
 }
 
 func PlotPlotErrorBarsU16PtrU16PtrU16PtrInt(label_id string, xs *[]uint16, ys *[]uint16, err *[]uint16, count int32) {
@@ -8970,7 +8567,6 @@ func PlotPlotErrorBarsU16PtrU16PtrU16PtrInt(label_id string, xs *[]uint16, ys *[
 	for i, errV := range errArg {
 		(*err)[i] = uint16(errV)
 	}
-
 }
 
 func PlotPlotErrorBarsU16PtrU16PtrU16PtrU16Ptr(label_id string, xs *[]uint16, ys *[]uint16, neg *[]uint16, pos *[]uint16, count int32) {
@@ -9014,7 +8610,6 @@ func PlotPlotErrorBarsU16PtrU16PtrU16PtrU16Ptr(label_id string, xs *[]uint16, ys
 	for i, posV := range posArg {
 		(*pos)[i] = uint16(posV)
 	}
-
 }
 
 func PlotPlotErrorBarsU32PtrU32PtrU32PtrInt(label_id string, xs *[]uint32, ys *[]uint32, err *[]uint32, count int32) {
@@ -9049,7 +8644,6 @@ func PlotPlotErrorBarsU32PtrU32PtrU32PtrInt(label_id string, xs *[]uint32, ys *[
 	for i, errV := range errArg {
 		(*err)[i] = uint32(errV)
 	}
-
 }
 
 func PlotPlotErrorBarsU32PtrU32PtrU32PtrU32Ptr(label_id string, xs *[]uint32, ys *[]uint32, neg *[]uint32, pos *[]uint32, count int32) {
@@ -9093,7 +8687,6 @@ func PlotPlotErrorBarsU32PtrU32PtrU32PtrU32Ptr(label_id string, xs *[]uint32, ys
 	for i, posV := range posArg {
 		(*pos)[i] = uint32(posV)
 	}
-
 }
 
 func PlotPlotErrorBarsU64PtrU64PtrU64PtrInt(label_id string, xs []uint64, ys []uint64, err []uint64, count int32) {
@@ -9101,7 +8694,6 @@ func PlotPlotErrorBarsU64PtrU64PtrU64PtrInt(label_id string, xs []uint64, ys []u
 	C.wrap_ImPlot_PlotErrorBars_U64PtrU64PtrU64PtrInt(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), (*C.ulonglong)(&(err[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotErrorBarsU64PtrU64PtrU64PtrU64Ptr(label_id string, xs []uint64, ys []uint64, neg []uint64, pos []uint64, count int32) {
@@ -9109,7 +8701,6 @@ func PlotPlotErrorBarsU64PtrU64PtrU64PtrU64Ptr(label_id string, xs []uint64, ys 
 	C.wrap_ImPlot_PlotErrorBars_U64PtrU64PtrU64PtrU64Ptr(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), (*C.ulonglong)(&(neg[0])), (*C.ulonglong)(&(pos[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotErrorBarsU8PtrU8PtrU8PtrInt(label_id string, xs *[]byte, ys *[]byte, err *[]byte, count int32) {
@@ -9144,7 +8735,6 @@ func PlotPlotErrorBarsU8PtrU8PtrU8PtrInt(label_id string, xs *[]byte, ys *[]byte
 	for i, errV := range errArg {
 		(*err)[i] = byte(errV)
 	}
-
 }
 
 func PlotPlotErrorBarsU8PtrU8PtrU8PtrU8Ptr(label_id string, xs *[]byte, ys *[]byte, neg *[]byte, pos *[]byte, count int32) {
@@ -9188,7 +8778,6 @@ func PlotPlotErrorBarsU8PtrU8PtrU8PtrU8Ptr(label_id string, xs *[]byte, ys *[]by
 	for i, posV := range posArg {
 		(*pos)[i] = byte(posV)
 	}
-
 }
 
 func PlotPlotErrorBarsdoublePtrdoublePtrdoublePtrInt(label_id string, xs *[]float64, ys *[]float64, err *[]float64, count int32) {
@@ -9223,7 +8812,6 @@ func PlotPlotErrorBarsdoublePtrdoublePtrdoublePtrInt(label_id string, xs *[]floa
 	for i, errV := range errArg {
 		(*err)[i] = float64(errV)
 	}
-
 }
 
 func PlotPlotErrorBarsdoublePtrdoublePtrdoublePtrdoublePtr(label_id string, xs *[]float64, ys *[]float64, neg *[]float64, pos *[]float64, count int32) {
@@ -9267,7 +8855,6 @@ func PlotPlotErrorBarsdoublePtrdoublePtrdoublePtrdoublePtr(label_id string, xs *
 	for i, posV := range posArg {
 		(*pos)[i] = float64(posV)
 	}
-
 }
 
 func PlotPlotHeatmapFloatPtr(label_id string, values []float32, rows int32, cols int32) {
@@ -9275,7 +8862,6 @@ func PlotPlotHeatmapFloatPtr(label_id string, values []float32, rows int32, cols
 	C.wrap_ImPlot_PlotHeatmap_FloatPtr(label_idArg, (*C.float)(&(values[0])), C.int(rows), C.int(cols))
 
 	label_idFin()
-
 }
 
 func PlotPlotHeatmapS16Ptr(label_id string, values *[]int, rows int32, cols int32) {
@@ -9292,7 +8878,6 @@ func PlotPlotHeatmapS16Ptr(label_id string, values *[]int, rows int32, cols int3
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int(valuesV)
 	}
-
 }
 
 func PlotPlotHeatmapS32Ptr(label_id string, values *[]int32, rows int32, cols int32) {
@@ -9309,7 +8894,6 @@ func PlotPlotHeatmapS32Ptr(label_id string, values *[]int32, rows int32, cols in
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int32(valuesV)
 	}
-
 }
 
 func PlotPlotHeatmapS64Ptr(label_id string, values []int64, rows int32, cols int32) {
@@ -9317,7 +8901,6 @@ func PlotPlotHeatmapS64Ptr(label_id string, values []int64, rows int32, cols int
 	C.wrap_ImPlot_PlotHeatmap_S64Ptr(label_idArg, (*C.longlong)(&(values[0])), C.int(rows), C.int(cols))
 
 	label_idFin()
-
 }
 
 func PlotPlotHeatmapS8Ptr(label_id string, values *[]int8, rows int32, cols int32) {
@@ -9334,7 +8917,6 @@ func PlotPlotHeatmapS8Ptr(label_id string, values *[]int8, rows int32, cols int3
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int8(valuesV)
 	}
-
 }
 
 func PlotPlotHeatmapU16Ptr(label_id string, values *[]uint16, rows int32, cols int32) {
@@ -9351,7 +8933,6 @@ func PlotPlotHeatmapU16Ptr(label_id string, values *[]uint16, rows int32, cols i
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint16(valuesV)
 	}
-
 }
 
 func PlotPlotHeatmapU32Ptr(label_id string, values *[]uint32, rows int32, cols int32) {
@@ -9368,7 +8949,6 @@ func PlotPlotHeatmapU32Ptr(label_id string, values *[]uint32, rows int32, cols i
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint32(valuesV)
 	}
-
 }
 
 func PlotPlotHeatmapU64Ptr(label_id string, values []uint64, rows int32, cols int32) {
@@ -9376,7 +8956,6 @@ func PlotPlotHeatmapU64Ptr(label_id string, values []uint64, rows int32, cols in
 	C.wrap_ImPlot_PlotHeatmap_U64Ptr(label_idArg, (*C.ulonglong)(&(values[0])), C.int(rows), C.int(cols))
 
 	label_idFin()
-
 }
 
 func PlotPlotHeatmapU8Ptr(label_id string, values *[]byte, rows int32, cols int32) {
@@ -9393,7 +8972,6 @@ func PlotPlotHeatmapU8Ptr(label_id string, values *[]byte, rows int32, cols int3
 	for i, valuesV := range valuesArg {
 		(*values)[i] = byte(valuesV)
 	}
-
 }
 
 func PlotPlotHeatmapdoublePtr(label_id string, values *[]float64, rows int32, cols int32) {
@@ -9410,7 +8988,6 @@ func PlotPlotHeatmapdoublePtr(label_id string, values *[]float64, rows int32, co
 	for i, valuesV := range valuesArg {
 		(*values)[i] = float64(valuesV)
 	}
-
 }
 
 func PlotPlotHistogram2DFloatPtr(label_id string, xs []float32, ys []float32, count int32) float64 {
@@ -9418,7 +8995,6 @@ func PlotPlotHistogram2DFloatPtr(label_id string, xs []float32, ys []float32, co
 
 	defer func() {
 		label_idFin()
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram2D_FloatPtr(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), C.int(count)))
 }
@@ -9445,7 +9021,6 @@ func PlotPlotHistogram2DS16Ptr(label_id string, xs *[]int, ys *[]int, count int3
 		for i, ysV := range ysArg {
 			(*ys)[i] = int(ysV)
 		}
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram2D_S16Ptr(label_idArg, (*C.ImS16)(&xsArg[0]), (*C.ImS16)(&ysArg[0]), C.int(count)))
 }
@@ -9472,7 +9047,6 @@ func PlotPlotHistogram2DS32Ptr(label_id string, xs *[]int32, ys *[]int32, count 
 		for i, ysV := range ysArg {
 			(*ys)[i] = int32(ysV)
 		}
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram2D_S32Ptr(label_idArg, (*C.ImS32)(&xsArg[0]), (*C.ImS32)(&ysArg[0]), C.int(count)))
 }
@@ -9482,7 +9056,6 @@ func PlotPlotHistogram2DS64Ptr(label_id string, xs []int64, ys []int64, count in
 
 	defer func() {
 		label_idFin()
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram2D_S64Ptr(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), C.int(count)))
 }
@@ -9509,7 +9082,6 @@ func PlotPlotHistogram2DS8Ptr(label_id string, xs *[]int8, ys *[]int8, count int
 		for i, ysV := range ysArg {
 			(*ys)[i] = int8(ysV)
 		}
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram2D_S8Ptr(label_idArg, (*C.ImS8)(&xsArg[0]), (*C.ImS8)(&ysArg[0]), C.int(count)))
 }
@@ -9536,7 +9108,6 @@ func PlotPlotHistogram2DU16Ptr(label_id string, xs *[]uint16, ys *[]uint16, coun
 		for i, ysV := range ysArg {
 			(*ys)[i] = uint16(ysV)
 		}
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram2D_U16Ptr(label_idArg, (*C.ImU16)(&xsArg[0]), (*C.ImU16)(&ysArg[0]), C.int(count)))
 }
@@ -9563,7 +9134,6 @@ func PlotPlotHistogram2DU32Ptr(label_id string, xs *[]uint32, ys *[]uint32, coun
 		for i, ysV := range ysArg {
 			(*ys)[i] = uint32(ysV)
 		}
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram2D_U32Ptr(label_idArg, (*C.ImU32)(&xsArg[0]), (*C.ImU32)(&ysArg[0]), C.int(count)))
 }
@@ -9573,7 +9143,6 @@ func PlotPlotHistogram2DU64Ptr(label_id string, xs []uint64, ys []uint64, count 
 
 	defer func() {
 		label_idFin()
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram2D_U64Ptr(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), C.int(count)))
 }
@@ -9600,7 +9169,6 @@ func PlotPlotHistogram2DU8Ptr(label_id string, xs *[]byte, ys *[]byte, count int
 		for i, ysV := range ysArg {
 			(*ys)[i] = byte(ysV)
 		}
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram2D_U8Ptr(label_idArg, (*C.ImU8)(&xsArg[0]), (*C.ImU8)(&ysArg[0]), C.int(count)))
 }
@@ -9627,7 +9195,6 @@ func PlotPlotHistogram2DdoublePtr(label_id string, xs *[]float64, ys *[]float64,
 		for i, ysV := range ysArg {
 			(*ys)[i] = float64(ysV)
 		}
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram2D_doublePtr(label_idArg, (*C.double)(&xsArg[0]), (*C.double)(&ysArg[0]), C.int(count)))
 }
@@ -9637,7 +9204,6 @@ func PlotPlotHistogramFloatPtr(label_id string, values []float32, count int32) f
 
 	defer func() {
 		label_idFin()
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram_FloatPtr(label_idArg, (*C.float)(&(values[0])), C.int(count)))
 }
@@ -9655,7 +9221,6 @@ func PlotPlotHistogramS16Ptr(label_id string, values *[]int, count int32) float6
 		for i, valuesV := range valuesArg {
 			(*values)[i] = int(valuesV)
 		}
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram_S16Ptr(label_idArg, (*C.ImS16)(&valuesArg[0]), C.int(count)))
 }
@@ -9673,7 +9238,6 @@ func PlotPlotHistogramS32Ptr(label_id string, values *[]int32, count int32) floa
 		for i, valuesV := range valuesArg {
 			(*values)[i] = int32(valuesV)
 		}
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram_S32Ptr(label_idArg, (*C.ImS32)(&valuesArg[0]), C.int(count)))
 }
@@ -9683,7 +9247,6 @@ func PlotPlotHistogramS64Ptr(label_id string, values []int64, count int32) float
 
 	defer func() {
 		label_idFin()
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram_S64Ptr(label_idArg, (*C.longlong)(&(values[0])), C.int(count)))
 }
@@ -9701,7 +9264,6 @@ func PlotPlotHistogramS8Ptr(label_id string, values *[]int8, count int32) float6
 		for i, valuesV := range valuesArg {
 			(*values)[i] = int8(valuesV)
 		}
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram_S8Ptr(label_idArg, (*C.ImS8)(&valuesArg[0]), C.int(count)))
 }
@@ -9719,7 +9281,6 @@ func PlotPlotHistogramU16Ptr(label_id string, values *[]uint16, count int32) flo
 		for i, valuesV := range valuesArg {
 			(*values)[i] = uint16(valuesV)
 		}
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram_U16Ptr(label_idArg, (*C.ImU16)(&valuesArg[0]), C.int(count)))
 }
@@ -9737,7 +9298,6 @@ func PlotPlotHistogramU32Ptr(label_id string, values *[]uint32, count int32) flo
 		for i, valuesV := range valuesArg {
 			(*values)[i] = uint32(valuesV)
 		}
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram_U32Ptr(label_idArg, (*C.ImU32)(&valuesArg[0]), C.int(count)))
 }
@@ -9747,7 +9307,6 @@ func PlotPlotHistogramU64Ptr(label_id string, values []uint64, count int32) floa
 
 	defer func() {
 		label_idFin()
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram_U64Ptr(label_idArg, (*C.ulonglong)(&(values[0])), C.int(count)))
 }
@@ -9765,7 +9324,6 @@ func PlotPlotHistogramU8Ptr(label_id string, values *[]byte, count int32) float6
 		for i, valuesV := range valuesArg {
 			(*values)[i] = byte(valuesV)
 		}
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram_U8Ptr(label_idArg, (*C.ImU8)(&valuesArg[0]), C.int(count)))
 }
@@ -9783,7 +9341,6 @@ func PlotPlotHistogramdoublePtr(label_id string, values *[]float64, count int32)
 		for i, valuesV := range valuesArg {
 			(*values)[i] = float64(valuesV)
 		}
-
 	}()
 	return float64(C.wrap_ImPlot_PlotHistogram_doublePtr(label_idArg, (*C.double)(&valuesArg[0]), C.int(count)))
 }
@@ -9793,7 +9350,6 @@ func PlotPlotImage(label_id string, user_texture_id TextureID, bounds_min PlotPo
 	C.wrap_ImPlot_PlotImage(label_idArg, C.ImTextureID(user_texture_id), bounds_min.toC(), bounds_max.toC())
 
 	label_idFin()
-
 }
 
 func PlotPlotInfLinesFloatPtr(label_id string, values []float32, count int32) {
@@ -9801,7 +9357,6 @@ func PlotPlotInfLinesFloatPtr(label_id string, values []float32, count int32) {
 	C.wrap_ImPlot_PlotInfLines_FloatPtr(label_idArg, (*C.float)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotInfLinesS16Ptr(label_id string, values *[]int, count int32) {
@@ -9818,7 +9373,6 @@ func PlotPlotInfLinesS16Ptr(label_id string, values *[]int, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int(valuesV)
 	}
-
 }
 
 func PlotPlotInfLinesS32Ptr(label_id string, values *[]int32, count int32) {
@@ -9835,7 +9389,6 @@ func PlotPlotInfLinesS32Ptr(label_id string, values *[]int32, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int32(valuesV)
 	}
-
 }
 
 func PlotPlotInfLinesS64Ptr(label_id string, values []int64, count int32) {
@@ -9843,7 +9396,6 @@ func PlotPlotInfLinesS64Ptr(label_id string, values []int64, count int32) {
 	C.wrap_ImPlot_PlotInfLines_S64Ptr(label_idArg, (*C.longlong)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotInfLinesS8Ptr(label_id string, values *[]int8, count int32) {
@@ -9860,7 +9412,6 @@ func PlotPlotInfLinesS8Ptr(label_id string, values *[]int8, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int8(valuesV)
 	}
-
 }
 
 func PlotPlotInfLinesU16Ptr(label_id string, values *[]uint16, count int32) {
@@ -9877,7 +9428,6 @@ func PlotPlotInfLinesU16Ptr(label_id string, values *[]uint16, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint16(valuesV)
 	}
-
 }
 
 func PlotPlotInfLinesU32Ptr(label_id string, values *[]uint32, count int32) {
@@ -9894,7 +9444,6 @@ func PlotPlotInfLinesU32Ptr(label_id string, values *[]uint32, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint32(valuesV)
 	}
-
 }
 
 func PlotPlotInfLinesU64Ptr(label_id string, values []uint64, count int32) {
@@ -9902,7 +9451,6 @@ func PlotPlotInfLinesU64Ptr(label_id string, values []uint64, count int32) {
 	C.wrap_ImPlot_PlotInfLines_U64Ptr(label_idArg, (*C.ulonglong)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotInfLinesU8Ptr(label_id string, values *[]byte, count int32) {
@@ -9919,7 +9467,6 @@ func PlotPlotInfLinesU8Ptr(label_id string, values *[]byte, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = byte(valuesV)
 	}
-
 }
 
 func PlotPlotInfLinesdoublePtr(label_id string, values *[]float64, count int32) {
@@ -9936,7 +9483,6 @@ func PlotPlotInfLinesdoublePtr(label_id string, values *[]float64, count int32) 
 	for i, valuesV := range valuesArg {
 		(*values)[i] = float64(valuesV)
 	}
-
 }
 
 func PlotPlotLineFloatPtrFloatPtr(label_id string, xs []float32, ys []float32, count int32) {
@@ -9944,7 +9490,6 @@ func PlotPlotLineFloatPtrFloatPtr(label_id string, xs []float32, ys []float32, c
 	C.wrap_ImPlot_PlotLine_FloatPtrFloatPtr(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotLineFloatPtrInt(label_id string, values []float32, count int32) {
@@ -9952,7 +9497,6 @@ func PlotPlotLineFloatPtrInt(label_id string, values []float32, count int32) {
 	C.wrap_ImPlot_PlotLine_FloatPtrInt(label_idArg, (*C.float)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotLineS16PtrInt(label_id string, values *[]int, count int32) {
@@ -9969,7 +9513,6 @@ func PlotPlotLineS16PtrInt(label_id string, values *[]int, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int(valuesV)
 	}
-
 }
 
 func PlotPlotLineS16PtrS16Ptr(label_id string, xs *[]int, ys *[]int, count int32) {
@@ -9995,7 +9538,6 @@ func PlotPlotLineS16PtrS16Ptr(label_id string, xs *[]int, ys *[]int, count int32
 	for i, ysV := range ysArg {
 		(*ys)[i] = int(ysV)
 	}
-
 }
 
 func PlotPlotLineS32PtrInt(label_id string, values *[]int32, count int32) {
@@ -10012,7 +9554,6 @@ func PlotPlotLineS32PtrInt(label_id string, values *[]int32, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int32(valuesV)
 	}
-
 }
 
 func PlotPlotLineS32PtrS32Ptr(label_id string, xs *[]int32, ys *[]int32, count int32) {
@@ -10038,7 +9579,6 @@ func PlotPlotLineS32PtrS32Ptr(label_id string, xs *[]int32, ys *[]int32, count i
 	for i, ysV := range ysArg {
 		(*ys)[i] = int32(ysV)
 	}
-
 }
 
 func PlotPlotLineS64PtrInt(label_id string, values []int64, count int32) {
@@ -10046,7 +9586,6 @@ func PlotPlotLineS64PtrInt(label_id string, values []int64, count int32) {
 	C.wrap_ImPlot_PlotLine_S64PtrInt(label_idArg, (*C.longlong)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotLineS64PtrS64Ptr(label_id string, xs []int64, ys []int64, count int32) {
@@ -10054,7 +9593,6 @@ func PlotPlotLineS64PtrS64Ptr(label_id string, xs []int64, ys []int64, count int
 	C.wrap_ImPlot_PlotLine_S64PtrS64Ptr(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotLineS8PtrInt(label_id string, values *[]int8, count int32) {
@@ -10071,7 +9609,6 @@ func PlotPlotLineS8PtrInt(label_id string, values *[]int8, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int8(valuesV)
 	}
-
 }
 
 func PlotPlotLineS8PtrS8Ptr(label_id string, xs *[]int8, ys *[]int8, count int32) {
@@ -10097,7 +9634,6 @@ func PlotPlotLineS8PtrS8Ptr(label_id string, xs *[]int8, ys *[]int8, count int32
 	for i, ysV := range ysArg {
 		(*ys)[i] = int8(ysV)
 	}
-
 }
 
 func PlotPlotLineU16PtrInt(label_id string, values *[]uint16, count int32) {
@@ -10114,7 +9650,6 @@ func PlotPlotLineU16PtrInt(label_id string, values *[]uint16, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint16(valuesV)
 	}
-
 }
 
 func PlotPlotLineU16PtrU16Ptr(label_id string, xs *[]uint16, ys *[]uint16, count int32) {
@@ -10140,7 +9675,6 @@ func PlotPlotLineU16PtrU16Ptr(label_id string, xs *[]uint16, ys *[]uint16, count
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint16(ysV)
 	}
-
 }
 
 func PlotPlotLineU32PtrInt(label_id string, values *[]uint32, count int32) {
@@ -10157,7 +9691,6 @@ func PlotPlotLineU32PtrInt(label_id string, values *[]uint32, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint32(valuesV)
 	}
-
 }
 
 func PlotPlotLineU32PtrU32Ptr(label_id string, xs *[]uint32, ys *[]uint32, count int32) {
@@ -10183,7 +9716,6 @@ func PlotPlotLineU32PtrU32Ptr(label_id string, xs *[]uint32, ys *[]uint32, count
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint32(ysV)
 	}
-
 }
 
 func PlotPlotLineU64PtrInt(label_id string, values []uint64, count int32) {
@@ -10191,7 +9723,6 @@ func PlotPlotLineU64PtrInt(label_id string, values []uint64, count int32) {
 	C.wrap_ImPlot_PlotLine_U64PtrInt(label_idArg, (*C.ulonglong)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotLineU64PtrU64Ptr(label_id string, xs []uint64, ys []uint64, count int32) {
@@ -10199,7 +9730,6 @@ func PlotPlotLineU64PtrU64Ptr(label_id string, xs []uint64, ys []uint64, count i
 	C.wrap_ImPlot_PlotLine_U64PtrU64Ptr(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotLineU8PtrInt(label_id string, values *[]byte, count int32) {
@@ -10216,7 +9746,6 @@ func PlotPlotLineU8PtrInt(label_id string, values *[]byte, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = byte(valuesV)
 	}
-
 }
 
 func PlotPlotLineU8PtrU8Ptr(label_id string, xs *[]byte, ys *[]byte, count int32) {
@@ -10242,7 +9771,6 @@ func PlotPlotLineU8PtrU8Ptr(label_id string, xs *[]byte, ys *[]byte, count int32
 	for i, ysV := range ysArg {
 		(*ys)[i] = byte(ysV)
 	}
-
 }
 
 func PlotPlotLinedoublePtrInt(label_id string, values *[]float64, count int32) {
@@ -10259,7 +9787,6 @@ func PlotPlotLinedoublePtrInt(label_id string, values *[]float64, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = float64(valuesV)
 	}
-
 }
 
 func PlotPlotLinedoublePtrdoublePtr(label_id string, xs *[]float64, ys *[]float64, count int32) {
@@ -10285,7 +9812,6 @@ func PlotPlotLinedoublePtrdoublePtr(label_id string, xs *[]float64, ys *[]float6
 	for i, ysV := range ysArg {
 		(*ys)[i] = float64(ysV)
 	}
-
 }
 
 func PlotPlotPieChartFloatPtr(label_ids []string, values []float32, count int32, x float64, y float64, radius float64) {
@@ -10293,7 +9819,6 @@ func PlotPlotPieChartFloatPtr(label_ids []string, values []float32, count int32,
 	C.wrap_ImPlot_PlotPieChart_FloatPtr(label_idsArg, (*C.float)(&(values[0])), C.int(count), C.double(x), C.double(y), C.double(radius))
 
 	label_idsFin()
-
 }
 
 func PlotPlotPieChartS16Ptr(label_ids []string, values *[]int, count int32, x float64, y float64, radius float64) {
@@ -10310,7 +9835,6 @@ func PlotPlotPieChartS16Ptr(label_ids []string, values *[]int, count int32, x fl
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int(valuesV)
 	}
-
 }
 
 func PlotPlotPieChartS32Ptr(label_ids []string, values *[]int32, count int32, x float64, y float64, radius float64) {
@@ -10327,7 +9851,6 @@ func PlotPlotPieChartS32Ptr(label_ids []string, values *[]int32, count int32, x 
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int32(valuesV)
 	}
-
 }
 
 func PlotPlotPieChartS64Ptr(label_ids []string, values []int64, count int32, x float64, y float64, radius float64) {
@@ -10335,7 +9858,6 @@ func PlotPlotPieChartS64Ptr(label_ids []string, values []int64, count int32, x f
 	C.wrap_ImPlot_PlotPieChart_S64Ptr(label_idsArg, (*C.longlong)(&(values[0])), C.int(count), C.double(x), C.double(y), C.double(radius))
 
 	label_idsFin()
-
 }
 
 func PlotPlotPieChartS8Ptr(label_ids []string, values *[]int8, count int32, x float64, y float64, radius float64) {
@@ -10352,7 +9874,6 @@ func PlotPlotPieChartS8Ptr(label_ids []string, values *[]int8, count int32, x fl
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int8(valuesV)
 	}
-
 }
 
 func PlotPlotPieChartU16Ptr(label_ids []string, values *[]uint16, count int32, x float64, y float64, radius float64) {
@@ -10369,7 +9890,6 @@ func PlotPlotPieChartU16Ptr(label_ids []string, values *[]uint16, count int32, x
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint16(valuesV)
 	}
-
 }
 
 func PlotPlotPieChartU32Ptr(label_ids []string, values *[]uint32, count int32, x float64, y float64, radius float64) {
@@ -10386,7 +9906,6 @@ func PlotPlotPieChartU32Ptr(label_ids []string, values *[]uint32, count int32, x
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint32(valuesV)
 	}
-
 }
 
 func PlotPlotPieChartU64Ptr(label_ids []string, values []uint64, count int32, x float64, y float64, radius float64) {
@@ -10394,7 +9913,6 @@ func PlotPlotPieChartU64Ptr(label_ids []string, values []uint64, count int32, x 
 	C.wrap_ImPlot_PlotPieChart_U64Ptr(label_idsArg, (*C.ulonglong)(&(values[0])), C.int(count), C.double(x), C.double(y), C.double(radius))
 
 	label_idsFin()
-
 }
 
 func PlotPlotPieChartU8Ptr(label_ids []string, values *[]byte, count int32, x float64, y float64, radius float64) {
@@ -10411,7 +9929,6 @@ func PlotPlotPieChartU8Ptr(label_ids []string, values *[]byte, count int32, x fl
 	for i, valuesV := range valuesArg {
 		(*values)[i] = byte(valuesV)
 	}
-
 }
 
 func PlotPlotPieChartdoublePtr(label_ids []string, values *[]float64, count int32, x float64, y float64, radius float64) {
@@ -10428,7 +9945,6 @@ func PlotPlotPieChartdoublePtr(label_ids []string, values *[]float64, count int3
 	for i, valuesV := range valuesArg {
 		(*values)[i] = float64(valuesV)
 	}
-
 }
 
 func PlotPlotScatterFloatPtrFloatPtr(label_id string, xs []float32, ys []float32, count int32) {
@@ -10436,7 +9952,6 @@ func PlotPlotScatterFloatPtrFloatPtr(label_id string, xs []float32, ys []float32
 	C.wrap_ImPlot_PlotScatter_FloatPtrFloatPtr(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotScatterFloatPtrInt(label_id string, values []float32, count int32) {
@@ -10444,7 +9959,6 @@ func PlotPlotScatterFloatPtrInt(label_id string, values []float32, count int32) 
 	C.wrap_ImPlot_PlotScatter_FloatPtrInt(label_idArg, (*C.float)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotScatterS16PtrInt(label_id string, values *[]int, count int32) {
@@ -10461,7 +9975,6 @@ func PlotPlotScatterS16PtrInt(label_id string, values *[]int, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int(valuesV)
 	}
-
 }
 
 func PlotPlotScatterS16PtrS16Ptr(label_id string, xs *[]int, ys *[]int, count int32) {
@@ -10487,7 +10000,6 @@ func PlotPlotScatterS16PtrS16Ptr(label_id string, xs *[]int, ys *[]int, count in
 	for i, ysV := range ysArg {
 		(*ys)[i] = int(ysV)
 	}
-
 }
 
 func PlotPlotScatterS32PtrInt(label_id string, values *[]int32, count int32) {
@@ -10504,7 +10016,6 @@ func PlotPlotScatterS32PtrInt(label_id string, values *[]int32, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int32(valuesV)
 	}
-
 }
 
 func PlotPlotScatterS32PtrS32Ptr(label_id string, xs *[]int32, ys *[]int32, count int32) {
@@ -10530,7 +10041,6 @@ func PlotPlotScatterS32PtrS32Ptr(label_id string, xs *[]int32, ys *[]int32, coun
 	for i, ysV := range ysArg {
 		(*ys)[i] = int32(ysV)
 	}
-
 }
 
 func PlotPlotScatterS64PtrInt(label_id string, values []int64, count int32) {
@@ -10538,7 +10048,6 @@ func PlotPlotScatterS64PtrInt(label_id string, values []int64, count int32) {
 	C.wrap_ImPlot_PlotScatter_S64PtrInt(label_idArg, (*C.longlong)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotScatterS64PtrS64Ptr(label_id string, xs []int64, ys []int64, count int32) {
@@ -10546,7 +10055,6 @@ func PlotPlotScatterS64PtrS64Ptr(label_id string, xs []int64, ys []int64, count 
 	C.wrap_ImPlot_PlotScatter_S64PtrS64Ptr(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotScatterS8PtrInt(label_id string, values *[]int8, count int32) {
@@ -10563,7 +10071,6 @@ func PlotPlotScatterS8PtrInt(label_id string, values *[]int8, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int8(valuesV)
 	}
-
 }
 
 func PlotPlotScatterS8PtrS8Ptr(label_id string, xs *[]int8, ys *[]int8, count int32) {
@@ -10589,7 +10096,6 @@ func PlotPlotScatterS8PtrS8Ptr(label_id string, xs *[]int8, ys *[]int8, count in
 	for i, ysV := range ysArg {
 		(*ys)[i] = int8(ysV)
 	}
-
 }
 
 func PlotPlotScatterU16PtrInt(label_id string, values *[]uint16, count int32) {
@@ -10606,7 +10112,6 @@ func PlotPlotScatterU16PtrInt(label_id string, values *[]uint16, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint16(valuesV)
 	}
-
 }
 
 func PlotPlotScatterU16PtrU16Ptr(label_id string, xs *[]uint16, ys *[]uint16, count int32) {
@@ -10632,7 +10137,6 @@ func PlotPlotScatterU16PtrU16Ptr(label_id string, xs *[]uint16, ys *[]uint16, co
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint16(ysV)
 	}
-
 }
 
 func PlotPlotScatterU32PtrInt(label_id string, values *[]uint32, count int32) {
@@ -10649,7 +10153,6 @@ func PlotPlotScatterU32PtrInt(label_id string, values *[]uint32, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint32(valuesV)
 	}
-
 }
 
 func PlotPlotScatterU32PtrU32Ptr(label_id string, xs *[]uint32, ys *[]uint32, count int32) {
@@ -10675,7 +10178,6 @@ func PlotPlotScatterU32PtrU32Ptr(label_id string, xs *[]uint32, ys *[]uint32, co
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint32(ysV)
 	}
-
 }
 
 func PlotPlotScatterU64PtrInt(label_id string, values []uint64, count int32) {
@@ -10683,7 +10185,6 @@ func PlotPlotScatterU64PtrInt(label_id string, values []uint64, count int32) {
 	C.wrap_ImPlot_PlotScatter_U64PtrInt(label_idArg, (*C.ulonglong)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotScatterU64PtrU64Ptr(label_id string, xs []uint64, ys []uint64, count int32) {
@@ -10691,7 +10192,6 @@ func PlotPlotScatterU64PtrU64Ptr(label_id string, xs []uint64, ys []uint64, coun
 	C.wrap_ImPlot_PlotScatter_U64PtrU64Ptr(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotScatterU8PtrInt(label_id string, values *[]byte, count int32) {
@@ -10708,7 +10208,6 @@ func PlotPlotScatterU8PtrInt(label_id string, values *[]byte, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = byte(valuesV)
 	}
-
 }
 
 func PlotPlotScatterU8PtrU8Ptr(label_id string, xs *[]byte, ys *[]byte, count int32) {
@@ -10734,7 +10233,6 @@ func PlotPlotScatterU8PtrU8Ptr(label_id string, xs *[]byte, ys *[]byte, count in
 	for i, ysV := range ysArg {
 		(*ys)[i] = byte(ysV)
 	}
-
 }
 
 func PlotPlotScatterdoublePtrInt(label_id string, values *[]float64, count int32) {
@@ -10751,7 +10249,6 @@ func PlotPlotScatterdoublePtrInt(label_id string, values *[]float64, count int32
 	for i, valuesV := range valuesArg {
 		(*values)[i] = float64(valuesV)
 	}
-
 }
 
 func PlotPlotScatterdoublePtrdoublePtr(label_id string, xs *[]float64, ys *[]float64, count int32) {
@@ -10777,7 +10274,6 @@ func PlotPlotScatterdoublePtrdoublePtr(label_id string, xs *[]float64, ys *[]flo
 	for i, ysV := range ysArg {
 		(*ys)[i] = float64(ysV)
 	}
-
 }
 
 func PlotPlotShadedFloatPtrFloatPtrFloatPtr(label_id string, xs []float32, ys1 []float32, ys2 []float32, count int32) {
@@ -10785,7 +10281,6 @@ func PlotPlotShadedFloatPtrFloatPtrFloatPtr(label_id string, xs []float32, ys1 [
 	C.wrap_ImPlot_PlotShaded_FloatPtrFloatPtrFloatPtr(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys1[0])), (*C.float)(&(ys2[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotShadedFloatPtrFloatPtrInt(label_id string, xs []float32, ys []float32, count int32) {
@@ -10793,7 +10288,6 @@ func PlotPlotShadedFloatPtrFloatPtrInt(label_id string, xs []float32, ys []float
 	C.wrap_ImPlot_PlotShaded_FloatPtrFloatPtrInt(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotShadedFloatPtrInt(label_id string, values []float32, count int32) {
@@ -10801,7 +10295,6 @@ func PlotPlotShadedFloatPtrInt(label_id string, values []float32, count int32) {
 	C.wrap_ImPlot_PlotShaded_FloatPtrInt(label_idArg, (*C.float)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotShadedS16PtrInt(label_id string, values *[]int, count int32) {
@@ -10818,7 +10311,6 @@ func PlotPlotShadedS16PtrInt(label_id string, values *[]int, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int(valuesV)
 	}
-
 }
 
 func PlotPlotShadedS16PtrS16PtrInt(label_id string, xs *[]int, ys *[]int, count int32) {
@@ -10844,7 +10336,6 @@ func PlotPlotShadedS16PtrS16PtrInt(label_id string, xs *[]int, ys *[]int, count 
 	for i, ysV := range ysArg {
 		(*ys)[i] = int(ysV)
 	}
-
 }
 
 func PlotPlotShadedS16PtrS16PtrS16Ptr(label_id string, xs *[]int, ys1 *[]int, ys2 *[]int, count int32) {
@@ -10879,7 +10370,6 @@ func PlotPlotShadedS16PtrS16PtrS16Ptr(label_id string, xs *[]int, ys1 *[]int, ys
 	for i, ys2V := range ys2Arg {
 		(*ys2)[i] = int(ys2V)
 	}
-
 }
 
 func PlotPlotShadedS32PtrInt(label_id string, values *[]int32, count int32) {
@@ -10896,7 +10386,6 @@ func PlotPlotShadedS32PtrInt(label_id string, values *[]int32, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int32(valuesV)
 	}
-
 }
 
 func PlotPlotShadedS32PtrS32PtrInt(label_id string, xs *[]int32, ys *[]int32, count int32) {
@@ -10922,7 +10411,6 @@ func PlotPlotShadedS32PtrS32PtrInt(label_id string, xs *[]int32, ys *[]int32, co
 	for i, ysV := range ysArg {
 		(*ys)[i] = int32(ysV)
 	}
-
 }
 
 func PlotPlotShadedS32PtrS32PtrS32Ptr(label_id string, xs *[]int32, ys1 *[]int32, ys2 *[]int32, count int32) {
@@ -10957,7 +10445,6 @@ func PlotPlotShadedS32PtrS32PtrS32Ptr(label_id string, xs *[]int32, ys1 *[]int32
 	for i, ys2V := range ys2Arg {
 		(*ys2)[i] = int32(ys2V)
 	}
-
 }
 
 func PlotPlotShadedS64PtrInt(label_id string, values []int64, count int32) {
@@ -10965,7 +10452,6 @@ func PlotPlotShadedS64PtrInt(label_id string, values []int64, count int32) {
 	C.wrap_ImPlot_PlotShaded_S64PtrInt(label_idArg, (*C.longlong)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotShadedS64PtrS64PtrInt(label_id string, xs []int64, ys []int64, count int32) {
@@ -10973,7 +10459,6 @@ func PlotPlotShadedS64PtrS64PtrInt(label_id string, xs []int64, ys []int64, coun
 	C.wrap_ImPlot_PlotShaded_S64PtrS64PtrInt(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotShadedS64PtrS64PtrS64Ptr(label_id string, xs []int64, ys1 []int64, ys2 []int64, count int32) {
@@ -10981,7 +10466,6 @@ func PlotPlotShadedS64PtrS64PtrS64Ptr(label_id string, xs []int64, ys1 []int64, 
 	C.wrap_ImPlot_PlotShaded_S64PtrS64PtrS64Ptr(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys1[0])), (*C.longlong)(&(ys2[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotShadedS8PtrInt(label_id string, values *[]int8, count int32) {
@@ -10998,7 +10482,6 @@ func PlotPlotShadedS8PtrInt(label_id string, values *[]int8, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int8(valuesV)
 	}
-
 }
 
 func PlotPlotShadedS8PtrS8PtrInt(label_id string, xs *[]int8, ys *[]int8, count int32) {
@@ -11024,7 +10507,6 @@ func PlotPlotShadedS8PtrS8PtrInt(label_id string, xs *[]int8, ys *[]int8, count 
 	for i, ysV := range ysArg {
 		(*ys)[i] = int8(ysV)
 	}
-
 }
 
 func PlotPlotShadedS8PtrS8PtrS8Ptr(label_id string, xs *[]int8, ys1 *[]int8, ys2 *[]int8, count int32) {
@@ -11059,7 +10541,6 @@ func PlotPlotShadedS8PtrS8PtrS8Ptr(label_id string, xs *[]int8, ys1 *[]int8, ys2
 	for i, ys2V := range ys2Arg {
 		(*ys2)[i] = int8(ys2V)
 	}
-
 }
 
 func PlotPlotShadedU16PtrInt(label_id string, values *[]uint16, count int32) {
@@ -11076,7 +10557,6 @@ func PlotPlotShadedU16PtrInt(label_id string, values *[]uint16, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint16(valuesV)
 	}
-
 }
 
 func PlotPlotShadedU16PtrU16PtrInt(label_id string, xs *[]uint16, ys *[]uint16, count int32) {
@@ -11102,7 +10582,6 @@ func PlotPlotShadedU16PtrU16PtrInt(label_id string, xs *[]uint16, ys *[]uint16, 
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint16(ysV)
 	}
-
 }
 
 func PlotPlotShadedU16PtrU16PtrU16Ptr(label_id string, xs *[]uint16, ys1 *[]uint16, ys2 *[]uint16, count int32) {
@@ -11137,7 +10616,6 @@ func PlotPlotShadedU16PtrU16PtrU16Ptr(label_id string, xs *[]uint16, ys1 *[]uint
 	for i, ys2V := range ys2Arg {
 		(*ys2)[i] = uint16(ys2V)
 	}
-
 }
 
 func PlotPlotShadedU32PtrInt(label_id string, values *[]uint32, count int32) {
@@ -11154,7 +10632,6 @@ func PlotPlotShadedU32PtrInt(label_id string, values *[]uint32, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint32(valuesV)
 	}
-
 }
 
 func PlotPlotShadedU32PtrU32PtrInt(label_id string, xs *[]uint32, ys *[]uint32, count int32) {
@@ -11180,7 +10657,6 @@ func PlotPlotShadedU32PtrU32PtrInt(label_id string, xs *[]uint32, ys *[]uint32, 
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint32(ysV)
 	}
-
 }
 
 func PlotPlotShadedU32PtrU32PtrU32Ptr(label_id string, xs *[]uint32, ys1 *[]uint32, ys2 *[]uint32, count int32) {
@@ -11215,7 +10691,6 @@ func PlotPlotShadedU32PtrU32PtrU32Ptr(label_id string, xs *[]uint32, ys1 *[]uint
 	for i, ys2V := range ys2Arg {
 		(*ys2)[i] = uint32(ys2V)
 	}
-
 }
 
 func PlotPlotShadedU64PtrInt(label_id string, values []uint64, count int32) {
@@ -11223,7 +10698,6 @@ func PlotPlotShadedU64PtrInt(label_id string, values []uint64, count int32) {
 	C.wrap_ImPlot_PlotShaded_U64PtrInt(label_idArg, (*C.ulonglong)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotShadedU64PtrU64PtrInt(label_id string, xs []uint64, ys []uint64, count int32) {
@@ -11231,7 +10705,6 @@ func PlotPlotShadedU64PtrU64PtrInt(label_id string, xs []uint64, ys []uint64, co
 	C.wrap_ImPlot_PlotShaded_U64PtrU64PtrInt(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotShadedU64PtrU64PtrU64Ptr(label_id string, xs []uint64, ys1 []uint64, ys2 []uint64, count int32) {
@@ -11239,7 +10712,6 @@ func PlotPlotShadedU64PtrU64PtrU64Ptr(label_id string, xs []uint64, ys1 []uint64
 	C.wrap_ImPlot_PlotShaded_U64PtrU64PtrU64Ptr(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys1[0])), (*C.ulonglong)(&(ys2[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotShadedU8PtrInt(label_id string, values *[]byte, count int32) {
@@ -11256,7 +10728,6 @@ func PlotPlotShadedU8PtrInt(label_id string, values *[]byte, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = byte(valuesV)
 	}
-
 }
 
 func PlotPlotShadedU8PtrU8PtrInt(label_id string, xs *[]byte, ys *[]byte, count int32) {
@@ -11282,7 +10753,6 @@ func PlotPlotShadedU8PtrU8PtrInt(label_id string, xs *[]byte, ys *[]byte, count 
 	for i, ysV := range ysArg {
 		(*ys)[i] = byte(ysV)
 	}
-
 }
 
 func PlotPlotShadedU8PtrU8PtrU8Ptr(label_id string, xs *[]byte, ys1 *[]byte, ys2 *[]byte, count int32) {
@@ -11317,7 +10787,6 @@ func PlotPlotShadedU8PtrU8PtrU8Ptr(label_id string, xs *[]byte, ys1 *[]byte, ys2
 	for i, ys2V := range ys2Arg {
 		(*ys2)[i] = byte(ys2V)
 	}
-
 }
 
 func PlotPlotShadeddoublePtrInt(label_id string, values *[]float64, count int32) {
@@ -11334,7 +10803,6 @@ func PlotPlotShadeddoublePtrInt(label_id string, values *[]float64, count int32)
 	for i, valuesV := range valuesArg {
 		(*values)[i] = float64(valuesV)
 	}
-
 }
 
 func PlotPlotShadeddoublePtrdoublePtrInt(label_id string, xs *[]float64, ys *[]float64, count int32) {
@@ -11360,7 +10828,6 @@ func PlotPlotShadeddoublePtrdoublePtrInt(label_id string, xs *[]float64, ys *[]f
 	for i, ysV := range ysArg {
 		(*ys)[i] = float64(ysV)
 	}
-
 }
 
 func PlotPlotShadeddoublePtrdoublePtrdoublePtr(label_id string, xs *[]float64, ys1 *[]float64, ys2 *[]float64, count int32) {
@@ -11395,7 +10862,6 @@ func PlotPlotShadeddoublePtrdoublePtrdoublePtr(label_id string, xs *[]float64, y
 	for i, ys2V := range ys2Arg {
 		(*ys2)[i] = float64(ys2V)
 	}
-
 }
 
 func PlotPlotStairsFloatPtrFloatPtr(label_id string, xs []float32, ys []float32, count int32) {
@@ -11403,7 +10869,6 @@ func PlotPlotStairsFloatPtrFloatPtr(label_id string, xs []float32, ys []float32,
 	C.wrap_ImPlot_PlotStairs_FloatPtrFloatPtr(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotStairsFloatPtrInt(label_id string, values []float32, count int32) {
@@ -11411,7 +10876,6 @@ func PlotPlotStairsFloatPtrInt(label_id string, values []float32, count int32) {
 	C.wrap_ImPlot_PlotStairs_FloatPtrInt(label_idArg, (*C.float)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotStairsS16PtrInt(label_id string, values *[]int, count int32) {
@@ -11428,7 +10892,6 @@ func PlotPlotStairsS16PtrInt(label_id string, values *[]int, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int(valuesV)
 	}
-
 }
 
 func PlotPlotStairsS16PtrS16Ptr(label_id string, xs *[]int, ys *[]int, count int32) {
@@ -11454,7 +10917,6 @@ func PlotPlotStairsS16PtrS16Ptr(label_id string, xs *[]int, ys *[]int, count int
 	for i, ysV := range ysArg {
 		(*ys)[i] = int(ysV)
 	}
-
 }
 
 func PlotPlotStairsS32PtrInt(label_id string, values *[]int32, count int32) {
@@ -11471,7 +10933,6 @@ func PlotPlotStairsS32PtrInt(label_id string, values *[]int32, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int32(valuesV)
 	}
-
 }
 
 func PlotPlotStairsS32PtrS32Ptr(label_id string, xs *[]int32, ys *[]int32, count int32) {
@@ -11497,7 +10958,6 @@ func PlotPlotStairsS32PtrS32Ptr(label_id string, xs *[]int32, ys *[]int32, count
 	for i, ysV := range ysArg {
 		(*ys)[i] = int32(ysV)
 	}
-
 }
 
 func PlotPlotStairsS64PtrInt(label_id string, values []int64, count int32) {
@@ -11505,7 +10965,6 @@ func PlotPlotStairsS64PtrInt(label_id string, values []int64, count int32) {
 	C.wrap_ImPlot_PlotStairs_S64PtrInt(label_idArg, (*C.longlong)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotStairsS64PtrS64Ptr(label_id string, xs []int64, ys []int64, count int32) {
@@ -11513,7 +10972,6 @@ func PlotPlotStairsS64PtrS64Ptr(label_id string, xs []int64, ys []int64, count i
 	C.wrap_ImPlot_PlotStairs_S64PtrS64Ptr(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotStairsS8PtrInt(label_id string, values *[]int8, count int32) {
@@ -11530,7 +10988,6 @@ func PlotPlotStairsS8PtrInt(label_id string, values *[]int8, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int8(valuesV)
 	}
-
 }
 
 func PlotPlotStairsS8PtrS8Ptr(label_id string, xs *[]int8, ys *[]int8, count int32) {
@@ -11556,7 +11013,6 @@ func PlotPlotStairsS8PtrS8Ptr(label_id string, xs *[]int8, ys *[]int8, count int
 	for i, ysV := range ysArg {
 		(*ys)[i] = int8(ysV)
 	}
-
 }
 
 func PlotPlotStairsU16PtrInt(label_id string, values *[]uint16, count int32) {
@@ -11573,7 +11029,6 @@ func PlotPlotStairsU16PtrInt(label_id string, values *[]uint16, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint16(valuesV)
 	}
-
 }
 
 func PlotPlotStairsU16PtrU16Ptr(label_id string, xs *[]uint16, ys *[]uint16, count int32) {
@@ -11599,7 +11054,6 @@ func PlotPlotStairsU16PtrU16Ptr(label_id string, xs *[]uint16, ys *[]uint16, cou
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint16(ysV)
 	}
-
 }
 
 func PlotPlotStairsU32PtrInt(label_id string, values *[]uint32, count int32) {
@@ -11616,7 +11070,6 @@ func PlotPlotStairsU32PtrInt(label_id string, values *[]uint32, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint32(valuesV)
 	}
-
 }
 
 func PlotPlotStairsU32PtrU32Ptr(label_id string, xs *[]uint32, ys *[]uint32, count int32) {
@@ -11642,7 +11095,6 @@ func PlotPlotStairsU32PtrU32Ptr(label_id string, xs *[]uint32, ys *[]uint32, cou
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint32(ysV)
 	}
-
 }
 
 func PlotPlotStairsU64PtrInt(label_id string, values []uint64, count int32) {
@@ -11650,7 +11102,6 @@ func PlotPlotStairsU64PtrInt(label_id string, values []uint64, count int32) {
 	C.wrap_ImPlot_PlotStairs_U64PtrInt(label_idArg, (*C.ulonglong)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotStairsU64PtrU64Ptr(label_id string, xs []uint64, ys []uint64, count int32) {
@@ -11658,7 +11109,6 @@ func PlotPlotStairsU64PtrU64Ptr(label_id string, xs []uint64, ys []uint64, count
 	C.wrap_ImPlot_PlotStairs_U64PtrU64Ptr(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotStairsU8PtrInt(label_id string, values *[]byte, count int32) {
@@ -11675,7 +11125,6 @@ func PlotPlotStairsU8PtrInt(label_id string, values *[]byte, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = byte(valuesV)
 	}
-
 }
 
 func PlotPlotStairsU8PtrU8Ptr(label_id string, xs *[]byte, ys *[]byte, count int32) {
@@ -11701,7 +11150,6 @@ func PlotPlotStairsU8PtrU8Ptr(label_id string, xs *[]byte, ys *[]byte, count int
 	for i, ysV := range ysArg {
 		(*ys)[i] = byte(ysV)
 	}
-
 }
 
 func PlotPlotStairsdoublePtrInt(label_id string, values *[]float64, count int32) {
@@ -11718,7 +11166,6 @@ func PlotPlotStairsdoublePtrInt(label_id string, values *[]float64, count int32)
 	for i, valuesV := range valuesArg {
 		(*values)[i] = float64(valuesV)
 	}
-
 }
 
 func PlotPlotStairsdoublePtrdoublePtr(label_id string, xs *[]float64, ys *[]float64, count int32) {
@@ -11744,7 +11191,6 @@ func PlotPlotStairsdoublePtrdoublePtr(label_id string, xs *[]float64, ys *[]floa
 	for i, ysV := range ysArg {
 		(*ys)[i] = float64(ysV)
 	}
-
 }
 
 func PlotPlotStemsFloatPtrFloatPtr(label_id string, xs []float32, ys []float32, count int32) {
@@ -11752,7 +11198,6 @@ func PlotPlotStemsFloatPtrFloatPtr(label_id string, xs []float32, ys []float32, 
 	C.wrap_ImPlot_PlotStems_FloatPtrFloatPtr(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotStemsFloatPtrInt(label_id string, values []float32, count int32) {
@@ -11760,7 +11205,6 @@ func PlotPlotStemsFloatPtrInt(label_id string, values []float32, count int32) {
 	C.wrap_ImPlot_PlotStems_FloatPtrInt(label_idArg, (*C.float)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotStemsS16PtrInt(label_id string, values *[]int, count int32) {
@@ -11777,7 +11221,6 @@ func PlotPlotStemsS16PtrInt(label_id string, values *[]int, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int(valuesV)
 	}
-
 }
 
 func PlotPlotStemsS16PtrS16Ptr(label_id string, xs *[]int, ys *[]int, count int32) {
@@ -11803,7 +11246,6 @@ func PlotPlotStemsS16PtrS16Ptr(label_id string, xs *[]int, ys *[]int, count int3
 	for i, ysV := range ysArg {
 		(*ys)[i] = int(ysV)
 	}
-
 }
 
 func PlotPlotStemsS32PtrInt(label_id string, values *[]int32, count int32) {
@@ -11820,7 +11262,6 @@ func PlotPlotStemsS32PtrInt(label_id string, values *[]int32, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int32(valuesV)
 	}
-
 }
 
 func PlotPlotStemsS32PtrS32Ptr(label_id string, xs *[]int32, ys *[]int32, count int32) {
@@ -11846,7 +11287,6 @@ func PlotPlotStemsS32PtrS32Ptr(label_id string, xs *[]int32, ys *[]int32, count 
 	for i, ysV := range ysArg {
 		(*ys)[i] = int32(ysV)
 	}
-
 }
 
 func PlotPlotStemsS64PtrInt(label_id string, values []int64, count int32) {
@@ -11854,7 +11294,6 @@ func PlotPlotStemsS64PtrInt(label_id string, values []int64, count int32) {
 	C.wrap_ImPlot_PlotStems_S64PtrInt(label_idArg, (*C.longlong)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotStemsS64PtrS64Ptr(label_id string, xs []int64, ys []int64, count int32) {
@@ -11862,7 +11301,6 @@ func PlotPlotStemsS64PtrS64Ptr(label_id string, xs []int64, ys []int64, count in
 	C.wrap_ImPlot_PlotStems_S64PtrS64Ptr(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotStemsS8PtrInt(label_id string, values *[]int8, count int32) {
@@ -11879,7 +11317,6 @@ func PlotPlotStemsS8PtrInt(label_id string, values *[]int8, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = int8(valuesV)
 	}
-
 }
 
 func PlotPlotStemsS8PtrS8Ptr(label_id string, xs *[]int8, ys *[]int8, count int32) {
@@ -11905,7 +11342,6 @@ func PlotPlotStemsS8PtrS8Ptr(label_id string, xs *[]int8, ys *[]int8, count int3
 	for i, ysV := range ysArg {
 		(*ys)[i] = int8(ysV)
 	}
-
 }
 
 func PlotPlotStemsU16PtrInt(label_id string, values *[]uint16, count int32) {
@@ -11922,7 +11358,6 @@ func PlotPlotStemsU16PtrInt(label_id string, values *[]uint16, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint16(valuesV)
 	}
-
 }
 
 func PlotPlotStemsU16PtrU16Ptr(label_id string, xs *[]uint16, ys *[]uint16, count int32) {
@@ -11948,7 +11383,6 @@ func PlotPlotStemsU16PtrU16Ptr(label_id string, xs *[]uint16, ys *[]uint16, coun
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint16(ysV)
 	}
-
 }
 
 func PlotPlotStemsU32PtrInt(label_id string, values *[]uint32, count int32) {
@@ -11965,7 +11399,6 @@ func PlotPlotStemsU32PtrInt(label_id string, values *[]uint32, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = uint32(valuesV)
 	}
-
 }
 
 func PlotPlotStemsU32PtrU32Ptr(label_id string, xs *[]uint32, ys *[]uint32, count int32) {
@@ -11991,7 +11424,6 @@ func PlotPlotStemsU32PtrU32Ptr(label_id string, xs *[]uint32, ys *[]uint32, coun
 	for i, ysV := range ysArg {
 		(*ys)[i] = uint32(ysV)
 	}
-
 }
 
 func PlotPlotStemsU64PtrInt(label_id string, values []uint64, count int32) {
@@ -11999,7 +11431,6 @@ func PlotPlotStemsU64PtrInt(label_id string, values []uint64, count int32) {
 	C.wrap_ImPlot_PlotStems_U64PtrInt(label_idArg, (*C.ulonglong)(&(values[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotStemsU64PtrU64Ptr(label_id string, xs []uint64, ys []uint64, count int32) {
@@ -12007,7 +11438,6 @@ func PlotPlotStemsU64PtrU64Ptr(label_id string, xs []uint64, ys []uint64, count 
 	C.wrap_ImPlot_PlotStems_U64PtrU64Ptr(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), C.int(count))
 
 	label_idFin()
-
 }
 
 func PlotPlotStemsU8PtrInt(label_id string, values *[]byte, count int32) {
@@ -12024,7 +11454,6 @@ func PlotPlotStemsU8PtrInt(label_id string, values *[]byte, count int32) {
 	for i, valuesV := range valuesArg {
 		(*values)[i] = byte(valuesV)
 	}
-
 }
 
 func PlotPlotStemsU8PtrU8Ptr(label_id string, xs *[]byte, ys *[]byte, count int32) {
@@ -12050,7 +11479,6 @@ func PlotPlotStemsU8PtrU8Ptr(label_id string, xs *[]byte, ys *[]byte, count int3
 	for i, ysV := range ysArg {
 		(*ys)[i] = byte(ysV)
 	}
-
 }
 
 func PlotPlotStemsdoublePtrInt(label_id string, values *[]float64, count int32) {
@@ -12067,7 +11495,6 @@ func PlotPlotStemsdoublePtrInt(label_id string, values *[]float64, count int32) 
 	for i, valuesV := range valuesArg {
 		(*values)[i] = float64(valuesV)
 	}
-
 }
 
 func PlotPlotStemsdoublePtrdoublePtr(label_id string, xs *[]float64, ys *[]float64, count int32) {
@@ -12093,7 +11520,6 @@ func PlotPlotStemsdoublePtrdoublePtr(label_id string, xs *[]float64, ys *[]float
 	for i, ysV := range ysArg {
 		(*ys)[i] = float64(ysV)
 	}
-
 }
 
 func PlotPlotText(text string, x float64, y float64) {
@@ -12101,7 +11527,6 @@ func PlotPlotText(text string, x float64, y float64) {
 	C.wrap_ImPlot_PlotText(textArg, C.double(x), C.double(y))
 
 	textFin()
-
 }
 
 func PlotPlotToPixelsPlotPoInt(plt PlotPoint) Vec2 {
@@ -12147,7 +11572,6 @@ func PlotRegisterOrGetItem(label_id string, flags PlotItemFlags) PlotItem {
 
 	defer func() {
 		label_idFin()
-
 	}()
 	return (PlotItem)(unsafe.Pointer(C.wrap_ImPlot_RegisterOrGetItem(label_idArg, C.ImPlotItemFlags(flags))))
 }
@@ -12194,7 +11618,6 @@ func PlotSetupAxes(x_label string, y_label string) {
 
 	x_labelFin()
 	y_labelFin()
-
 }
 
 func PlotSetupAxesLimits(x_min float64, x_max float64, y_min float64, y_max float64) {
@@ -12224,7 +11647,6 @@ func PlotSetupAxisTicksdoublePtr(axis PlotAxisEnum, values *[]float64, n_ticks i
 	for i, valuesV := range valuesArg {
 		(*values)[i] = float64(valuesV)
 	}
-
 }
 
 func PlotSetupLegend(location PlotLocation) {
@@ -12240,7 +11662,6 @@ func PlotShowAltLegend(title_id string) {
 	C.wrap_ImPlot_ShowAltLegend(title_idArg)
 
 	title_idFin()
-
 }
 
 func PlotShowAxisContextMenu(axis PlotAxis, equal_axis PlotAxis) {
@@ -12256,7 +11677,6 @@ func PlotShowDatePicker(id string, level *int32, t *PlotTime) bool {
 		idFin()
 		levelFin()
 		tFin()
-
 	}()
 	return C.wrap_ImPlot_ShowDatePicker(idArg, levelArg, tArg) == C.bool(true)
 }
@@ -12482,7 +11902,6 @@ func (self PlotAxis) SetLinkedMin(v *float64) {
 	C.wrap_ImPlotAxis_SetLinkedMin(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self PlotAxis) SetLinkedMax(v *float64) {
@@ -12490,7 +11909,6 @@ func (self PlotAxis) SetLinkedMax(v *float64) {
 	C.wrap_ImPlotAxis_SetLinkedMax(self.handle(), vArg)
 
 	vFin()
-
 }
 
 func (self PlotAxis) SetPickerLevel(v int32) {


### PR DESCRIPTION
gofumpt (https://github.com/mvdan/gofumpt) is a drop-in replacement for gofmt. It provides more stricted rules.
This change will make code in the project look better