### PR TITLE
Codegen: remove Im* prefix restriction on structs

### DIFF
--- a/cimgui_funcs.go
+++ b/cimgui_funcs.go
@@ -13632,6 +13632,14 @@ func (self InputTextState) ScrollX() float32 {
 	return float32(C.wrap_ImGuiInputTextState_GetScrollX(self.handle()))
 }
 
+func (self InputTextState) SetStb(v STBTexteditState) {
+	C.wrap_ImGuiInputTextState_SetStb(self.handle(), v.c())
+}
+
+func (self InputTextState) Stb() STBTexteditState {
+	return newSTBTexteditStateFromC(C.wrap_ImGuiInputTextState_GetStb(self.handle()))
+}
+
 func (self InputTextState) SetCursorAnim(v float32) {
 	C.wrap_ImGuiInputTextState_SetCursorAnim(self.handle(), C.float(v))
 }
@@ -18891,4 +18899,84 @@ func (self WindowTempData) SetTextWrapPos(v float32) {
 
 func (self WindowTempData) TextWrapPos() float32 {
 	return float32(C.wrap_ImGuiWindowTempData_GetTextWrapPos(self.handle()))
+}
+
+func (self STBTexteditState) TexteditStateGetcursor() int {
+	return int(C.wrap_STB_TexteditState_Getcursor(self.handle()))
+}
+
+func (self STBTexteditState) TexteditStateGetselectstart() int {
+	return int(C.wrap_STB_TexteditState_Getselect_start(self.handle()))
+}
+
+func (self STBTexteditState) TexteditStateGetselectend() int {
+	return int(C.wrap_STB_TexteditState_Getselect_end(self.handle()))
+}
+
+func (self STBTexteditState) TexteditStateGetrowcountperpage() int {
+	return int(C.wrap_STB_TexteditState_Getrow_count_per_page(self.handle()))
+}
+
+func (self STBTexteditState) TexteditStateGetpreferredx() float32 {
+	return float32(C.wrap_STB_TexteditState_Getpreferred_x(self.handle()))
+}
+
+func (self STBTexteditState) TexteditStateGetundostate() StbUndoState {
+	return newStbUndoStateFromC(C.wrap_STB_TexteditState_Getundostate(self.handle()))
+}
+
+func (self StbTexteditRow) x0() float32 {
+	return float32(C.wrap_StbTexteditRow_Getx0(self.handle()))
+}
+
+func (self StbTexteditRow) x1() float32 {
+	return float32(C.wrap_StbTexteditRow_Getx1(self.handle()))
+}
+
+func (self StbTexteditRow) baselineydelta() float32 {
+	return float32(C.wrap_StbTexteditRow_Getbaseline_y_delta(self.handle()))
+}
+
+func (self StbTexteditRow) ymin() float32 {
+	return float32(C.wrap_StbTexteditRow_Getymin(self.handle()))
+}
+
+func (self StbTexteditRow) ymax() float32 {
+	return float32(C.wrap_StbTexteditRow_Getymax(self.handle()))
+}
+
+func (self StbTexteditRow) numchars() int {
+	return int(C.wrap_StbTexteditRow_Getnum_chars(self.handle()))
+}
+
+func (self StbUndoRecord) where() int {
+	return int(C.wrap_StbUndoRecord_Getwhere(self.handle()))
+}
+
+func (self StbUndoRecord) insertlength() int {
+	return int(C.wrap_StbUndoRecord_Getinsert_length(self.handle()))
+}
+
+func (self StbUndoRecord) deletelength() int {
+	return int(C.wrap_StbUndoRecord_Getdelete_length(self.handle()))
+}
+
+func (self StbUndoRecord) charstorage() int {
+	return int(C.wrap_StbUndoRecord_Getchar_storage(self.handle()))
+}
+
+func (self StbUndoState) undopoint() int {
+	return int(C.wrap_StbUndoState_Getundo_point(self.handle()))
+}
+
+func (self StbUndoState) redopoint() int {
+	return int(C.wrap_StbUndoState_Getredo_point(self.handle()))
+}
+
+func (self StbUndoState) undocharpoint() int {
+	return int(C.wrap_StbUndoState_Getundo_char_point(self.handle()))
+}
+
+func (self StbUndoState) redocharpoint() int {
+	return int(C.wrap_StbUndoState_Getredo_char_point(self.handle()))
 }

--- a/cimgui_structs.go
+++ b/cimgui_structs.go
@@ -1336,3 +1336,59 @@ func (data WindowTempData) c() C.ImGuiWindowTempData {
 func newWindowTempDataFromC(cvalue C.ImGuiWindowTempData) WindowTempData {
 	return WindowTempData(unsafe.Pointer(&cvalue))
 }
+
+type STBTexteditState uintptr
+
+func (data STBTexteditState) handle() *C.STB_TexteditState {
+	return (*C.STB_TexteditState)(unsafe.Pointer(data))
+}
+
+func (data STBTexteditState) c() C.STB_TexteditState {
+	return *(data.handle())
+}
+
+func newSTBTexteditStateFromC(cvalue C.STB_TexteditState) STBTexteditState {
+	return STBTexteditState(unsafe.Pointer(&cvalue))
+}
+
+type StbTexteditRow uintptr
+
+func (data StbTexteditRow) handle() *C.StbTexteditRow {
+	return (*C.StbTexteditRow)(unsafe.Pointer(data))
+}
+
+func (data StbTexteditRow) c() C.StbTexteditRow {
+	return *(data.handle())
+}
+
+func newStbTexteditRowFromC(cvalue C.StbTexteditRow) StbTexteditRow {
+	return StbTexteditRow(unsafe.Pointer(&cvalue))
+}
+
+type StbUndoRecord uintptr
+
+func (data StbUndoRecord) handle() *C.StbUndoRecord {
+	return (*C.StbUndoRecord)(unsafe.Pointer(data))
+}
+
+func (data StbUndoRecord) c() C.StbUndoRecord {
+	return *(data.handle())
+}
+
+func newStbUndoRecordFromC(cvalue C.StbUndoRecord) StbUndoRecord {
+	return StbUndoRecord(unsafe.Pointer(&cvalue))
+}
+
+type StbUndoState uintptr
+
+func (data StbUndoState) handle() *C.StbUndoState {
+	return (*C.StbUndoState)(unsafe.Pointer(data))
+}
+
+func (data StbUndoState) c() C.StbUndoState {
+	return *(data.handle())
+}
+
+func newStbUndoStateFromC(cvalue C.StbUndoState) StbUndoState {
+	return StbUndoState(unsafe.Pointer(&cvalue))
+}

--- a/cimplot_funcs.go
+++ b/cimplot_funcs.go
@@ -12427,6 +12427,20 @@ func PlotTagYBool(y float64, col Vec4) {
 	C.wrap_ImPlot_TagY_Bool(C.double(y), col.toC())
 }
 
+func (self FormatterTimeData) TimeDataGetTime() PlotTime {
+	out := &PlotTime{}
+	out.fromC(C.wrap_Formatter_Time_Data_GetTime(self.handle()))
+	return *out
+}
+
+func (self FormatterTimeData) TimeDataGetSpec() PlotDateTimeSpec {
+	return newPlotDateTimeSpecFromC(C.wrap_Formatter_Time_Data_GetSpec(self.handle()))
+}
+
+func (self FormatterTimeData) TimeDataGetUserFormatterData() unsafe.Pointer {
+	return unsafe.Pointer(C.wrap_Formatter_Time_Data_GetUserFormatterData(self.handle()))
+}
+
 func (self PlotAlignmentData) SetVertical(v bool) {
 	C.wrap_ImPlotAlignmentData_SetVertical(self.handle(), C.bool(v))
 }

--- a/cimplot_structs.go
+++ b/cimplot_structs.go
@@ -7,6 +7,20 @@ package imgui
 import "C"
 import "unsafe"
 
+type FormatterTimeData uintptr
+
+func (data FormatterTimeData) handle() *C.Formatter_Time_Data {
+	return (*C.Formatter_Time_Data)(unsafe.Pointer(data))
+}
+
+func (data FormatterTimeData) c() C.Formatter_Time_Data {
+	return *(data.handle())
+}
+
+func newFormatterTimeDataFromC(cvalue C.Formatter_Time_Data) FormatterTimeData {
+	return FormatterTimeData(unsafe.Pointer(&cvalue))
+}
+
 type PlotAlignmentData uintptr
 
 func (data PlotAlignmentData) handle() *C.ImPlotAlignmentData {

--- a/cmd/codegen/structures_deffinition.go
+++ b/cmd/codegen/structures_deffinition.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"strings"
 )
 
 // StructSection appears in json file on top of structs definition section.
@@ -77,10 +76,6 @@ func shouldSkipStruct(name string) bool {
 		"ImColor":     true,
 		"ImPlotPoint": true,
 		"ImPlotTime":  true,
-	}
-
-	if !strings.HasPrefix(name, "Im") {
-		return true
 	}
 
 	// Skip all value type struct


### PR DESCRIPTION
Idk why was that restriction there, but after removing it, much more function is generated