### PR TITLE
Whitelist certain internal functions

### DIFF
--- a/cimgui_funcs.go
+++ b/cimgui_funcs.go
@@ -2227,6 +2227,10 @@ func CurrentContext() Context {
 	return (Context)(unsafe.Pointer(C.igGetCurrentContext()))
 }
 
+func CurrentWindow() Window {
+	return (Window)(unsafe.Pointer(C.igGetCurrentWindow()))
+}
+
 func CursorPos() Vec2 {
 	pOut := &Vec2{}
 	pOutArg, pOutFin := wrap[C.ImVec2, *Vec2](pOut)
@@ -3583,6 +3587,10 @@ func SetWindowFocusStr(name string) {
 
 func SetWindowFontScale(scale float32) {
 	C.igSetWindowFontScale(C.float(scale))
+}
+
+func SetWindowHitTestHole(window Window, pos Vec2, size Vec2) {
+	C.igSetWindowHitTestHole(window.handle(), pos.toC(), size.toC())
 }
 
 // SetWindowPosStrV parameter default value hint:

--- a/cmd/codegen/whitelist.json
+++ b/cmd/codegen/whitelist.json
@@ -1,0 +1,6 @@
+{
+  "internal": [
+    "igGetCurrentWindow",
+    "igSetWindowHitTestHole"
+  ]
+}


### PR DESCRIPTION
Some of the functions in `imgui_internal` can be useful, and sometimes the only way to archive a certain feature.

My use-case is a window that _doesn't_ respond to hit test for a section where I'm displaying a texture. This will forward the mouse / keyboard events to the rest of my app instead.