### PR TITLE
Output parameter default hints in the same order as in the function

### DIFF
--- a/cimgui_funcs.go
+++ b/cimgui_funcs.go
@@ -183,19 +183,19 @@ func (self DrawList) AddDrawCmd() {
 }
 
 // AddImageV parameter default value hint:
-// col: 4294967295
-// uv_max: ImVec2(1,1)
 // uv_min: ImVec2(0,0)
+// uv_max: ImVec2(1,1)
+// col: 4294967295
 func (self DrawList) AddImageV(user_texture_id TextureID, p_min Vec2, p_max Vec2, uv_min Vec2, uv_max Vec2, col uint32) {
 	C.ImDrawList_AddImage(self.handle(), C.ImTextureID(user_texture_id), p_min.toC(), p_max.toC(), uv_min.toC(), uv_max.toC(), C.ImU32(col))
 }
 
 // AddImageQuadV parameter default value hint:
-// col: 4294967295
 // uv1: ImVec2(0,0)
 // uv2: ImVec2(1,0)
 // uv3: ImVec2(1,1)
 // uv4: ImVec2(0,1)
+// col: 4294967295
 func (self DrawList) AddImageQuadV(user_texture_id TextureID, p1 Vec2, p2 Vec2, p3 Vec2, p4 Vec2, uv1 Vec2, uv2 Vec2, uv3 Vec2, uv4 Vec2, col uint32) {
 	C.ImDrawList_AddImageQuad(self.handle(), C.ImTextureID(user_texture_id), p1.toC(), p2.toC(), p3.toC(), p4.toC(), uv1.toC(), uv2.toC(), uv3.toC(), uv4.toC(), C.ImU32(col))
 }
@@ -240,16 +240,16 @@ func (self DrawList) AddQuadFilled(p1 Vec2, p2 Vec2, p3 Vec2, p4 Vec2, col uint3
 }
 
 // AddRectV parameter default value hint:
-// flags: 0
 // rounding: 0.0f
+// flags: 0
 // thickness: 1.0f
 func (self DrawList) AddRectV(p_min Vec2, p_max Vec2, col uint32, rounding float32, flags DrawFlags, thickness float32) {
 	C.ImDrawList_AddRect(self.handle(), p_min.toC(), p_max.toC(), C.ImU32(col), C.float(rounding), C.ImDrawFlags(flags), C.float(thickness))
 }
 
 // AddRectFilledV parameter default value hint:
-// flags: 0
 // rounding: 0.0f
+// flags: 0
 func (self DrawList) AddRectFilledV(p_min Vec2, p_max Vec2, col uint32, rounding float32, flags DrawFlags) {
 	C.ImDrawList_AddRectFilled(self.handle(), p_min.toC(), p_max.toC(), C.ImU32(col), C.float(rounding), C.ImDrawFlags(flags))
 }
@@ -259,9 +259,8 @@ func (self DrawList) AddRectFilledMultiColor(p_min Vec2, p_max Vec2, col_upr_lef
 }
 
 // AddTextFontPtrV parameter default value hint:
-// cpu_fine_clip_rect: NULL
-// text_end: NULL
 // wrap_width: 0.0f
+// cpu_fine_clip_rect: NULL
 func (self DrawList) AddTextFontPtrV(font Font, font_size float32, pos Vec2, col uint32, text_begin string, wrap_width float32, cpu_fine_clip_rect *Vec4) {
 	text_beginArg, text_beginFin := wrapString(text_begin)
 	cpu_fine_clip_rectArg, cpu_fine_clip_rectFin := wrap[C.ImVec4, *Vec4](cpu_fine_clip_rect)
@@ -272,7 +271,6 @@ func (self DrawList) AddTextFontPtrV(font Font, font_size float32, pos Vec2, col
 }
 
 // AddTextVec2V parameter default value hint:
-// text_end: NULL
 func (self DrawList) AddTextVec2V(pos Vec2, col uint32, text_begin string) {
 	text_beginArg, text_beginFin := wrapString(text_begin)
 	C.wrap_ImDrawList_AddText_Vec2V(self.handle(), pos.toC(), C.ImU32(col), text_beginArg)
@@ -371,8 +369,8 @@ func (self DrawList) PathLineToMergeDuplicate(pos Vec2) {
 }
 
 // PathRectV parameter default value hint:
-// flags: 0
 // rounding: 0.0f
+// flags: 0
 func (self DrawList) PathRectV(rect_min Vec2, rect_max Vec2, rounding float32, flags DrawFlags) {
 	C.ImDrawList_PathRect(self.handle(), rect_min.toC(), rect_max.toC(), C.float(rounding), C.ImDrawFlags(flags))
 }
@@ -648,7 +646,6 @@ func (self FontGlyphRangesBuilder) AddRanges(ranges *Wchar) {
 }
 
 // AddTextV parameter default value hint:
-// text_end: NULL
 func (self FontGlyphRangesBuilder) AddTextV(text string) {
 	textArg, textFin := wrapString(text)
 	C.wrap_ImFontGlyphRangesBuilder_AddTextV(self.handle(), textArg)
@@ -692,7 +689,6 @@ func (self Font) BuildLookupTable() {
 
 // CalcTextSizeAV parameter default value hint:
 // remaining: NULL
-// text_end: NULL
 func (self Font) CalcTextSizeAV(size float32, max_width float32, wrap_width float32, text_begin string, remaining []string) Vec2 {
 	pOut := new(Vec2)
 	pOutArg, pOutFin := wrap[C.ImVec2, *Vec2](pOut)
@@ -758,8 +754,8 @@ func (self Font) RenderChar(draw_list DrawList, size float32, pos Vec2, col uint
 }
 
 // RenderTextV parameter default value hint:
-// cpu_fine_clip: false
 // wrap_width: 0.0f
+// cpu_fine_clip: false
 func (self Font) RenderTextV(draw_list DrawList, size float32, pos Vec2, col uint32, clip_rect Vec4, text_begin string, wrap_width float32, cpu_fine_clip bool) {
 	text_beginArg, text_beginFin := wrapString(text_begin)
 	C.wrap_ImFont_RenderTextV(self.handle(), draw_list.handle(), C.float(size), pos.toC(), C.ImU32(col), clip_rect.toC(), text_beginArg, C.float(wrap_width), C.bool(cpu_fine_clip))
@@ -964,7 +960,6 @@ func NewInputTextCallbackData() InputTextCallbackData {
 }
 
 // InsertCharsV parameter default value hint:
-// text_end: NULL
 func (self InputTextCallbackData) InsertCharsV(pos int32, text string) {
 	textArg, textFin := wrapString(text)
 	C.wrap_ImGuiInputTextCallbackData_InsertCharsV(self.handle(), C.int(pos), textArg)
@@ -1509,7 +1504,6 @@ func (self TextFilter) IsActive() bool {
 }
 
 // PassFilterV parameter default value hint:
-// text_end: NULL
 func (self TextFilter) PassFilterV(text string) bool {
 	textArg, textFin := wrapString(text)
 
@@ -2046,8 +2040,8 @@ func InternalArrowButtonExV(str_id string, dir Dir, size_arg Vec2, flags ButtonF
 }
 
 // BeginV parameter default value hint:
-// flags: 0
 // p_open: NULL
+// flags: 0
 func BeginV(name string, p_open *bool, flags WindowFlags) bool {
 	nameArg, nameFin := wrapString(name)
 	p_openArg, p_openFin := wrapBool(p_open)
@@ -2075,17 +2069,17 @@ func BeginChildFrameV(id ID, size Vec2, flags WindowFlags) bool {
 }
 
 // BeginChildIDV parameter default value hint:
+// size: ImVec2(0,0)
 // border: false
 // flags: 0
-// size: ImVec2(0,0)
 func BeginChildIDV(id ID, size Vec2, border bool, flags WindowFlags) bool {
 	return C.igBeginChild_ID(C.ImGuiID(id), size.toC(), C.bool(border), C.ImGuiWindowFlags(flags)) == C.bool(true)
 }
 
 // BeginChildStrV parameter default value hint:
+// size: ImVec2(0,0)
 // border: false
 // flags: 0
-// size: ImVec2(0,0)
 func BeginChildStrV(str_id string, size Vec2, border bool, flags WindowFlags) bool {
 	str_idArg, str_idFin := wrapString(str_id)
 
@@ -2219,8 +2213,8 @@ func BeginPopupV(str_id string, flags WindowFlags) bool {
 }
 
 // BeginPopupContextItemV parameter default value hint:
-// popup_flags: 1
 // str_id: NULL
+// popup_flags: 1
 func BeginPopupContextItemV(str_id string, popup_flags PopupFlags) bool {
 	str_idArg, str_idFin := wrapString(str_id)
 
@@ -2231,8 +2225,8 @@ func BeginPopupContextItemV(str_id string, popup_flags PopupFlags) bool {
 }
 
 // BeginPopupContextVoidV parameter default value hint:
-// popup_flags: 1
 // str_id: NULL
+// popup_flags: 1
 func BeginPopupContextVoidV(str_id string, popup_flags PopupFlags) bool {
 	str_idArg, str_idFin := wrapString(str_id)
 
@@ -2243,8 +2237,8 @@ func BeginPopupContextVoidV(str_id string, popup_flags PopupFlags) bool {
 }
 
 // BeginPopupContextWindowV parameter default value hint:
-// popup_flags: 1
 // str_id: NULL
+// popup_flags: 1
 func BeginPopupContextWindowV(str_id string, popup_flags PopupFlags) bool {
 	str_idArg, str_idFin := wrapString(str_id)
 
@@ -2259,8 +2253,8 @@ func InternalBeginPopupEx(id ID, extra_flags WindowFlags) bool {
 }
 
 // BeginPopupModalV parameter default value hint:
-// flags: 0
 // p_open: NULL
+// flags: 0
 func BeginPopupModalV(name string, p_open *bool, flags WindowFlags) bool {
 	nameArg, nameFin := wrapString(name)
 	p_openArg, p_openFin := wrapBool(p_open)
@@ -2288,8 +2282,8 @@ func InternalBeginTabBarEx(tab_bar TabBar, bb Rect, flags TabBarFlags, dock_node
 }
 
 // BeginTabItemV parameter default value hint:
-// flags: 0
 // p_open: NULL
+// flags: 0
 func BeginTabItemV(label string, p_open *bool, flags TabItemFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	p_openArg, p_openFin := wrapBool(p_open)
@@ -2303,8 +2297,8 @@ func BeginTabItemV(label string, p_open *bool, flags TabItemFlags) bool {
 
 // BeginTableV parameter default value hint:
 // flags: 0
-// inner_width: 0.0f
 // outer_size: ImVec2(0.0f,0.0f)
+// inner_width: 0.0f
 func BeginTableV(str_id string, column int32, flags TableFlags, outer_size Vec2, inner_width float32) bool {
 	str_idArg, str_idFin := wrapString(str_id)
 
@@ -2316,8 +2310,8 @@ func BeginTableV(str_id string, column int32, flags TableFlags, outer_size Vec2,
 
 // InternalBeginTableExV parameter default value hint:
 // flags: 0
-// inner_width: 0.0f
 // outer_size: ImVec2(0,0)
+// inner_width: 0.0f
 func InternalBeginTableExV(name string, id ID, columns_count int32, flags TableFlags, outer_size Vec2, inner_width float32) bool {
 	nameArg, nameFin := wrapString(name)
 
@@ -2396,8 +2390,8 @@ func InternalButtonBehaviorV(bb Rect, id ID, out_hovered *bool, out_held *bool, 
 }
 
 // InternalButtonExV parameter default value hint:
-// flags: 0
 // size_arg: ImVec2(0,0)
+// flags: 0
 func InternalButtonExV(label string, size_arg Vec2, flags ButtonFlags) bool {
 	labelArg, labelFin := wrapString(label)
 
@@ -2428,7 +2422,6 @@ func InternalCalcRoundingFlagsForRectInRect(r_in Rect, r_outer Rect, threshold f
 
 // CalcTextSizeV parameter default value hint:
 // hide_text_after_double_hash: false
-// text_end: NULL
 // wrap_width: -1.0f
 func CalcTextSizeV(text string, hide_text_after_double_hash bool, wrap_width float32) Vec2 {
 	pOut := new(Vec2)
@@ -2712,9 +2705,9 @@ func InternalColorTooltip(text string, col []float32, flags ColorEditFlags) {
 }
 
 // ColumnsV parameter default value hint:
-// border: true
 // count: 1
 // id: NULL
+// border: true
 func ColumnsV(count int32, id string, border bool) {
 	idArg, idFin := wrapString(id)
 	C.igColumns(C.int(count), idArg, C.bool(border))
@@ -2945,8 +2938,8 @@ func DestroyPlatformWindows() {
 }
 
 // InternalDockBuilderAddNodeV parameter default value hint:
-// flags: 0
 // node_id: 0
+// flags: 0
 func InternalDockBuilderAddNodeV(node_id ID, flags DockNodeFlags) ID {
 	return ID(C.igDockBuilderAddNode(C.ImGuiID(node_id), C.ImGuiDockNodeFlags(flags)))
 }
@@ -3097,16 +3090,16 @@ func InternalDockNodeWindowMenuHandlerDefault(ctx Context, node DockNode, tab_ba
 }
 
 // DockSpaceV parameter default value hint:
-// flags: 0
 // size: ImVec2(0,0)
+// flags: 0
 // window_class: NULL
 func DockSpaceV(id ID, size Vec2, flags DockNodeFlags, window_class WindowClass) ID {
 	return ID(C.igDockSpace(C.ImGuiID(id), size.toC(), C.ImGuiDockNodeFlags(flags), window_class.handle()))
 }
 
 // DockSpaceOverViewportV parameter default value hint:
-// flags: 0
 // viewport: NULL
+// flags: 0
 // window_class: NULL
 func DockSpaceOverViewportV(viewport Viewport, flags DockNodeFlags, window_class WindowClass) ID {
 	return ID(C.igDockSpaceOverViewport(viewport.handle(), C.ImGuiDockNodeFlags(flags), window_class.handle()))
@@ -3122,11 +3115,11 @@ func InternalDragBehavior(id ID, data_type DataType, p_v unsafe.Pointer, v_speed
 }
 
 // DragFloatV parameter default value hint:
-// flags: 0
-// format: "%.3f"
-// v_max: 0.0f
-// v_min: 0.0f
 // v_speed: 1.0f
+// v_min: 0.0f
+// v_max: 0.0f
+// format: "%.3f"
+// flags: 0
 func DragFloatV(label string, v *float32, v_speed float32, v_min float32, v_max float32, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	vArg, vFin := wrapNumberPtr[C.float, float32](v)
@@ -3141,11 +3134,11 @@ func DragFloatV(label string, v *float32, v_speed float32, v_min float32, v_max 
 }
 
 // DragFloat2V parameter default value hint:
-// flags: 0
-// format: "%.3f"
-// v_max: 0.0f
-// v_min: 0.0f
 // v_speed: 1.0f
+// v_min: 0.0f
+// v_max: 0.0f
+// format: "%.3f"
+// flags: 0
 func DragFloat2V(label string, v *[2]float32, v_speed float32, v_min float32, v_max float32, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 
@@ -3168,11 +3161,11 @@ func DragFloat2V(label string, v *[2]float32, v_speed float32, v_min float32, v_
 }
 
 // DragFloat3V parameter default value hint:
-// flags: 0
-// format: "%.3f"
-// v_max: 0.0f
-// v_min: 0.0f
 // v_speed: 1.0f
+// v_min: 0.0f
+// v_max: 0.0f
+// format: "%.3f"
+// flags: 0
 func DragFloat3V(label string, v *[3]float32, v_speed float32, v_min float32, v_max float32, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 
@@ -3195,11 +3188,11 @@ func DragFloat3V(label string, v *[3]float32, v_speed float32, v_min float32, v_
 }
 
 // DragFloat4V parameter default value hint:
-// flags: 0
-// format: "%.3f"
-// v_max: 0.0f
-// v_min: 0.0f
 // v_speed: 1.0f
+// v_min: 0.0f
+// v_max: 0.0f
+// format: "%.3f"
+// flags: 0
 func DragFloat4V(label string, v *[4]float32, v_speed float32, v_min float32, v_max float32, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 
@@ -3222,12 +3215,12 @@ func DragFloat4V(label string, v *[4]float32, v_speed float32, v_min float32, v_
 }
 
 // DragFloatRange2V parameter default value hint:
-// flags: 0
+// v_speed: 1.0f
+// v_min: 0.0f
+// v_max: 0.0f
 // format: "%.3f"
 // format_max: NULL
-// v_max: 0.0f
-// v_min: 0.0f
-// v_speed: 1.0f
+// flags: 0
 func DragFloatRange2V(label string, v_current_min *float32, v_current_max *float32, v_speed float32, v_min float32, v_max float32, format string, format_max string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	v_current_minArg, v_current_minFin := wrapNumberPtr[C.float, float32](v_current_min)
@@ -3246,11 +3239,11 @@ func DragFloatRange2V(label string, v_current_min *float32, v_current_max *float
 }
 
 // DragIntV parameter default value hint:
-// flags: 0
-// format: "%d"
-// v_max: 0
-// v_min: 0
 // v_speed: 1.0f
+// v_min: 0
+// v_max: 0
+// format: "%d"
+// flags: 0
 func DragIntV(label string, v *int32, v_speed float32, v_min int32, v_max int32, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	vArg, vFin := wrapNumberPtr[C.int, int32](v)
@@ -3265,11 +3258,11 @@ func DragIntV(label string, v *int32, v_speed float32, v_min int32, v_max int32,
 }
 
 // DragInt2V parameter default value hint:
-// flags: 0
-// format: "%d"
-// v_max: 0
-// v_min: 0
 // v_speed: 1.0f
+// v_min: 0
+// v_max: 0
+// format: "%d"
+// flags: 0
 func DragInt2V(label string, v *[2]int32, v_speed float32, v_min int32, v_max int32, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 
@@ -3292,11 +3285,11 @@ func DragInt2V(label string, v *[2]int32, v_speed float32, v_min int32, v_max in
 }
 
 // DragInt3V parameter default value hint:
-// flags: 0
-// format: "%d"
-// v_max: 0
-// v_min: 0
 // v_speed: 1.0f
+// v_min: 0
+// v_max: 0
+// format: "%d"
+// flags: 0
 func DragInt3V(label string, v *[3]int32, v_speed float32, v_min int32, v_max int32, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 
@@ -3319,11 +3312,11 @@ func DragInt3V(label string, v *[3]int32, v_speed float32, v_min int32, v_max in
 }
 
 // DragInt4V parameter default value hint:
-// flags: 0
-// format: "%d"
-// v_max: 0
-// v_min: 0
 // v_speed: 1.0f
+// v_min: 0
+// v_max: 0
+// format: "%d"
+// flags: 0
 func DragInt4V(label string, v *[4]int32, v_speed float32, v_min int32, v_max int32, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 
@@ -3346,12 +3339,12 @@ func DragInt4V(label string, v *[4]int32, v_speed float32, v_min int32, v_max in
 }
 
 // DragIntRange2V parameter default value hint:
-// flags: 0
+// v_speed: 1.0f
+// v_min: 0
+// v_max: 0
 // format: "%d"
 // format_max: NULL
-// v_max: 0
-// v_min: 0
-// v_speed: 1.0f
+// flags: 0
 func DragIntRange2V(label string, v_current_min *int32, v_current_max *int32, v_speed float32, v_min int32, v_max int32, format string, format_max string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	v_current_minArg, v_current_minFin := wrapNumberPtr[C.int, int32](v_current_min)
@@ -3370,11 +3363,11 @@ func DragIntRange2V(label string, v_current_min *int32, v_current_max *int32, v_
 }
 
 // DragScalarV parameter default value hint:
-// flags: 0
-// format: NULL
-// p_max: NULL
-// p_min: NULL
 // v_speed: 1.0f
+// p_min: NULL
+// p_max: NULL
+// format: NULL
+// flags: 0
 func DragScalarV(label string, data_type DataType, p_data unsafe.Pointer, v_speed float32, p_min unsafe.Pointer, p_max unsafe.Pointer, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	formatArg, formatFin := wrapString(format)
@@ -3387,11 +3380,11 @@ func DragScalarV(label string, data_type DataType, p_data unsafe.Pointer, v_spee
 }
 
 // DragScalarNV parameter default value hint:
-// flags: 0
-// format: NULL
-// p_max: NULL
-// p_min: NULL
 // v_speed: 1.0f
+// p_min: NULL
+// p_max: NULL
+// format: NULL
+// flags: 0
 func DragScalarNV(label string, data_type DataType, p_data unsafe.Pointer, components int32, v_speed float32, p_min unsafe.Pointer, p_max unsafe.Pointer, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	formatArg, formatFin := wrapString(format)
@@ -3515,7 +3508,6 @@ func InternalFindOrCreateColumns(window Window, id ID) OldColumns {
 }
 
 // InternalFindRenderedTextEndV parameter default value hint:
-// text_end: NULL
 func InternalFindRenderedTextEndV(text string) string {
 	textArg, textFin := wrapString(text)
 
@@ -4801,19 +4793,19 @@ func InternalImUpperPowerOfTwo(v int32) int {
 }
 
 // ImageV parameter default value hint:
-// border_col: ImVec4(0,0,0,0)
-// tint_col: ImVec4(1,1,1,1)
 // uv0: ImVec2(0,0)
 // uv1: ImVec2(1,1)
+// tint_col: ImVec4(1,1,1,1)
+// border_col: ImVec4(0,0,0,0)
 func ImageV(user_texture_id TextureID, size Vec2, uv0 Vec2, uv1 Vec2, tint_col Vec4, border_col Vec4) {
 	C.igImage(C.ImTextureID(user_texture_id), size.toC(), uv0.toC(), uv1.toC(), tint_col.toC(), border_col.toC())
 }
 
 // ImageButtonV parameter default value hint:
-// bg_col: ImVec4(0,0,0,0)
-// tint_col: ImVec4(1,1,1,1)
 // uv0: ImVec2(0,0)
 // uv1: ImVec2(1,1)
+// bg_col: ImVec4(0,0,0,0)
+// tint_col: ImVec4(1,1,1,1)
 func ImageButtonV(str_id string, user_texture_id TextureID, size Vec2, uv0 Vec2, uv1 Vec2, bg_col Vec4, tint_col Vec4) bool {
 	str_idArg, str_idFin := wrapString(str_id)
 
@@ -4840,10 +4832,10 @@ func InternalInitialize() {
 }
 
 // InputDoubleV parameter default value hint:
-// flags: 0
-// format: "%.6f"
 // step: 0.0
 // step_fast: 0.0
+// format: "%.6f"
+// flags: 0
 func InputDoubleV(label string, v *float64, step float64, step_fast float64, format string, flags InputTextFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	vArg, vFin := wrapNumberPtr[C.double, float64](v)
@@ -4858,10 +4850,10 @@ func InputDoubleV(label string, v *float64, step float64, step_fast float64, for
 }
 
 // InputFloatV parameter default value hint:
-// flags: 0
-// format: "%.3f"
 // step: 0.0f
 // step_fast: 0.0f
+// format: "%.3f"
+// flags: 0
 func InputFloatV(label string, v *float32, step float32, step_fast float32, format string, flags InputTextFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	vArg, vFin := wrapNumberPtr[C.float, float32](v)
@@ -4876,8 +4868,8 @@ func InputFloatV(label string, v *float32, step float32, step_fast float32, form
 }
 
 // InputFloat2V parameter default value hint:
-// flags: 0
 // format: "%.3f"
+// flags: 0
 func InputFloat2V(label string, v *[2]float32, format string, flags InputTextFlags) bool {
 	labelArg, labelFin := wrapString(label)
 
@@ -4900,8 +4892,8 @@ func InputFloat2V(label string, v *[2]float32, format string, flags InputTextFla
 }
 
 // InputFloat3V parameter default value hint:
-// flags: 0
 // format: "%.3f"
+// flags: 0
 func InputFloat3V(label string, v *[3]float32, format string, flags InputTextFlags) bool {
 	labelArg, labelFin := wrapString(label)
 
@@ -4924,8 +4916,8 @@ func InputFloat3V(label string, v *[3]float32, format string, flags InputTextFla
 }
 
 // InputFloat4V parameter default value hint:
-// flags: 0
 // format: "%.3f"
+// flags: 0
 func InputFloat4V(label string, v *[4]float32, format string, flags InputTextFlags) bool {
 	labelArg, labelFin := wrapString(label)
 
@@ -4948,9 +4940,9 @@ func InputFloat4V(label string, v *[4]float32, format string, flags InputTextFla
 }
 
 // InputIntV parameter default value hint:
-// flags: 0
 // step: 1
 // step_fast: 100
+// flags: 0
 func InputIntV(label string, v *int32, step int32, step_fast int32, flags InputTextFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	vArg, vFin := wrapNumberPtr[C.int, int32](v)
@@ -5023,10 +5015,10 @@ func InputInt4V(label string, v *[4]int32, flags InputTextFlags) bool {
 }
 
 // InputScalarV parameter default value hint:
-// flags: 0
-// format: NULL
 // p_step: NULL
 // p_step_fast: NULL
+// format: NULL
+// flags: 0
 func InputScalarV(label string, data_type DataType, p_data unsafe.Pointer, p_step unsafe.Pointer, p_step_fast unsafe.Pointer, format string, flags InputTextFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	formatArg, formatFin := wrapString(format)
@@ -5039,10 +5031,10 @@ func InputScalarV(label string, data_type DataType, p_data unsafe.Pointer, p_ste
 }
 
 // InputScalarNV parameter default value hint:
-// flags: 0
-// format: NULL
 // p_step: NULL
 // p_step_fast: NULL
+// format: NULL
+// flags: 0
 func InputScalarNV(label string, data_type DataType, p_data unsafe.Pointer, components int32, p_step unsafe.Pointer, p_step_fast unsafe.Pointer, format string, flags InputTextFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	formatArg, formatFin := wrapString(format)
@@ -5412,7 +5404,6 @@ func LogFinish() {
 }
 
 // InternalLogRenderedTextV parameter default value hint:
-// text_end: NULL
 func InternalLogRenderedTextV(ref_pos *Vec2, text string) {
 	ref_posArg, ref_posFin := wrap[C.ImVec2, *Vec2](ref_pos)
 	textArg, textFin := wrapString(text)
@@ -5487,9 +5478,9 @@ func MemFree(ptr unsafe.Pointer) {
 }
 
 // InternalMenuItemExV parameter default value hint:
-// enabled: true
-// selected: false
 // shortcut: NULL
+// selected: false
+// enabled: true
 func InternalMenuItemExV(label string, icon string, shortcut string, selected bool, enabled bool) bool {
 	labelArg, labelFin := wrapString(label)
 	iconArg, iconFin := wrapString(icon)
@@ -5504,9 +5495,9 @@ func InternalMenuItemExV(label string, icon string, shortcut string, selected bo
 }
 
 // MenuItemBoolV parameter default value hint:
-// enabled: true
-// selected: false
 // shortcut: NULL
+// selected: false
+// enabled: true
 func MenuItemBoolV(label string, shortcut string, selected bool, enabled bool) bool {
 	labelArg, labelFin := wrapString(label)
 	shortcutArg, shortcutFin := wrapString(shortcut)
@@ -5592,8 +5583,8 @@ func InternalOpenPopupExV(id ID, popup_flags PopupFlags) {
 }
 
 // OpenPopupOnItemClickV parameter default value hint:
-// popup_flags: 1
 // str_id: NULL
+// popup_flags: 1
 func OpenPopupOnItemClickV(str_id string, popup_flags PopupFlags) {
 	str_idArg, str_idFin := wrapString(str_id)
 	C.igOpenPopupOnItemClick(str_idArg, C.ImGuiPopupFlags(popup_flags))
@@ -5617,12 +5608,12 @@ func OpenPopupStrV(str_id string, popup_flags PopupFlags) {
 }
 
 // PlotHistogramFloatPtrV parameter default value hint:
-// graph_size: ImVec2(0,0)
-// overlay_text: NULL
-// scale_max: FLT_MAX
-// scale_min: FLT_MAX
-// stride: sizeof(float)
 // values_offset: 0
+// overlay_text: NULL
+// scale_min: FLT_MAX
+// scale_max: FLT_MAX
+// graph_size: ImVec2(0,0)
+// stride: sizeof(float)
 func PlotHistogramFloatPtrV(label string, values []float32, values_count int32, values_offset int32, overlay_text string, scale_min float32, scale_max float32, graph_size Vec2, stride int32) {
 	labelArg, labelFin := wrapString(label)
 	overlay_textArg, overlay_textFin := wrapString(overlay_text)
@@ -5633,12 +5624,12 @@ func PlotHistogramFloatPtrV(label string, values []float32, values_count int32, 
 }
 
 // PlotLinesFloatPtrV parameter default value hint:
-// graph_size: ImVec2(0,0)
-// overlay_text: NULL
-// scale_max: FLT_MAX
-// scale_min: FLT_MAX
-// stride: sizeof(float)
 // values_offset: 0
+// overlay_text: NULL
+// scale_min: FLT_MAX
+// scale_max: FLT_MAX
+// graph_size: ImVec2(0,0)
+// stride: sizeof(float)
 func PlotLinesFloatPtrV(label string, values []float32, values_count int32, values_offset int32, overlay_text string, scale_min float32, scale_max float32, graph_size Vec2, stride int32) {
 	labelArg, labelFin := wrapString(label)
 	overlay_textArg, overlay_textFin := wrapString(overlay_text)
@@ -5701,8 +5692,8 @@ func PopTextWrapPos() {
 }
 
 // ProgressBarV parameter default value hint:
-// overlay: NULL
 // size_arg: ImVec2(-FLT_MIN,0)
+// overlay: NULL
 func ProgressBarV(fraction float32, size_arg Vec2, overlay string) {
 	overlayArg, overlayFin := wrapString(overlay)
 	C.igProgressBar(C.float(fraction), size_arg.toC(), overlayArg)
@@ -5858,8 +5849,8 @@ func InternalRenderCheckMark(draw_list DrawList, pos Vec2, col uint32, sz float3
 }
 
 // InternalRenderColorRectWithAlphaCheckerboardV parameter default value hint:
-// flags: 0
 // rounding: 0.0f
+// flags: 0
 func InternalRenderColorRectWithAlphaCheckerboardV(draw_list DrawList, p_min Vec2, p_max Vec2, fill_col uint32, grid_step float32, grid_off Vec2, rounding float32, flags DrawFlags) {
 	C.igRenderColorRectWithAlphaCheckerboard(draw_list.handle(), p_min.toC(), p_max.toC(), C.ImU32(fill_col), C.float(grid_step), grid_off.toC(), C.float(rounding), C.ImDrawFlags(flags))
 }
@@ -5908,7 +5899,6 @@ func InternalRenderRectFilledWithHole(draw_list DrawList, outer Rect, inner Rect
 
 // InternalRenderTextV parameter default value hint:
 // hide_text_after_hash: true
-// text_end: NULL
 func InternalRenderTextV(pos Vec2, text string, hide_text_after_hash bool) {
 	textArg, textFin := wrapString(text)
 	C.wrap_igRenderTextV(pos.toC(), textArg, C.bool(hide_text_after_hash))
@@ -5996,8 +5986,8 @@ func InternalScrollbar(axis Axis) {
 }
 
 // SelectableBoolV parameter default value hint:
-// flags: 0
 // selected: false
+// flags: 0
 // size: ImVec2(0,0)
 func SelectableBoolV(label string, selected bool, flags SelectableFlags, size Vec2) bool {
 	labelArg, labelFin := wrapString(label)
@@ -6278,8 +6268,8 @@ func InternalSetScrollYWindowPtr(window Window, scroll_y float32) {
 }
 
 // InternalSetShortcutRoutingV parameter default value hint:
-// flags: 0
 // owner_id: 0
+// flags: 0
 func InternalSetShortcutRoutingV(key_chord KeyChord, owner_id ID, flags InputFlags) bool {
 	return C.igSetShortcutRouting(C.ImGuiKeyChord(key_chord), C.ImGuiID(owner_id), C.ImGuiInputFlags(flags)) == C.bool(true)
 }
@@ -6405,8 +6395,8 @@ func InternalShadeVertsLinearUV(draw_list DrawList, vert_start_idx int32, vert_e
 }
 
 // InternalShortcutV parameter default value hint:
-// flags: 0
 // owner_id: 0
+// flags: 0
 func InternalShortcutV(key_chord KeyChord, owner_id ID, flags InputFlags) bool {
 	return C.igShortcut(C.ImGuiKeyChord(key_chord), C.ImGuiID(owner_id), C.ImGuiInputFlags(flags)) == C.bool(true)
 }
@@ -6495,10 +6485,10 @@ func InternalShutdown() {
 }
 
 // SliderAngleV parameter default value hint:
-// flags: 0
-// format: "%.0f deg"
-// v_degrees_max: +360.0f
 // v_degrees_min: -360.0f
+// v_degrees_max: +360.0f
+// format: "%.0f deg"
+// flags: 0
 func SliderAngleV(label string, v_rad *float32, v_degrees_min float32, v_degrees_max float32, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	v_radArg, v_radFin := wrapNumberPtr[C.float, float32](v_rad)
@@ -6524,8 +6514,8 @@ func InternalSliderBehavior(bb Rect, id ID, data_type DataType, p_v unsafe.Point
 }
 
 // SliderFloatV parameter default value hint:
-// flags: 0
 // format: "%.3f"
+// flags: 0
 func SliderFloatV(label string, v *float32, v_min float32, v_max float32, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	vArg, vFin := wrapNumberPtr[C.float, float32](v)
@@ -6540,8 +6530,8 @@ func SliderFloatV(label string, v *float32, v_min float32, v_max float32, format
 }
 
 // SliderFloat2V parameter default value hint:
-// flags: 0
 // format: "%.3f"
+// flags: 0
 func SliderFloat2V(label string, v *[2]float32, v_min float32, v_max float32, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 
@@ -6564,8 +6554,8 @@ func SliderFloat2V(label string, v *[2]float32, v_min float32, v_max float32, fo
 }
 
 // SliderFloat3V parameter default value hint:
-// flags: 0
 // format: "%.3f"
+// flags: 0
 func SliderFloat3V(label string, v *[3]float32, v_min float32, v_max float32, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 
@@ -6588,8 +6578,8 @@ func SliderFloat3V(label string, v *[3]float32, v_min float32, v_max float32, fo
 }
 
 // SliderFloat4V parameter default value hint:
-// flags: 0
 // format: "%.3f"
+// flags: 0
 func SliderFloat4V(label string, v *[4]float32, v_min float32, v_max float32, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 
@@ -6612,8 +6602,8 @@ func SliderFloat4V(label string, v *[4]float32, v_min float32, v_max float32, fo
 }
 
 // SliderIntV parameter default value hint:
-// flags: 0
 // format: "%d"
+// flags: 0
 func SliderIntV(label string, v *int32, v_min int32, v_max int32, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	vArg, vFin := wrapNumberPtr[C.int, int32](v)
@@ -6628,8 +6618,8 @@ func SliderIntV(label string, v *int32, v_min int32, v_max int32, format string,
 }
 
 // SliderInt2V parameter default value hint:
-// flags: 0
 // format: "%d"
+// flags: 0
 func SliderInt2V(label string, v *[2]int32, v_min int32, v_max int32, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 
@@ -6652,8 +6642,8 @@ func SliderInt2V(label string, v *[2]int32, v_min int32, v_max int32, format str
 }
 
 // SliderInt3V parameter default value hint:
-// flags: 0
 // format: "%d"
+// flags: 0
 func SliderInt3V(label string, v *[3]int32, v_min int32, v_max int32, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 
@@ -6676,8 +6666,8 @@ func SliderInt3V(label string, v *[3]int32, v_min int32, v_max int32, format str
 }
 
 // SliderInt4V parameter default value hint:
-// flags: 0
 // format: "%d"
+// flags: 0
 func SliderInt4V(label string, v *[4]int32, v_min int32, v_max int32, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 
@@ -6700,8 +6690,8 @@ func SliderInt4V(label string, v *[4]int32, v_min int32, v_max int32, format str
 }
 
 // SliderScalarV parameter default value hint:
-// flags: 0
 // format: NULL
+// flags: 0
 func SliderScalarV(label string, data_type DataType, p_data unsafe.Pointer, p_min unsafe.Pointer, p_max unsafe.Pointer, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	formatArg, formatFin := wrapString(format)
@@ -6714,8 +6704,8 @@ func SliderScalarV(label string, data_type DataType, p_data unsafe.Pointer, p_mi
 }
 
 // SliderScalarNV parameter default value hint:
-// flags: 0
 // format: NULL
+// flags: 0
 func SliderScalarNV(label string, data_type DataType, p_data unsafe.Pointer, components int32, p_min unsafe.Pointer, p_max unsafe.Pointer, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	formatArg, formatFin := wrapString(format)
@@ -6741,9 +6731,9 @@ func Spacing() {
 }
 
 // InternalSplitterBehaviorV parameter default value hint:
-// bg_col: 0
 // hover_extend: 0.0f
 // hover_visibility_delay: 0.0f
+// bg_col: 0
 func InternalSplitterBehaviorV(bb Rect, id ID, axis Axis, size1 *float32, size2 *float32, min_size1 float32, min_size2 float32, hover_extend float32, hover_visibility_delay float32, bg_col uint32) bool {
 	size1Arg, size1Fin := wrapNumberPtr[C.float, float32](size1)
 	size2Arg, size2Fin := wrapNumberPtr[C.float, float32](size2)
@@ -7055,8 +7045,8 @@ func TableNextColumn() bool {
 }
 
 // TableNextRowV parameter default value hint:
-// min_row_height: 0.0f
 // row_flags: 0
+// min_row_height: 0.0f
 func TableNextRowV(row_flags TableRowFlags, min_row_height float32) {
 	C.igTableNextRow(C.ImGuiTableRowFlags(row_flags), C.float(min_row_height))
 }
@@ -7173,8 +7163,8 @@ func InternalTempInputIsActive(id ID) bool {
 }
 
 // InternalTempInputScalarV parameter default value hint:
-// p_clamp_max: NULL
 // p_clamp_min: NULL
+// p_clamp_max: NULL
 func InternalTempInputScalarV(bb Rect, id ID, label string, data_type DataType, p_data unsafe.Pointer, format string, p_clamp_min unsafe.Pointer, p_clamp_max unsafe.Pointer) bool {
 	labelArg, labelFin := wrapString(label)
 	formatArg, formatFin := wrapString(format)
@@ -7228,7 +7218,6 @@ func TextDisabled(fmt string) {
 
 // InternalTextExV parameter default value hint:
 // flags: 0
-// text_end: NULL
 func InternalTextExV(text string, flags TextFlags) {
 	textArg, textFin := wrapString(text)
 	C.wrap_igTextExV(textArg, C.ImGuiTextFlags(flags))
@@ -7237,7 +7226,6 @@ func InternalTextExV(text string, flags TextFlags) {
 }
 
 // TextUnformattedV parameter default value hint:
-// text_end: NULL
 func TextUnformattedV(text string) {
 	textArg, textFin := wrapString(text)
 	C.wrap_igTextUnformattedV(textArg)
@@ -7387,8 +7375,8 @@ func InternalUpdateWindowParentAndRootLinks(window Window, flags WindowFlags, pa
 }
 
 // VSliderFloatV parameter default value hint:
-// flags: 0
 // format: "%.3f"
+// flags: 0
 func VSliderFloatV(label string, size Vec2, v *float32, v_min float32, v_max float32, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	vArg, vFin := wrapNumberPtr[C.float, float32](v)
@@ -7403,8 +7391,8 @@ func VSliderFloatV(label string, size Vec2, v *float32, v_min float32, v_max flo
 }
 
 // VSliderIntV parameter default value hint:
-// flags: 0
 // format: "%d"
+// flags: 0
 func VSliderIntV(label string, size Vec2, v *int32, v_min int32, v_max int32, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	vArg, vFin := wrapNumberPtr[C.int, int32](v)
@@ -7419,8 +7407,8 @@ func VSliderIntV(label string, size Vec2, v *int32, v_min int32, v_max int32, fo
 }
 
 // VSliderScalarV parameter default value hint:
-// flags: 0
 // format: NULL
+// flags: 0
 func VSliderScalarV(label string, size Vec2, data_type DataType, p_data unsafe.Pointer, p_min unsafe.Pointer, p_max unsafe.Pointer, format string, flags SliderFlags) bool {
 	labelArg, labelFin := wrapString(label)
 	formatArg, formatFin := wrapString(format)

--- a/cimplot_funcs.go
+++ b/cimplot_funcs.go
@@ -739,7 +739,6 @@ func PlotAddColormapVec4PtrV(name string, cols *Vec4, size int32, qual bool) Plo
 }
 
 // PlotAddTextCenteredV parameter default value hint:
-// text_end: NULL
 func PlotAddTextCenteredV(DrawList DrawList, top_center Vec2, col uint32, text_begin string) {
 	text_beginArg, text_beginFin := wrapString(text_begin)
 	C.wrap_ImPlot_AddTextCenteredV(DrawList.handle(), top_center.toC(), C.ImU32(col), text_beginArg)
@@ -748,7 +747,6 @@ func PlotAddTextCenteredV(DrawList DrawList, top_center Vec2, col uint32, text_b
 }
 
 // PlotAddTextVerticalV parameter default value hint:
-// text_end: NULL
 func PlotAddTextVerticalV(DrawList DrawList, pos Vec2, col uint32, text_begin string) {
 	text_beginArg, text_beginFin := wrapString(text_begin)
 	C.wrap_ImPlot_AddTextVerticalV(DrawList.handle(), pos.toC(), C.ImU32(col), text_beginArg)
@@ -832,8 +830,8 @@ func PlotBeginItemV(label_id string, flags PlotItemFlags, recolor_from PlotCol) 
 }
 
 // PlotBeginPlotV parameter default value hint:
-// flags: 0
 // size: ImVec2(-1,0)
+// flags: 0
 func PlotBeginPlotV(title_id string, size Vec2, flags PlotFlags) bool {
 	title_idArg, title_idFin := wrapString(title_id)
 
@@ -844,9 +842,9 @@ func PlotBeginPlotV(title_id string, size Vec2, flags PlotFlags) bool {
 }
 
 // PlotBeginSubplotsV parameter default value hint:
-// col_ratios: NULL
 // flags: 0
 // row_ratios: NULL
+// col_ratios: NULL
 func PlotBeginSubplotsV(title_id string, rows int32, cols int32, size Vec2, flags PlotSubplotFlags, row_ratios *float32, col_ratios *float32) bool {
 	title_idArg, title_idFin := wrapString(title_id)
 	row_ratiosArg, row_ratiosFin := wrapNumberPtr[C.float, float32](row_ratios)
@@ -940,8 +938,8 @@ func PlotClampLabelPos(pos Vec2, size Vec2, Min Vec2, Max Vec2) Vec2 {
 }
 
 // PlotColormapButtonV parameter default value hint:
-// cmap: -1
 // size: ImVec2(0,0)
+// cmap: -1
 func PlotColormapButtonV(label string, size Vec2, cmap PlotColormap) bool {
 	labelArg, labelFin := wrapString(label)
 
@@ -956,10 +954,10 @@ func PlotColormapIcon(cmap PlotColormap) {
 }
 
 // PlotColormapScaleV parameter default value hint:
-// cmap: -1
-// flags: 0
-// format: "%g"
 // size: ImVec2(0,0)
+// format: "%g"
+// flags: 0
+// cmap: -1
 func PlotColormapScaleV(label string, scale_min float64, scale_max float64, size Vec2, format string, flags PlotColormapScaleFlags, cmap PlotColormap) {
 	labelArg, labelFin := wrapString(label)
 	formatArg, formatFin := wrapString(format)
@@ -970,9 +968,9 @@ func PlotColormapScaleV(label string, scale_min float64, scale_max float64, size
 }
 
 // PlotColormapSliderV parameter default value hint:
-// cmap: -1
-// format: ""
 // out: NULL
+// format: ""
+// cmap: -1
 func PlotColormapSliderV(label string, t *float32, out *Vec4, format string, cmap PlotColormap) bool {
 	labelArg, labelFin := wrapString(label)
 	tArg, tFin := wrapNumberPtr[C.float, float32](t)
@@ -1010,8 +1008,8 @@ func PlotDestroyContextV(ctx PlotContext) {
 }
 
 // PlotDragLineXV parameter default value hint:
-// flags: 0
 // thickness: 1
+// flags: 0
 func PlotDragLineXV(id int32, x *float64, col Vec4, thickness float32, flags PlotDragToolFlags) bool {
 	xArg, xFin := wrapNumberPtr[C.double, float64](x)
 
@@ -1022,8 +1020,8 @@ func PlotDragLineXV(id int32, x *float64, col Vec4, thickness float32, flags Plo
 }
 
 // PlotDragLineYV parameter default value hint:
-// flags: 0
 // thickness: 1
+// flags: 0
 func PlotDragLineYV(id int32, y *float64, col Vec4, thickness float32, flags PlotDragToolFlags) bool {
 	yArg, yFin := wrapNumberPtr[C.double, float64](y)
 
@@ -1034,8 +1032,8 @@ func PlotDragLineYV(id int32, y *float64, col Vec4, thickness float32, flags Plo
 }
 
 // PlotDragPointV parameter default value hint:
-// flags: 0
 // size: 4
+// flags: 0
 func PlotDragPointV(id int32, x *float64, y *float64, col Vec4, size float32, flags PlotDragToolFlags) bool {
 	xArg, xFin := wrapNumberPtr[C.double, float64](x)
 	yArg, yFin := wrapNumberPtr[C.double, float64](y)
@@ -1373,8 +1371,8 @@ func PlotGetYear(t PlotTime) int {
 }
 
 // PlotHideNextItemV parameter default value hint:
-// cond: ImPlotCond_Once
 // hidden: true
+// cond: ImPlotCond_Once
 func PlotHideNextItemV(hidden bool, cond PlotCond) {
 	C.ImPlot_HideNextItem(C.bool(hidden), C.ImPlotCond(cond))
 }
@@ -2260,9 +2258,9 @@ func PlotPixelsToPlotVec2V(pix Vec2, x_axis PlotAxisEnum, y_axis PlotAxisEnum) P
 }
 
 // PlotPlotBarGroupsFloatPtrV parameter default value hint:
-// flags: 0
 // group_size: 0.67
 // shift: 0
+// flags: 0
 func PlotPlotBarGroupsFloatPtrV(label_ids []string, values []float32, item_count int32, group_count int32, group_size float64, shift float64, flags PlotBarGroupsFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	C.ImPlot_PlotBarGroups_FloatPtr(label_idsArg, (*C.float)(&(values[0])), C.int(item_count), C.int(group_count), C.double(group_size), C.double(shift), C.ImPlotBarGroupsFlags(flags))
@@ -2271,9 +2269,9 @@ func PlotPlotBarGroupsFloatPtrV(label_ids []string, values []float32, item_count
 }
 
 // PlotPlotBarGroupsS16PtrV parameter default value hint:
-// flags: 0
 // group_size: 0.67
 // shift: 0
+// flags: 0
 func PlotPlotBarGroupsS16PtrV(label_ids []string, values *[]int, item_count int32, group_count int32, group_size float64, shift float64, flags PlotBarGroupsFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	valuesArg := make([]C.ImS16, len(*values))
@@ -2291,9 +2289,9 @@ func PlotPlotBarGroupsS16PtrV(label_ids []string, values *[]int, item_count int3
 }
 
 // PlotPlotBarGroupsS32PtrV parameter default value hint:
-// flags: 0
 // group_size: 0.67
 // shift: 0
+// flags: 0
 func PlotPlotBarGroupsS32PtrV(label_ids []string, values *[]int32, item_count int32, group_count int32, group_size float64, shift float64, flags PlotBarGroupsFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	valuesArg := make([]C.ImS32, len(*values))
@@ -2311,9 +2309,9 @@ func PlotPlotBarGroupsS32PtrV(label_ids []string, values *[]int32, item_count in
 }
 
 // PlotPlotBarGroupsS64PtrV parameter default value hint:
-// flags: 0
 // group_size: 0.67
 // shift: 0
+// flags: 0
 func PlotPlotBarGroupsS64PtrV(label_ids []string, values []int64, item_count int32, group_count int32, group_size float64, shift float64, flags PlotBarGroupsFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	C.ImPlot_PlotBarGroups_S64Ptr(label_idsArg, (*C.longlong)(&(values[0])), C.int(item_count), C.int(group_count), C.double(group_size), C.double(shift), C.ImPlotBarGroupsFlags(flags))
@@ -2322,9 +2320,9 @@ func PlotPlotBarGroupsS64PtrV(label_ids []string, values []int64, item_count int
 }
 
 // PlotPlotBarGroupsS8PtrV parameter default value hint:
-// flags: 0
 // group_size: 0.67
 // shift: 0
+// flags: 0
 func PlotPlotBarGroupsS8PtrV(label_ids []string, values *[]int8, item_count int32, group_count int32, group_size float64, shift float64, flags PlotBarGroupsFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	valuesArg := make([]C.ImS8, len(*values))
@@ -2342,9 +2340,9 @@ func PlotPlotBarGroupsS8PtrV(label_ids []string, values *[]int8, item_count int3
 }
 
 // PlotPlotBarGroupsU16PtrV parameter default value hint:
-// flags: 0
 // group_size: 0.67
 // shift: 0
+// flags: 0
 func PlotPlotBarGroupsU16PtrV(label_ids []string, values *[]uint16, item_count int32, group_count int32, group_size float64, shift float64, flags PlotBarGroupsFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	valuesArg := make([]C.ImU16, len(*values))
@@ -2362,9 +2360,9 @@ func PlotPlotBarGroupsU16PtrV(label_ids []string, values *[]uint16, item_count i
 }
 
 // PlotPlotBarGroupsU32PtrV parameter default value hint:
-// flags: 0
 // group_size: 0.67
 // shift: 0
+// flags: 0
 func PlotPlotBarGroupsU32PtrV(label_ids []string, values *[]uint32, item_count int32, group_count int32, group_size float64, shift float64, flags PlotBarGroupsFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	valuesArg := make([]C.ImU32, len(*values))
@@ -2382,9 +2380,9 @@ func PlotPlotBarGroupsU32PtrV(label_ids []string, values *[]uint32, item_count i
 }
 
 // PlotPlotBarGroupsU64PtrV parameter default value hint:
-// flags: 0
 // group_size: 0.67
 // shift: 0
+// flags: 0
 func PlotPlotBarGroupsU64PtrV(label_ids []string, values []uint64, item_count int32, group_count int32, group_size float64, shift float64, flags PlotBarGroupsFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	C.ImPlot_PlotBarGroups_U64Ptr(label_idsArg, (*C.ulonglong)(&(values[0])), C.int(item_count), C.int(group_count), C.double(group_size), C.double(shift), C.ImPlotBarGroupsFlags(flags))
@@ -2393,9 +2391,9 @@ func PlotPlotBarGroupsU64PtrV(label_ids []string, values []uint64, item_count in
 }
 
 // PlotPlotBarGroupsU8PtrV parameter default value hint:
-// flags: 0
 // group_size: 0.67
 // shift: 0
+// flags: 0
 func PlotPlotBarGroupsU8PtrV(label_ids []string, values *[]byte, item_count int32, group_count int32, group_size float64, shift float64, flags PlotBarGroupsFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	valuesArg := make([]C.ImU8, len(*values))
@@ -2413,9 +2411,9 @@ func PlotPlotBarGroupsU8PtrV(label_ids []string, values *[]byte, item_count int3
 }
 
 // PlotPlotBarGroupsdoublePtrV parameter default value hint:
-// flags: 0
 // group_size: 0.67
 // shift: 0
+// flags: 0
 func PlotPlotBarGroupsdoublePtrV(label_ids []string, values *[]float64, item_count int32, group_count int32, group_size float64, shift float64, flags PlotBarGroupsFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	valuesArg := make([]C.double, len(*values))
@@ -2445,9 +2443,9 @@ func PlotPlotBarsFloatPtrFloatPtrV(label_id string, xs []float32, ys []float32, 
 
 // PlotPlotBarsFloatPtrIntV parameter default value hint:
 // bar_size: 0.67
+// shift: 0
 // flags: 0
 // offset: 0
-// shift: 0
 // stride: sizeof(float)
 func PlotPlotBarsFloatPtrIntV(label_id string, values []float32, count int32, bar_size float64, shift float64, flags PlotBarsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -2458,9 +2456,9 @@ func PlotPlotBarsFloatPtrIntV(label_id string, values []float32, count int32, ba
 
 // PlotPlotBarsS16PtrIntV parameter default value hint:
 // bar_size: 0.67
+// shift: 0
 // flags: 0
 // offset: 0
-// shift: 0
 // stride: sizeof(ImS16)
 func PlotPlotBarsS16PtrIntV(label_id string, values *[]int, count int32, bar_size float64, shift float64, flags PlotBarsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -2509,9 +2507,9 @@ func PlotPlotBarsS16PtrS16PtrV(label_id string, xs *[]int, ys *[]int, count int3
 
 // PlotPlotBarsS32PtrIntV parameter default value hint:
 // bar_size: 0.67
+// shift: 0
 // flags: 0
 // offset: 0
-// shift: 0
 // stride: sizeof(ImS32)
 func PlotPlotBarsS32PtrIntV(label_id string, values *[]int32, count int32, bar_size float64, shift float64, flags PlotBarsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -2560,9 +2558,9 @@ func PlotPlotBarsS32PtrS32PtrV(label_id string, xs *[]int32, ys *[]int32, count 
 
 // PlotPlotBarsS64PtrIntV parameter default value hint:
 // bar_size: 0.67
+// shift: 0
 // flags: 0
 // offset: 0
-// shift: 0
 // stride: sizeof(ImS64)
 func PlotPlotBarsS64PtrIntV(label_id string, values []int64, count int32, bar_size float64, shift float64, flags PlotBarsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -2584,9 +2582,9 @@ func PlotPlotBarsS64PtrS64PtrV(label_id string, xs []int64, ys []int64, count in
 
 // PlotPlotBarsS8PtrIntV parameter default value hint:
 // bar_size: 0.67
+// shift: 0
 // flags: 0
 // offset: 0
-// shift: 0
 // stride: sizeof(ImS8)
 func PlotPlotBarsS8PtrIntV(label_id string, values *[]int8, count int32, bar_size float64, shift float64, flags PlotBarsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -2635,9 +2633,9 @@ func PlotPlotBarsS8PtrS8PtrV(label_id string, xs *[]int8, ys *[]int8, count int3
 
 // PlotPlotBarsU16PtrIntV parameter default value hint:
 // bar_size: 0.67
+// shift: 0
 // flags: 0
 // offset: 0
-// shift: 0
 // stride: sizeof(ImU16)
 func PlotPlotBarsU16PtrIntV(label_id string, values *[]uint16, count int32, bar_size float64, shift float64, flags PlotBarsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -2686,9 +2684,9 @@ func PlotPlotBarsU16PtrU16PtrV(label_id string, xs *[]uint16, ys *[]uint16, coun
 
 // PlotPlotBarsU32PtrIntV parameter default value hint:
 // bar_size: 0.67
+// shift: 0
 // flags: 0
 // offset: 0
-// shift: 0
 // stride: sizeof(ImU32)
 func PlotPlotBarsU32PtrIntV(label_id string, values *[]uint32, count int32, bar_size float64, shift float64, flags PlotBarsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -2737,9 +2735,9 @@ func PlotPlotBarsU32PtrU32PtrV(label_id string, xs *[]uint32, ys *[]uint32, coun
 
 // PlotPlotBarsU64PtrIntV parameter default value hint:
 // bar_size: 0.67
+// shift: 0
 // flags: 0
 // offset: 0
-// shift: 0
 // stride: sizeof(ImU64)
 func PlotPlotBarsU64PtrIntV(label_id string, values []uint64, count int32, bar_size float64, shift float64, flags PlotBarsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -2761,9 +2759,9 @@ func PlotPlotBarsU64PtrU64PtrV(label_id string, xs []uint64, ys []uint64, count 
 
 // PlotPlotBarsU8PtrIntV parameter default value hint:
 // bar_size: 0.67
+// shift: 0
 // flags: 0
 // offset: 0
-// shift: 0
 // stride: sizeof(ImU8)
 func PlotPlotBarsU8PtrIntV(label_id string, values *[]byte, count int32, bar_size float64, shift float64, flags PlotBarsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -2812,9 +2810,9 @@ func PlotPlotBarsU8PtrU8PtrV(label_id string, xs *[]byte, ys *[]byte, count int3
 
 // PlotPlotBarsdoublePtrIntV parameter default value hint:
 // bar_size: 0.67
+// shift: 0
 // flags: 0
 // offset: 0
-// shift: 0
 // stride: sizeof(double)
 func PlotPlotBarsdoublePtrIntV(label_id string, values *[]float64, count int32, bar_size float64, shift float64, flags PlotBarsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -3768,12 +3766,12 @@ func PlotPlotErrorBarsdoublePtrdoublePtrdoublePtrdoublePtrV(label_id string, xs 
 }
 
 // PlotPlotHeatmapFloatPtrV parameter default value hint:
-// bounds_max: ImPlotPoint(1,1)
-// bounds_min: ImPlotPoint(0,0)
-// flags: 0
-// label_fmt: "%.1f"
-// scale_max: 0
 // scale_min: 0
+// scale_max: 0
+// label_fmt: "%.1f"
+// bounds_min: ImPlotPoint(0,0)
+// bounds_max: ImPlotPoint(1,1)
+// flags: 0
 func PlotPlotHeatmapFloatPtrV(label_id string, values []float32, rows int32, cols int32, scale_min float64, scale_max float64, label_fmt string, bounds_min PlotPoint, bounds_max PlotPoint, flags PlotHeatmapFlags) {
 	label_idArg, label_idFin := wrapString(label_id)
 	label_fmtArg, label_fmtFin := wrapString(label_fmt)
@@ -3784,12 +3782,12 @@ func PlotPlotHeatmapFloatPtrV(label_id string, values []float32, rows int32, col
 }
 
 // PlotPlotHeatmapS16PtrV parameter default value hint:
-// bounds_max: ImPlotPoint(1,1)
-// bounds_min: ImPlotPoint(0,0)
-// flags: 0
-// label_fmt: "%.1f"
-// scale_max: 0
 // scale_min: 0
+// scale_max: 0
+// label_fmt: "%.1f"
+// bounds_min: ImPlotPoint(0,0)
+// bounds_max: ImPlotPoint(1,1)
+// flags: 0
 func PlotPlotHeatmapS16PtrV(label_id string, values *[]int, rows int32, cols int32, scale_min float64, scale_max float64, label_fmt string, bounds_min PlotPoint, bounds_max PlotPoint, flags PlotHeatmapFlags) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImS16, len(*values))
@@ -3810,12 +3808,12 @@ func PlotPlotHeatmapS16PtrV(label_id string, values *[]int, rows int32, cols int
 }
 
 // PlotPlotHeatmapS32PtrV parameter default value hint:
-// bounds_max: ImPlotPoint(1,1)
-// bounds_min: ImPlotPoint(0,0)
-// flags: 0
-// label_fmt: "%.1f"
-// scale_max: 0
 // scale_min: 0
+// scale_max: 0
+// label_fmt: "%.1f"
+// bounds_min: ImPlotPoint(0,0)
+// bounds_max: ImPlotPoint(1,1)
+// flags: 0
 func PlotPlotHeatmapS32PtrV(label_id string, values *[]int32, rows int32, cols int32, scale_min float64, scale_max float64, label_fmt string, bounds_min PlotPoint, bounds_max PlotPoint, flags PlotHeatmapFlags) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImS32, len(*values))
@@ -3836,12 +3834,12 @@ func PlotPlotHeatmapS32PtrV(label_id string, values *[]int32, rows int32, cols i
 }
 
 // PlotPlotHeatmapS64PtrV parameter default value hint:
-// bounds_max: ImPlotPoint(1,1)
-// bounds_min: ImPlotPoint(0,0)
-// flags: 0
-// label_fmt: "%.1f"
-// scale_max: 0
 // scale_min: 0
+// scale_max: 0
+// label_fmt: "%.1f"
+// bounds_min: ImPlotPoint(0,0)
+// bounds_max: ImPlotPoint(1,1)
+// flags: 0
 func PlotPlotHeatmapS64PtrV(label_id string, values []int64, rows int32, cols int32, scale_min float64, scale_max float64, label_fmt string, bounds_min PlotPoint, bounds_max PlotPoint, flags PlotHeatmapFlags) {
 	label_idArg, label_idFin := wrapString(label_id)
 	label_fmtArg, label_fmtFin := wrapString(label_fmt)
@@ -3852,12 +3850,12 @@ func PlotPlotHeatmapS64PtrV(label_id string, values []int64, rows int32, cols in
 }
 
 // PlotPlotHeatmapS8PtrV parameter default value hint:
-// bounds_max: ImPlotPoint(1,1)
-// bounds_min: ImPlotPoint(0,0)
-// flags: 0
-// label_fmt: "%.1f"
-// scale_max: 0
 // scale_min: 0
+// scale_max: 0
+// label_fmt: "%.1f"
+// bounds_min: ImPlotPoint(0,0)
+// bounds_max: ImPlotPoint(1,1)
+// flags: 0
 func PlotPlotHeatmapS8PtrV(label_id string, values *[]int8, rows int32, cols int32, scale_min float64, scale_max float64, label_fmt string, bounds_min PlotPoint, bounds_max PlotPoint, flags PlotHeatmapFlags) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImS8, len(*values))
@@ -3878,12 +3876,12 @@ func PlotPlotHeatmapS8PtrV(label_id string, values *[]int8, rows int32, cols int
 }
 
 // PlotPlotHeatmapU16PtrV parameter default value hint:
-// bounds_max: ImPlotPoint(1,1)
-// bounds_min: ImPlotPoint(0,0)
-// flags: 0
-// label_fmt: "%.1f"
-// scale_max: 0
 // scale_min: 0
+// scale_max: 0
+// label_fmt: "%.1f"
+// bounds_min: ImPlotPoint(0,0)
+// bounds_max: ImPlotPoint(1,1)
+// flags: 0
 func PlotPlotHeatmapU16PtrV(label_id string, values *[]uint16, rows int32, cols int32, scale_min float64, scale_max float64, label_fmt string, bounds_min PlotPoint, bounds_max PlotPoint, flags PlotHeatmapFlags) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImU16, len(*values))
@@ -3904,12 +3902,12 @@ func PlotPlotHeatmapU16PtrV(label_id string, values *[]uint16, rows int32, cols 
 }
 
 // PlotPlotHeatmapU32PtrV parameter default value hint:
-// bounds_max: ImPlotPoint(1,1)
-// bounds_min: ImPlotPoint(0,0)
-// flags: 0
-// label_fmt: "%.1f"
-// scale_max: 0
 // scale_min: 0
+// scale_max: 0
+// label_fmt: "%.1f"
+// bounds_min: ImPlotPoint(0,0)
+// bounds_max: ImPlotPoint(1,1)
+// flags: 0
 func PlotPlotHeatmapU32PtrV(label_id string, values *[]uint32, rows int32, cols int32, scale_min float64, scale_max float64, label_fmt string, bounds_min PlotPoint, bounds_max PlotPoint, flags PlotHeatmapFlags) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImU32, len(*values))
@@ -3930,12 +3928,12 @@ func PlotPlotHeatmapU32PtrV(label_id string, values *[]uint32, rows int32, cols 
 }
 
 // PlotPlotHeatmapU64PtrV parameter default value hint:
-// bounds_max: ImPlotPoint(1,1)
-// bounds_min: ImPlotPoint(0,0)
-// flags: 0
-// label_fmt: "%.1f"
-// scale_max: 0
 // scale_min: 0
+// scale_max: 0
+// label_fmt: "%.1f"
+// bounds_min: ImPlotPoint(0,0)
+// bounds_max: ImPlotPoint(1,1)
+// flags: 0
 func PlotPlotHeatmapU64PtrV(label_id string, values []uint64, rows int32, cols int32, scale_min float64, scale_max float64, label_fmt string, bounds_min PlotPoint, bounds_max PlotPoint, flags PlotHeatmapFlags) {
 	label_idArg, label_idFin := wrapString(label_id)
 	label_fmtArg, label_fmtFin := wrapString(label_fmt)
@@ -3946,12 +3944,12 @@ func PlotPlotHeatmapU64PtrV(label_id string, values []uint64, rows int32, cols i
 }
 
 // PlotPlotHeatmapU8PtrV parameter default value hint:
-// bounds_max: ImPlotPoint(1,1)
-// bounds_min: ImPlotPoint(0,0)
-// flags: 0
-// label_fmt: "%.1f"
-// scale_max: 0
 // scale_min: 0
+// scale_max: 0
+// label_fmt: "%.1f"
+// bounds_min: ImPlotPoint(0,0)
+// bounds_max: ImPlotPoint(1,1)
+// flags: 0
 func PlotPlotHeatmapU8PtrV(label_id string, values *[]byte, rows int32, cols int32, scale_min float64, scale_max float64, label_fmt string, bounds_min PlotPoint, bounds_max PlotPoint, flags PlotHeatmapFlags) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImU8, len(*values))
@@ -3972,12 +3970,12 @@ func PlotPlotHeatmapU8PtrV(label_id string, values *[]byte, rows int32, cols int
 }
 
 // PlotPlotHeatmapdoublePtrV parameter default value hint:
-// bounds_max: ImPlotPoint(1,1)
-// bounds_min: ImPlotPoint(0,0)
-// flags: 0
-// label_fmt: "%.1f"
-// scale_max: 0
 // scale_min: 0
+// scale_max: 0
+// label_fmt: "%.1f"
+// bounds_min: ImPlotPoint(0,0)
+// bounds_max: ImPlotPoint(1,1)
+// flags: 0
 func PlotPlotHeatmapdoublePtrV(label_id string, values *[]float64, rows int32, cols int32, scale_min float64, scale_max float64, label_fmt string, bounds_min PlotPoint, bounds_max PlotPoint, flags PlotHeatmapFlags) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.double, len(*values))
@@ -3998,10 +3996,10 @@ func PlotPlotHeatmapdoublePtrV(label_id string, values *[]float64, rows int32, c
 }
 
 // PlotPlotImageV parameter default value hint:
-// flags: 0
-// tint_col: ImVec4(1,1,1,1)
 // uv0: ImVec2(0,0)
 // uv1: ImVec2(1,1)
+// tint_col: ImVec4(1,1,1,1)
+// flags: 0
 func PlotPlotImageV(label_id string, user_texture_id TextureID, bounds_min PlotPoint, bounds_max PlotPoint, uv0 Vec2, uv1 Vec2, tint_col Vec4, flags PlotImageFlags) {
 	label_idArg, label_idFin := wrapString(label_id)
 	C.ImPlot_PlotImage(label_idArg, C.ImTextureID(user_texture_id), bounds_min.toC(), bounds_max.toC(), uv0.toC(), uv1.toC(), tint_col.toC(), C.ImPlotImageFlags(flags))
@@ -4194,11 +4192,11 @@ func PlotPlotLineFloatPtrFloatPtrV(label_id string, xs []float32, ys []float32, 
 }
 
 // PlotPlotLineFloatPtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(float)
-// xscale: 1
-// xstart: 0
 func PlotPlotLineFloatPtrIntV(label_id string, values []float32, count int32, xscale float64, xstart float64, flags PlotLineFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	C.ImPlot_PlotLine_FloatPtrInt(label_idArg, (*C.float)(&(values[0])), C.int(count), C.double(xscale), C.double(xstart), C.ImPlotLineFlags(flags), C.int(offset), C.int(stride))
@@ -4207,11 +4205,11 @@ func PlotPlotLineFloatPtrIntV(label_id string, values []float32, count int32, xs
 }
 
 // PlotPlotLineS16PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS16)
-// xscale: 1
-// xstart: 0
 func PlotPlotLineS16PtrIntV(label_id string, values *[]int, count int32, xscale float64, xstart float64, flags PlotLineFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImS16, len(*values))
@@ -4258,11 +4256,11 @@ func PlotPlotLineS16PtrS16PtrV(label_id string, xs *[]int, ys *[]int, count int3
 }
 
 // PlotPlotLineS32PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS32)
-// xscale: 1
-// xstart: 0
 func PlotPlotLineS32PtrIntV(label_id string, values *[]int32, count int32, xscale float64, xstart float64, flags PlotLineFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImS32, len(*values))
@@ -4309,11 +4307,11 @@ func PlotPlotLineS32PtrS32PtrV(label_id string, xs *[]int32, ys *[]int32, count 
 }
 
 // PlotPlotLineS64PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS64)
-// xscale: 1
-// xstart: 0
 func PlotPlotLineS64PtrIntV(label_id string, values []int64, count int32, xscale float64, xstart float64, flags PlotLineFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	C.ImPlot_PlotLine_S64PtrInt(label_idArg, (*C.longlong)(&(values[0])), C.int(count), C.double(xscale), C.double(xstart), C.ImPlotLineFlags(flags), C.int(offset), C.int(stride))
@@ -4333,11 +4331,11 @@ func PlotPlotLineS64PtrS64PtrV(label_id string, xs []int64, ys []int64, count in
 }
 
 // PlotPlotLineS8PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS8)
-// xscale: 1
-// xstart: 0
 func PlotPlotLineS8PtrIntV(label_id string, values *[]int8, count int32, xscale float64, xstart float64, flags PlotLineFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImS8, len(*values))
@@ -4384,11 +4382,11 @@ func PlotPlotLineS8PtrS8PtrV(label_id string, xs *[]int8, ys *[]int8, count int3
 }
 
 // PlotPlotLineU16PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU16)
-// xscale: 1
-// xstart: 0
 func PlotPlotLineU16PtrIntV(label_id string, values *[]uint16, count int32, xscale float64, xstart float64, flags PlotLineFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImU16, len(*values))
@@ -4435,11 +4433,11 @@ func PlotPlotLineU16PtrU16PtrV(label_id string, xs *[]uint16, ys *[]uint16, coun
 }
 
 // PlotPlotLineU32PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU32)
-// xscale: 1
-// xstart: 0
 func PlotPlotLineU32PtrIntV(label_id string, values *[]uint32, count int32, xscale float64, xstart float64, flags PlotLineFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImU32, len(*values))
@@ -4486,11 +4484,11 @@ func PlotPlotLineU32PtrU32PtrV(label_id string, xs *[]uint32, ys *[]uint32, coun
 }
 
 // PlotPlotLineU64PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU64)
-// xscale: 1
-// xstart: 0
 func PlotPlotLineU64PtrIntV(label_id string, values []uint64, count int32, xscale float64, xstart float64, flags PlotLineFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	C.ImPlot_PlotLine_U64PtrInt(label_idArg, (*C.ulonglong)(&(values[0])), C.int(count), C.double(xscale), C.double(xstart), C.ImPlotLineFlags(flags), C.int(offset), C.int(stride))
@@ -4510,11 +4508,11 @@ func PlotPlotLineU64PtrU64PtrV(label_id string, xs []uint64, ys []uint64, count 
 }
 
 // PlotPlotLineU8PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU8)
-// xscale: 1
-// xstart: 0
 func PlotPlotLineU8PtrIntV(label_id string, values *[]byte, count int32, xscale float64, xstart float64, flags PlotLineFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImU8, len(*values))
@@ -4561,11 +4559,11 @@ func PlotPlotLineU8PtrU8PtrV(label_id string, xs *[]byte, ys *[]byte, count int3
 }
 
 // PlotPlotLinedoublePtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(double)
-// xscale: 1
-// xstart: 0
 func PlotPlotLinedoublePtrIntV(label_id string, values *[]float64, count int32, xscale float64, xstart float64, flags PlotLineFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.double, len(*values))
@@ -4612,9 +4610,9 @@ func PlotPlotLinedoublePtrdoublePtrV(label_id string, xs *[]float64, ys *[]float
 }
 
 // PlotPlotPieChartFloatPtrV parameter default value hint:
+// label_fmt: "%.1f"
 // angle0: 90
 // flags: 0
-// label_fmt: "%.1f"
 func PlotPlotPieChartFloatPtrV(label_ids []string, values []float32, count int32, x float64, y float64, radius float64, label_fmt string, angle0 float64, flags PlotPieChartFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	label_fmtArg, label_fmtFin := wrapString(label_fmt)
@@ -4625,9 +4623,9 @@ func PlotPlotPieChartFloatPtrV(label_ids []string, values []float32, count int32
 }
 
 // PlotPlotPieChartS16PtrV parameter default value hint:
+// label_fmt: "%.1f"
 // angle0: 90
 // flags: 0
-// label_fmt: "%.1f"
 func PlotPlotPieChartS16PtrV(label_ids []string, values *[]int, count int32, x float64, y float64, radius float64, label_fmt string, angle0 float64, flags PlotPieChartFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	valuesArg := make([]C.ImS16, len(*values))
@@ -4648,9 +4646,9 @@ func PlotPlotPieChartS16PtrV(label_ids []string, values *[]int, count int32, x f
 }
 
 // PlotPlotPieChartS32PtrV parameter default value hint:
+// label_fmt: "%.1f"
 // angle0: 90
 // flags: 0
-// label_fmt: "%.1f"
 func PlotPlotPieChartS32PtrV(label_ids []string, values *[]int32, count int32, x float64, y float64, radius float64, label_fmt string, angle0 float64, flags PlotPieChartFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	valuesArg := make([]C.ImS32, len(*values))
@@ -4671,9 +4669,9 @@ func PlotPlotPieChartS32PtrV(label_ids []string, values *[]int32, count int32, x
 }
 
 // PlotPlotPieChartS64PtrV parameter default value hint:
+// label_fmt: "%.1f"
 // angle0: 90
 // flags: 0
-// label_fmt: "%.1f"
 func PlotPlotPieChartS64PtrV(label_ids []string, values []int64, count int32, x float64, y float64, radius float64, label_fmt string, angle0 float64, flags PlotPieChartFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	label_fmtArg, label_fmtFin := wrapString(label_fmt)
@@ -4684,9 +4682,9 @@ func PlotPlotPieChartS64PtrV(label_ids []string, values []int64, count int32, x 
 }
 
 // PlotPlotPieChartS8PtrV parameter default value hint:
+// label_fmt: "%.1f"
 // angle0: 90
 // flags: 0
-// label_fmt: "%.1f"
 func PlotPlotPieChartS8PtrV(label_ids []string, values *[]int8, count int32, x float64, y float64, radius float64, label_fmt string, angle0 float64, flags PlotPieChartFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	valuesArg := make([]C.ImS8, len(*values))
@@ -4707,9 +4705,9 @@ func PlotPlotPieChartS8PtrV(label_ids []string, values *[]int8, count int32, x f
 }
 
 // PlotPlotPieChartU16PtrV parameter default value hint:
+// label_fmt: "%.1f"
 // angle0: 90
 // flags: 0
-// label_fmt: "%.1f"
 func PlotPlotPieChartU16PtrV(label_ids []string, values *[]uint16, count int32, x float64, y float64, radius float64, label_fmt string, angle0 float64, flags PlotPieChartFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	valuesArg := make([]C.ImU16, len(*values))
@@ -4730,9 +4728,9 @@ func PlotPlotPieChartU16PtrV(label_ids []string, values *[]uint16, count int32, 
 }
 
 // PlotPlotPieChartU32PtrV parameter default value hint:
+// label_fmt: "%.1f"
 // angle0: 90
 // flags: 0
-// label_fmt: "%.1f"
 func PlotPlotPieChartU32PtrV(label_ids []string, values *[]uint32, count int32, x float64, y float64, radius float64, label_fmt string, angle0 float64, flags PlotPieChartFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	valuesArg := make([]C.ImU32, len(*values))
@@ -4753,9 +4751,9 @@ func PlotPlotPieChartU32PtrV(label_ids []string, values *[]uint32, count int32, 
 }
 
 // PlotPlotPieChartU64PtrV parameter default value hint:
+// label_fmt: "%.1f"
 // angle0: 90
 // flags: 0
-// label_fmt: "%.1f"
 func PlotPlotPieChartU64PtrV(label_ids []string, values []uint64, count int32, x float64, y float64, radius float64, label_fmt string, angle0 float64, flags PlotPieChartFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	label_fmtArg, label_fmtFin := wrapString(label_fmt)
@@ -4766,9 +4764,9 @@ func PlotPlotPieChartU64PtrV(label_ids []string, values []uint64, count int32, x
 }
 
 // PlotPlotPieChartU8PtrV parameter default value hint:
+// label_fmt: "%.1f"
 // angle0: 90
 // flags: 0
-// label_fmt: "%.1f"
 func PlotPlotPieChartU8PtrV(label_ids []string, values *[]byte, count int32, x float64, y float64, radius float64, label_fmt string, angle0 float64, flags PlotPieChartFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	valuesArg := make([]C.ImU8, len(*values))
@@ -4789,9 +4787,9 @@ func PlotPlotPieChartU8PtrV(label_ids []string, values *[]byte, count int32, x f
 }
 
 // PlotPlotPieChartdoublePtrV parameter default value hint:
+// label_fmt: "%.1f"
 // angle0: 90
 // flags: 0
-// label_fmt: "%.1f"
 func PlotPlotPieChartdoublePtrV(label_ids []string, values *[]float64, count int32, x float64, y float64, radius float64, label_fmt string, angle0 float64, flags PlotPieChartFlags) {
 	label_idsArg, label_idsFin := wrapStringList(label_ids)
 	valuesArg := make([]C.double, len(*values))
@@ -4823,11 +4821,11 @@ func PlotPlotScatterFloatPtrFloatPtrV(label_id string, xs []float32, ys []float3
 }
 
 // PlotPlotScatterFloatPtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(float)
-// xscale: 1
-// xstart: 0
 func PlotPlotScatterFloatPtrIntV(label_id string, values []float32, count int32, xscale float64, xstart float64, flags PlotScatterFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	C.ImPlot_PlotScatter_FloatPtrInt(label_idArg, (*C.float)(&(values[0])), C.int(count), C.double(xscale), C.double(xstart), C.ImPlotScatterFlags(flags), C.int(offset), C.int(stride))
@@ -4836,11 +4834,11 @@ func PlotPlotScatterFloatPtrIntV(label_id string, values []float32, count int32,
 }
 
 // PlotPlotScatterS16PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS16)
-// xscale: 1
-// xstart: 0
 func PlotPlotScatterS16PtrIntV(label_id string, values *[]int, count int32, xscale float64, xstart float64, flags PlotScatterFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImS16, len(*values))
@@ -4887,11 +4885,11 @@ func PlotPlotScatterS16PtrS16PtrV(label_id string, xs *[]int, ys *[]int, count i
 }
 
 // PlotPlotScatterS32PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS32)
-// xscale: 1
-// xstart: 0
 func PlotPlotScatterS32PtrIntV(label_id string, values *[]int32, count int32, xscale float64, xstart float64, flags PlotScatterFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImS32, len(*values))
@@ -4938,11 +4936,11 @@ func PlotPlotScatterS32PtrS32PtrV(label_id string, xs *[]int32, ys *[]int32, cou
 }
 
 // PlotPlotScatterS64PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS64)
-// xscale: 1
-// xstart: 0
 func PlotPlotScatterS64PtrIntV(label_id string, values []int64, count int32, xscale float64, xstart float64, flags PlotScatterFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	C.ImPlot_PlotScatter_S64PtrInt(label_idArg, (*C.longlong)(&(values[0])), C.int(count), C.double(xscale), C.double(xstart), C.ImPlotScatterFlags(flags), C.int(offset), C.int(stride))
@@ -4962,11 +4960,11 @@ func PlotPlotScatterS64PtrS64PtrV(label_id string, xs []int64, ys []int64, count
 }
 
 // PlotPlotScatterS8PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS8)
-// xscale: 1
-// xstart: 0
 func PlotPlotScatterS8PtrIntV(label_id string, values *[]int8, count int32, xscale float64, xstart float64, flags PlotScatterFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImS8, len(*values))
@@ -5013,11 +5011,11 @@ func PlotPlotScatterS8PtrS8PtrV(label_id string, xs *[]int8, ys *[]int8, count i
 }
 
 // PlotPlotScatterU16PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU16)
-// xscale: 1
-// xstart: 0
 func PlotPlotScatterU16PtrIntV(label_id string, values *[]uint16, count int32, xscale float64, xstart float64, flags PlotScatterFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImU16, len(*values))
@@ -5064,11 +5062,11 @@ func PlotPlotScatterU16PtrU16PtrV(label_id string, xs *[]uint16, ys *[]uint16, c
 }
 
 // PlotPlotScatterU32PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU32)
-// xscale: 1
-// xstart: 0
 func PlotPlotScatterU32PtrIntV(label_id string, values *[]uint32, count int32, xscale float64, xstart float64, flags PlotScatterFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImU32, len(*values))
@@ -5115,11 +5113,11 @@ func PlotPlotScatterU32PtrU32PtrV(label_id string, xs *[]uint32, ys *[]uint32, c
 }
 
 // PlotPlotScatterU64PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU64)
-// xscale: 1
-// xstart: 0
 func PlotPlotScatterU64PtrIntV(label_id string, values []uint64, count int32, xscale float64, xstart float64, flags PlotScatterFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	C.ImPlot_PlotScatter_U64PtrInt(label_idArg, (*C.ulonglong)(&(values[0])), C.int(count), C.double(xscale), C.double(xstart), C.ImPlotScatterFlags(flags), C.int(offset), C.int(stride))
@@ -5139,11 +5137,11 @@ func PlotPlotScatterU64PtrU64PtrV(label_id string, xs []uint64, ys []uint64, cou
 }
 
 // PlotPlotScatterU8PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU8)
-// xscale: 1
-// xstart: 0
 func PlotPlotScatterU8PtrIntV(label_id string, values *[]byte, count int32, xscale float64, xstart float64, flags PlotScatterFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImU8, len(*values))
@@ -5190,11 +5188,11 @@ func PlotPlotScatterU8PtrU8PtrV(label_id string, xs *[]byte, ys *[]byte, count i
 }
 
 // PlotPlotScatterdoublePtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(double)
-// xscale: 1
-// xstart: 0
 func PlotPlotScatterdoublePtrIntV(label_id string, values *[]float64, count int32, xscale float64, xstart float64, flags PlotScatterFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.double, len(*values))
@@ -5252,10 +5250,10 @@ func PlotPlotShadedFloatPtrFloatPtrFloatPtrV(label_id string, xs []float32, ys1 
 }
 
 // PlotPlotShadedFloatPtrFloatPtrIntV parameter default value hint:
+// yref: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(float)
-// yref: 0
 func PlotPlotShadedFloatPtrFloatPtrIntV(label_id string, xs []float32, ys []float32, count int32, yref float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	C.ImPlot_PlotShaded_FloatPtrFloatPtrInt(label_idArg, (*C.float)(&(xs[0])), (*C.float)(&(ys[0])), C.int(count), C.double(yref), C.ImPlotShadedFlags(flags), C.int(offset), C.int(stride))
@@ -5264,12 +5262,12 @@ func PlotPlotShadedFloatPtrFloatPtrIntV(label_id string, xs []float32, ys []floa
 }
 
 // PlotPlotShadedFloatPtrIntV parameter default value hint:
+// yref: 0
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(float)
-// xscale: 1
-// xstart: 0
-// yref: 0
 func PlotPlotShadedFloatPtrIntV(label_id string, values []float32, count int32, yref float64, xscale float64, xstart float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	C.ImPlot_PlotShaded_FloatPtrInt(label_idArg, (*C.float)(&(values[0])), C.int(count), C.double(yref), C.double(xscale), C.double(xstart), C.ImPlotShadedFlags(flags), C.int(offset), C.int(stride))
@@ -5278,12 +5276,12 @@ func PlotPlotShadedFloatPtrIntV(label_id string, values []float32, count int32, 
 }
 
 // PlotPlotShadedS16PtrIntV parameter default value hint:
+// yref: 0
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS16)
-// xscale: 1
-// xstart: 0
-// yref: 0
 func PlotPlotShadedS16PtrIntV(label_id string, values *[]int, count int32, yref float64, xscale float64, xstart float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImS16, len(*values))
@@ -5301,10 +5299,10 @@ func PlotPlotShadedS16PtrIntV(label_id string, values *[]int, count int32, yref 
 }
 
 // PlotPlotShadedS16PtrS16PtrIntV parameter default value hint:
+// yref: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS16)
-// yref: 0
 func PlotPlotShadedS16PtrS16PtrIntV(label_id string, xs *[]int, ys *[]int, count int32, yref float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	xsArg := make([]C.ImS16, len(*xs))
@@ -5369,12 +5367,12 @@ func PlotPlotShadedS16PtrS16PtrS16PtrV(label_id string, xs *[]int, ys1 *[]int, y
 }
 
 // PlotPlotShadedS32PtrIntV parameter default value hint:
+// yref: 0
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS32)
-// xscale: 1
-// xstart: 0
-// yref: 0
 func PlotPlotShadedS32PtrIntV(label_id string, values *[]int32, count int32, yref float64, xscale float64, xstart float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImS32, len(*values))
@@ -5392,10 +5390,10 @@ func PlotPlotShadedS32PtrIntV(label_id string, values *[]int32, count int32, yre
 }
 
 // PlotPlotShadedS32PtrS32PtrIntV parameter default value hint:
+// yref: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS32)
-// yref: 0
 func PlotPlotShadedS32PtrS32PtrIntV(label_id string, xs *[]int32, ys *[]int32, count int32, yref float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	xsArg := make([]C.ImS32, len(*xs))
@@ -5460,12 +5458,12 @@ func PlotPlotShadedS32PtrS32PtrS32PtrV(label_id string, xs *[]int32, ys1 *[]int3
 }
 
 // PlotPlotShadedS64PtrIntV parameter default value hint:
+// yref: 0
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS64)
-// xscale: 1
-// xstart: 0
-// yref: 0
 func PlotPlotShadedS64PtrIntV(label_id string, values []int64, count int32, yref float64, xscale float64, xstart float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	C.ImPlot_PlotShaded_S64PtrInt(label_idArg, (*C.longlong)(&(values[0])), C.int(count), C.double(yref), C.double(xscale), C.double(xstart), C.ImPlotShadedFlags(flags), C.int(offset), C.int(stride))
@@ -5474,10 +5472,10 @@ func PlotPlotShadedS64PtrIntV(label_id string, values []int64, count int32, yref
 }
 
 // PlotPlotShadedS64PtrS64PtrIntV parameter default value hint:
+// yref: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS64)
-// yref: 0
 func PlotPlotShadedS64PtrS64PtrIntV(label_id string, xs []int64, ys []int64, count int32, yref float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	C.ImPlot_PlotShaded_S64PtrS64PtrInt(label_idArg, (*C.longlong)(&(xs[0])), (*C.longlong)(&(ys[0])), C.int(count), C.double(yref), C.ImPlotShadedFlags(flags), C.int(offset), C.int(stride))
@@ -5497,12 +5495,12 @@ func PlotPlotShadedS64PtrS64PtrS64PtrV(label_id string, xs []int64, ys1 []int64,
 }
 
 // PlotPlotShadedS8PtrIntV parameter default value hint:
+// yref: 0
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS8)
-// xscale: 1
-// xstart: 0
-// yref: 0
 func PlotPlotShadedS8PtrIntV(label_id string, values *[]int8, count int32, yref float64, xscale float64, xstart float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImS8, len(*values))
@@ -5520,10 +5518,10 @@ func PlotPlotShadedS8PtrIntV(label_id string, values *[]int8, count int32, yref 
 }
 
 // PlotPlotShadedS8PtrS8PtrIntV parameter default value hint:
+// yref: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS8)
-// yref: 0
 func PlotPlotShadedS8PtrS8PtrIntV(label_id string, xs *[]int8, ys *[]int8, count int32, yref float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	xsArg := make([]C.ImS8, len(*xs))
@@ -5588,12 +5586,12 @@ func PlotPlotShadedS8PtrS8PtrS8PtrV(label_id string, xs *[]int8, ys1 *[]int8, ys
 }
 
 // PlotPlotShadedU16PtrIntV parameter default value hint:
+// yref: 0
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU16)
-// xscale: 1
-// xstart: 0
-// yref: 0
 func PlotPlotShadedU16PtrIntV(label_id string, values *[]uint16, count int32, yref float64, xscale float64, xstart float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImU16, len(*values))
@@ -5611,10 +5609,10 @@ func PlotPlotShadedU16PtrIntV(label_id string, values *[]uint16, count int32, yr
 }
 
 // PlotPlotShadedU16PtrU16PtrIntV parameter default value hint:
+// yref: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU16)
-// yref: 0
 func PlotPlotShadedU16PtrU16PtrIntV(label_id string, xs *[]uint16, ys *[]uint16, count int32, yref float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	xsArg := make([]C.ImU16, len(*xs))
@@ -5679,12 +5677,12 @@ func PlotPlotShadedU16PtrU16PtrU16PtrV(label_id string, xs *[]uint16, ys1 *[]uin
 }
 
 // PlotPlotShadedU32PtrIntV parameter default value hint:
+// yref: 0
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU32)
-// xscale: 1
-// xstart: 0
-// yref: 0
 func PlotPlotShadedU32PtrIntV(label_id string, values *[]uint32, count int32, yref float64, xscale float64, xstart float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImU32, len(*values))
@@ -5702,10 +5700,10 @@ func PlotPlotShadedU32PtrIntV(label_id string, values *[]uint32, count int32, yr
 }
 
 // PlotPlotShadedU32PtrU32PtrIntV parameter default value hint:
+// yref: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU32)
-// yref: 0
 func PlotPlotShadedU32PtrU32PtrIntV(label_id string, xs *[]uint32, ys *[]uint32, count int32, yref float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	xsArg := make([]C.ImU32, len(*xs))
@@ -5770,12 +5768,12 @@ func PlotPlotShadedU32PtrU32PtrU32PtrV(label_id string, xs *[]uint32, ys1 *[]uin
 }
 
 // PlotPlotShadedU64PtrIntV parameter default value hint:
+// yref: 0
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU64)
-// xscale: 1
-// xstart: 0
-// yref: 0
 func PlotPlotShadedU64PtrIntV(label_id string, values []uint64, count int32, yref float64, xscale float64, xstart float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	C.ImPlot_PlotShaded_U64PtrInt(label_idArg, (*C.ulonglong)(&(values[0])), C.int(count), C.double(yref), C.double(xscale), C.double(xstart), C.ImPlotShadedFlags(flags), C.int(offset), C.int(stride))
@@ -5784,10 +5782,10 @@ func PlotPlotShadedU64PtrIntV(label_id string, values []uint64, count int32, yre
 }
 
 // PlotPlotShadedU64PtrU64PtrIntV parameter default value hint:
+// yref: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU64)
-// yref: 0
 func PlotPlotShadedU64PtrU64PtrIntV(label_id string, xs []uint64, ys []uint64, count int32, yref float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	C.ImPlot_PlotShaded_U64PtrU64PtrInt(label_idArg, (*C.ulonglong)(&(xs[0])), (*C.ulonglong)(&(ys[0])), C.int(count), C.double(yref), C.ImPlotShadedFlags(flags), C.int(offset), C.int(stride))
@@ -5807,12 +5805,12 @@ func PlotPlotShadedU64PtrU64PtrU64PtrV(label_id string, xs []uint64, ys1 []uint6
 }
 
 // PlotPlotShadedU8PtrIntV parameter default value hint:
+// yref: 0
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU8)
-// xscale: 1
-// xstart: 0
-// yref: 0
 func PlotPlotShadedU8PtrIntV(label_id string, values *[]byte, count int32, yref float64, xscale float64, xstart float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImU8, len(*values))
@@ -5830,10 +5828,10 @@ func PlotPlotShadedU8PtrIntV(label_id string, values *[]byte, count int32, yref 
 }
 
 // PlotPlotShadedU8PtrU8PtrIntV parameter default value hint:
+// yref: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU8)
-// yref: 0
 func PlotPlotShadedU8PtrU8PtrIntV(label_id string, xs *[]byte, ys *[]byte, count int32, yref float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	xsArg := make([]C.ImU8, len(*xs))
@@ -5898,12 +5896,12 @@ func PlotPlotShadedU8PtrU8PtrU8PtrV(label_id string, xs *[]byte, ys1 *[]byte, ys
 }
 
 // PlotPlotShadeddoublePtrIntV parameter default value hint:
+// yref: 0
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(double)
-// xscale: 1
-// xstart: 0
-// yref: 0
 func PlotPlotShadeddoublePtrIntV(label_id string, values *[]float64, count int32, yref float64, xscale float64, xstart float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.double, len(*values))
@@ -5921,10 +5919,10 @@ func PlotPlotShadeddoublePtrIntV(label_id string, values *[]float64, count int32
 }
 
 // PlotPlotShadeddoublePtrdoublePtrIntV parameter default value hint:
+// yref: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(double)
-// yref: 0
 func PlotPlotShadeddoublePtrdoublePtrIntV(label_id string, xs *[]float64, ys *[]float64, count int32, yref float64, flags PlotShadedFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	xsArg := make([]C.double, len(*xs))
@@ -6000,11 +5998,11 @@ func PlotPlotStairsFloatPtrFloatPtrV(label_id string, xs []float32, ys []float32
 }
 
 // PlotPlotStairsFloatPtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(float)
-// xscale: 1
-// xstart: 0
 func PlotPlotStairsFloatPtrIntV(label_id string, values []float32, count int32, xscale float64, xstart float64, flags PlotStairsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	C.ImPlot_PlotStairs_FloatPtrInt(label_idArg, (*C.float)(&(values[0])), C.int(count), C.double(xscale), C.double(xstart), C.ImPlotStairsFlags(flags), C.int(offset), C.int(stride))
@@ -6013,11 +6011,11 @@ func PlotPlotStairsFloatPtrIntV(label_id string, values []float32, count int32, 
 }
 
 // PlotPlotStairsS16PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS16)
-// xscale: 1
-// xstart: 0
 func PlotPlotStairsS16PtrIntV(label_id string, values *[]int, count int32, xscale float64, xstart float64, flags PlotStairsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImS16, len(*values))
@@ -6064,11 +6062,11 @@ func PlotPlotStairsS16PtrS16PtrV(label_id string, xs *[]int, ys *[]int, count in
 }
 
 // PlotPlotStairsS32PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS32)
-// xscale: 1
-// xstart: 0
 func PlotPlotStairsS32PtrIntV(label_id string, values *[]int32, count int32, xscale float64, xstart float64, flags PlotStairsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImS32, len(*values))
@@ -6115,11 +6113,11 @@ func PlotPlotStairsS32PtrS32PtrV(label_id string, xs *[]int32, ys *[]int32, coun
 }
 
 // PlotPlotStairsS64PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS64)
-// xscale: 1
-// xstart: 0
 func PlotPlotStairsS64PtrIntV(label_id string, values []int64, count int32, xscale float64, xstart float64, flags PlotStairsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	C.ImPlot_PlotStairs_S64PtrInt(label_idArg, (*C.longlong)(&(values[0])), C.int(count), C.double(xscale), C.double(xstart), C.ImPlotStairsFlags(flags), C.int(offset), C.int(stride))
@@ -6139,11 +6137,11 @@ func PlotPlotStairsS64PtrS64PtrV(label_id string, xs []int64, ys []int64, count 
 }
 
 // PlotPlotStairsS8PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImS8)
-// xscale: 1
-// xstart: 0
 func PlotPlotStairsS8PtrIntV(label_id string, values *[]int8, count int32, xscale float64, xstart float64, flags PlotStairsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImS8, len(*values))
@@ -6190,11 +6188,11 @@ func PlotPlotStairsS8PtrS8PtrV(label_id string, xs *[]int8, ys *[]int8, count in
 }
 
 // PlotPlotStairsU16PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU16)
-// xscale: 1
-// xstart: 0
 func PlotPlotStairsU16PtrIntV(label_id string, values *[]uint16, count int32, xscale float64, xstart float64, flags PlotStairsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImU16, len(*values))
@@ -6241,11 +6239,11 @@ func PlotPlotStairsU16PtrU16PtrV(label_id string, xs *[]uint16, ys *[]uint16, co
 }
 
 // PlotPlotStairsU32PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU32)
-// xscale: 1
-// xstart: 0
 func PlotPlotStairsU32PtrIntV(label_id string, values *[]uint32, count int32, xscale float64, xstart float64, flags PlotStairsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImU32, len(*values))
@@ -6292,11 +6290,11 @@ func PlotPlotStairsU32PtrU32PtrV(label_id string, xs *[]uint32, ys *[]uint32, co
 }
 
 // PlotPlotStairsU64PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU64)
-// xscale: 1
-// xstart: 0
 func PlotPlotStairsU64PtrIntV(label_id string, values []uint64, count int32, xscale float64, xstart float64, flags PlotStairsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	C.ImPlot_PlotStairs_U64PtrInt(label_idArg, (*C.ulonglong)(&(values[0])), C.int(count), C.double(xscale), C.double(xstart), C.ImPlotStairsFlags(flags), C.int(offset), C.int(stride))
@@ -6316,11 +6314,11 @@ func PlotPlotStairsU64PtrU64PtrV(label_id string, xs []uint64, ys []uint64, coun
 }
 
 // PlotPlotStairsU8PtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(ImU8)
-// xscale: 1
-// xstart: 0
 func PlotPlotStairsU8PtrIntV(label_id string, values *[]byte, count int32, xscale float64, xstart float64, flags PlotStairsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.ImU8, len(*values))
@@ -6367,11 +6365,11 @@ func PlotPlotStairsU8PtrU8PtrV(label_id string, xs *[]byte, ys *[]byte, count in
 }
 
 // PlotPlotStairsdoublePtrIntV parameter default value hint:
+// xscale: 1
+// xstart: 0
 // flags: 0
 // offset: 0
 // stride: sizeof(double)
-// xscale: 1
-// xstart: 0
 func PlotPlotStairsdoublePtrIntV(label_id string, values *[]float64, count int32, xscale float64, xstart float64, flags PlotStairsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
 	valuesArg := make([]C.double, len(*values))
@@ -6418,9 +6416,9 @@ func PlotPlotStairsdoublePtrdoublePtrV(label_id string, xs *[]float64, ys *[]flo
 }
 
 // PlotPlotStemsFloatPtrFloatPtrV parameter default value hint:
+// ref: 0
 // flags: 0
 // offset: 0
-// ref: 0
 // stride: sizeof(float)
 func PlotPlotStemsFloatPtrFloatPtrV(label_id string, xs []float32, ys []float32, count int32, ref float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6430,11 +6428,11 @@ func PlotPlotStemsFloatPtrFloatPtrV(label_id string, xs []float32, ys []float32,
 }
 
 // PlotPlotStemsFloatPtrIntV parameter default value hint:
-// flags: 0
-// offset: 0
 // ref: 0
 // scale: 1
 // start: 0
+// flags: 0
+// offset: 0
 // stride: sizeof(float)
 func PlotPlotStemsFloatPtrIntV(label_id string, values []float32, count int32, ref float64, scale float64, start float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6444,11 +6442,11 @@ func PlotPlotStemsFloatPtrIntV(label_id string, values []float32, count int32, r
 }
 
 // PlotPlotStemsS16PtrIntV parameter default value hint:
-// flags: 0
-// offset: 0
 // ref: 0
 // scale: 1
 // start: 0
+// flags: 0
+// offset: 0
 // stride: sizeof(ImS16)
 func PlotPlotStemsS16PtrIntV(label_id string, values *[]int, count int32, ref float64, scale float64, start float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6467,9 +6465,9 @@ func PlotPlotStemsS16PtrIntV(label_id string, values *[]int, count int32, ref fl
 }
 
 // PlotPlotStemsS16PtrS16PtrV parameter default value hint:
+// ref: 0
 // flags: 0
 // offset: 0
-// ref: 0
 // stride: sizeof(ImS16)
 func PlotPlotStemsS16PtrS16PtrV(label_id string, xs *[]int, ys *[]int, count int32, ref float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6497,11 +6495,11 @@ func PlotPlotStemsS16PtrS16PtrV(label_id string, xs *[]int, ys *[]int, count int
 }
 
 // PlotPlotStemsS32PtrIntV parameter default value hint:
-// flags: 0
-// offset: 0
 // ref: 0
 // scale: 1
 // start: 0
+// flags: 0
+// offset: 0
 // stride: sizeof(ImS32)
 func PlotPlotStemsS32PtrIntV(label_id string, values *[]int32, count int32, ref float64, scale float64, start float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6520,9 +6518,9 @@ func PlotPlotStemsS32PtrIntV(label_id string, values *[]int32, count int32, ref 
 }
 
 // PlotPlotStemsS32PtrS32PtrV parameter default value hint:
+// ref: 0
 // flags: 0
 // offset: 0
-// ref: 0
 // stride: sizeof(ImS32)
 func PlotPlotStemsS32PtrS32PtrV(label_id string, xs *[]int32, ys *[]int32, count int32, ref float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6550,11 +6548,11 @@ func PlotPlotStemsS32PtrS32PtrV(label_id string, xs *[]int32, ys *[]int32, count
 }
 
 // PlotPlotStemsS64PtrIntV parameter default value hint:
-// flags: 0
-// offset: 0
 // ref: 0
 // scale: 1
 // start: 0
+// flags: 0
+// offset: 0
 // stride: sizeof(ImS64)
 func PlotPlotStemsS64PtrIntV(label_id string, values []int64, count int32, ref float64, scale float64, start float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6564,9 +6562,9 @@ func PlotPlotStemsS64PtrIntV(label_id string, values []int64, count int32, ref f
 }
 
 // PlotPlotStemsS64PtrS64PtrV parameter default value hint:
+// ref: 0
 // flags: 0
 // offset: 0
-// ref: 0
 // stride: sizeof(ImS64)
 func PlotPlotStemsS64PtrS64PtrV(label_id string, xs []int64, ys []int64, count int32, ref float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6576,11 +6574,11 @@ func PlotPlotStemsS64PtrS64PtrV(label_id string, xs []int64, ys []int64, count i
 }
 
 // PlotPlotStemsS8PtrIntV parameter default value hint:
-// flags: 0
-// offset: 0
 // ref: 0
 // scale: 1
 // start: 0
+// flags: 0
+// offset: 0
 // stride: sizeof(ImS8)
 func PlotPlotStemsS8PtrIntV(label_id string, values *[]int8, count int32, ref float64, scale float64, start float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6599,9 +6597,9 @@ func PlotPlotStemsS8PtrIntV(label_id string, values *[]int8, count int32, ref fl
 }
 
 // PlotPlotStemsS8PtrS8PtrV parameter default value hint:
+// ref: 0
 // flags: 0
 // offset: 0
-// ref: 0
 // stride: sizeof(ImS8)
 func PlotPlotStemsS8PtrS8PtrV(label_id string, xs *[]int8, ys *[]int8, count int32, ref float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6629,11 +6627,11 @@ func PlotPlotStemsS8PtrS8PtrV(label_id string, xs *[]int8, ys *[]int8, count int
 }
 
 // PlotPlotStemsU16PtrIntV parameter default value hint:
-// flags: 0
-// offset: 0
 // ref: 0
 // scale: 1
 // start: 0
+// flags: 0
+// offset: 0
 // stride: sizeof(ImU16)
 func PlotPlotStemsU16PtrIntV(label_id string, values *[]uint16, count int32, ref float64, scale float64, start float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6652,9 +6650,9 @@ func PlotPlotStemsU16PtrIntV(label_id string, values *[]uint16, count int32, ref
 }
 
 // PlotPlotStemsU16PtrU16PtrV parameter default value hint:
+// ref: 0
 // flags: 0
 // offset: 0
-// ref: 0
 // stride: sizeof(ImU16)
 func PlotPlotStemsU16PtrU16PtrV(label_id string, xs *[]uint16, ys *[]uint16, count int32, ref float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6682,11 +6680,11 @@ func PlotPlotStemsU16PtrU16PtrV(label_id string, xs *[]uint16, ys *[]uint16, cou
 }
 
 // PlotPlotStemsU32PtrIntV parameter default value hint:
-// flags: 0
-// offset: 0
 // ref: 0
 // scale: 1
 // start: 0
+// flags: 0
+// offset: 0
 // stride: sizeof(ImU32)
 func PlotPlotStemsU32PtrIntV(label_id string, values *[]uint32, count int32, ref float64, scale float64, start float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6705,9 +6703,9 @@ func PlotPlotStemsU32PtrIntV(label_id string, values *[]uint32, count int32, ref
 }
 
 // PlotPlotStemsU32PtrU32PtrV parameter default value hint:
+// ref: 0
 // flags: 0
 // offset: 0
-// ref: 0
 // stride: sizeof(ImU32)
 func PlotPlotStemsU32PtrU32PtrV(label_id string, xs *[]uint32, ys *[]uint32, count int32, ref float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6735,11 +6733,11 @@ func PlotPlotStemsU32PtrU32PtrV(label_id string, xs *[]uint32, ys *[]uint32, cou
 }
 
 // PlotPlotStemsU64PtrIntV parameter default value hint:
-// flags: 0
-// offset: 0
 // ref: 0
 // scale: 1
 // start: 0
+// flags: 0
+// offset: 0
 // stride: sizeof(ImU64)
 func PlotPlotStemsU64PtrIntV(label_id string, values []uint64, count int32, ref float64, scale float64, start float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6749,9 +6747,9 @@ func PlotPlotStemsU64PtrIntV(label_id string, values []uint64, count int32, ref 
 }
 
 // PlotPlotStemsU64PtrU64PtrV parameter default value hint:
+// ref: 0
 // flags: 0
 // offset: 0
-// ref: 0
 // stride: sizeof(ImU64)
 func PlotPlotStemsU64PtrU64PtrV(label_id string, xs []uint64, ys []uint64, count int32, ref float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6761,11 +6759,11 @@ func PlotPlotStemsU64PtrU64PtrV(label_id string, xs []uint64, ys []uint64, count
 }
 
 // PlotPlotStemsU8PtrIntV parameter default value hint:
-// flags: 0
-// offset: 0
 // ref: 0
 // scale: 1
 // start: 0
+// flags: 0
+// offset: 0
 // stride: sizeof(ImU8)
 func PlotPlotStemsU8PtrIntV(label_id string, values *[]byte, count int32, ref float64, scale float64, start float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6784,9 +6782,9 @@ func PlotPlotStemsU8PtrIntV(label_id string, values *[]byte, count int32, ref fl
 }
 
 // PlotPlotStemsU8PtrU8PtrV parameter default value hint:
+// ref: 0
 // flags: 0
 // offset: 0
-// ref: 0
 // stride: sizeof(ImU8)
 func PlotPlotStemsU8PtrU8PtrV(label_id string, xs *[]byte, ys *[]byte, count int32, ref float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6814,11 +6812,11 @@ func PlotPlotStemsU8PtrU8PtrV(label_id string, xs *[]byte, ys *[]byte, count int
 }
 
 // PlotPlotStemsdoublePtrIntV parameter default value hint:
-// flags: 0
-// offset: 0
 // ref: 0
 // scale: 1
 // start: 0
+// flags: 0
+// offset: 0
 // stride: sizeof(double)
 func PlotPlotStemsdoublePtrIntV(label_id string, values *[]float64, count int32, ref float64, scale float64, start float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6837,9 +6835,9 @@ func PlotPlotStemsdoublePtrIntV(label_id string, values *[]float64, count int32,
 }
 
 // PlotPlotStemsdoublePtrdoublePtrV parameter default value hint:
+// ref: 0
 // flags: 0
 // offset: 0
-// ref: 0
 // stride: sizeof(double)
 func PlotPlotStemsdoublePtrdoublePtrV(label_id string, xs *[]float64, ys *[]float64, count int32, ref float64, flags PlotStemsFlags, offset int32, stride int32) {
 	label_idArg, label_idFin := wrapString(label_id)
@@ -6867,8 +6865,8 @@ func PlotPlotStemsdoublePtrdoublePtrV(label_id string, xs *[]float64, ys *[]floa
 }
 
 // PlotPlotTextV parameter default value hint:
-// flags: 0
 // pix_offset: ImVec2(0,0)
+// flags: 0
 func PlotPlotTextV(text string, x float64, y float64, pix_offset Vec2, flags PlotTextFlags) {
 	textArg, textFin := wrapString(text)
 	C.ImPlot_PlotText(textArg, C.double(x), C.double(y), pix_offset.toC(), C.ImPlotTextFlags(flags))
@@ -7091,8 +7089,8 @@ func PlotSetNextErrorBarStyleV(col Vec4, size float32, weight float32) {
 }
 
 // PlotSetNextFillStyleV parameter default value hint:
-// alpha_mod: -1
 // col: ImVec4(0,0,0,-1)
+// alpha_mod: -1
 func PlotSetNextFillStyleV(col Vec4, alpha_mod float32) {
 	C.ImPlot_SetNextFillStyle(col.toC(), C.float(alpha_mod))
 }
@@ -7105,11 +7103,11 @@ func PlotSetNextLineStyleV(col Vec4, weight float32) {
 }
 
 // PlotSetNextMarkerStyleV parameter default value hint:
-// fill: ImVec4(0,0,0,-1)
 // marker: -1
-// outline: ImVec4(0,0,0,-1)
 // size: -1
+// fill: ImVec4(0,0,0,-1)
 // weight: -1
+// outline: ImVec4(0,0,0,-1)
 func PlotSetNextMarkerStyleV(marker PlotMarker, size float32, fill Vec4, weight float32, outline Vec4) {
 	C.ImPlot_SetNextMarkerStyle(C.ImPlotMarker(marker), C.float(size), fill.toC(), C.float(weight), outline.toC())
 }
@@ -7133,8 +7131,8 @@ func PlotSetupAxesLimitsV(x_min float64, x_max float64, y_min float64, y_max flo
 }
 
 // PlotSetupAxisV parameter default value hint:
-// flags: 0
 // label: NULL
+// flags: 0
 func PlotSetupAxisV(axis PlotAxisEnum, label string, flags PlotAxisFlags) {
 	labelArg, labelFin := wrapString(label)
 	C.ImPlot_SetupAxis(C.ImAxis(axis), labelArg, C.ImPlotAxisFlags(flags))
@@ -7173,8 +7171,8 @@ func PlotSetupAxisScalePlotScale(axis PlotAxisEnum, scale PlotScale) {
 }
 
 // PlotSetupAxisTicksdoubleV parameter default value hint:
-// keep_default: false
 // labels: NULL
+// keep_default: false
 func PlotSetupAxisTicksdoubleV(axis PlotAxisEnum, v_min float64, v_max float64, n_ticks int32, labels []string, keep_default bool) {
 	labelsArg, labelsFin := wrapStringList(labels)
 	C.ImPlot_SetupAxisTicks_double(C.ImAxis(axis), C.double(v_min), C.double(v_max), C.int(n_ticks), labelsArg, C.bool(keep_default))
@@ -7183,8 +7181,8 @@ func PlotSetupAxisTicksdoubleV(axis PlotAxisEnum, v_min float64, v_max float64, 
 }
 
 // PlotSetupAxisTicksdoublePtrV parameter default value hint:
-// keep_default: false
 // labels: NULL
+// keep_default: false
 func PlotSetupAxisTicksdoublePtrV(axis PlotAxisEnum, values *[]float64, n_ticks int32, labels []string, keep_default bool) {
 	valuesArg := make([]C.double, len(*values))
 	for i, valuesV := range *values {
@@ -7226,9 +7224,9 @@ func PlotSetupMouseTextV(location PlotLocation, flags PlotMouseTextFlags) {
 }
 
 // PlotShowAltLegendV parameter default value hint:
-// interactable: true
-// size: ImVec2(0,0)
 // vertical: true
+// size: ImVec2(0,0)
+// interactable: true
 func PlotShowAltLegendV(title_id string, vertical bool, size Vec2, interactable bool) {
 	title_idArg, title_idFin := wrapString(title_id)
 	C.ImPlot_ShowAltLegend(title_idArg, C.bool(vertical), size.toC(), C.bool(interactable))


### PR DESCRIPTION
This makes it much easier to figure out what the default hints are for functions with many parameters.

It feels a bit hacking to split the arg after space to the get name. A better solution might be to change args from a `[]string` to a `[]Arg` type which contains both name and type. But that's a bigger design change