### PR TITLE
fix issues/163 : call C.free on a GO pointer - not C pointer that cause a panic

### DIFF
--- a/type_wrapper.go
+++ b/type_wrapper.go
@@ -72,7 +72,6 @@ func wrapStringList(value []string) (wrapped **C.char, finisher func()) {
 	wrapped = (**C.char)(unsafe.Pointer(&wrappedList[0]))
 
 	finisher = func() {
-		C.free(unsafe.Pointer(wrapped))
 		for _, v := range wrappedList {
 			C.free(unsafe.Pointer(v))
 		}


### PR DESCRIPTION
eg:
running on windows:
imgui.PlotPlotPieChartFloatPtrV cause window closed without any exception and stack dump


