### PR TITLE
codegen: introduce helper types to clearify code

### DIFF
--- a/cmd/codegen/enum_deffinition.go
+++ b/cmd/codegen/enum_deffinition.go
@@ -14,16 +14,16 @@ type EnumsSection struct {
 
 // EnumDef represents a definition of an ImGui enum (like flags).
 type EnumDef struct {
-	Name         string
+	Name         CIdentifier
 	CommentAbove string
 	Values       []EnumValueDef
 }
 
 // EnumValueDef represents a definition of an ImGui enum value.
 type EnumValueDef struct {
-	Name    string `json:"name"`
-	Value   int    `json:"calc_value"`
-	Comment string `json:"comment"`
+	Name    CIdentifier `json:"name"`
+	Value   int         `json:"calc_value"`
+	Comment string      `json:"comment"`
 }
 
 type CommentDef struct {
@@ -63,7 +63,7 @@ func getEnumDefs(enumJsonBytes []byte) ([]EnumDef, error) {
 		}
 
 		enum := EnumDef{
-			Name:   k,
+			Name:   CIdentifier(k),
 			Values: enumValues,
 		}
 

--- a/cmd/codegen/function_deffiniton.go
+++ b/cmd/codegen/function_deffiniton.go
@@ -9,9 +9,9 @@ import (
 // FuncDef represents a definition of a function in cimgui's json format
 type FuncDef struct {
 	// FuncName is a cimgui name of the function
-	FuncName string `json:"ov_cimguiname"`
+	FuncName CIdentifier `json:"ov_cimguiname"`
 	// FuncName is an original Dear ImGui's name of the function
-	OriginalFuncName string `json:"original_func_name"`
+	OriginalFuncName CIdentifier `json:"original_func_name"`
 	// Args represents a plain string list of function arguments
 	Args string `json:"args"`
 	// ArgsT represents a more accurate list of arg:type list
@@ -32,8 +32,8 @@ type FuncDef struct {
 	InvocationStmt string `json:"invocation_stmt"`
 
 	// Ret determines a type of returned value
-	Ret    string `json:"ret"`
-	StName string `json:"stname"`
+	Ret    CIdentifier `json:"ret"`
+	StName string      `json:"stname"`
 
 	// NonUDT is != 0 whenever the function has a pointer argument
 	// that could be considered as its result.
@@ -43,19 +43,19 @@ type FuncDef struct {
 
 	// The names could collide between cimgui and the function generated
 	// here, so we may need to add a prefix.
-	CWrapperFuncName string
+	CWrapperFuncName CIdentifier
 
 	// AllCallArgs is used to determine if a wrapper is needed: if the cimgui
 	// function takes the exact same arguments as the wrapper, the wrapper is
 	// not needed.
-	AllCallArgs string
+	AllCallArgs CIdentifier
 }
 
 // ArgDef represents a deffinition of function's argument
 type ArgDef struct {
-	Name       string `json:"name"`
-	Type       string `json:"type"`
-	CustomType string `json:"custom_type"`
+	Name       CIdentifier `json:"name"`
+	Type       CIdentifier `json:"type"`
+	CustomType CIdentifier `json:"custom_type"`
 }
 
 // getFunDefs takes a json file bytes as an argument and returns

--- a/cmd/codegen/gengo.go
+++ b/cmd/codegen/gengo.go
@@ -53,17 +53,16 @@ var replace = map[CIdentifier]GoIdentifier{
 	//"ImSetDrawCursor":         "SetCursor",
 }
 
-func trimImGuiPrefix(n CIdentifier) CIdentifier {
-	tmpName := string(n)
-	if strings.HasPrefix(tmpName, "ImGui") {
-		tmpName = strings.TrimPrefix(tmpName, "ImGui")
-	} else if strings.HasPrefix(tmpName, "Im") && len(n) > 2 && strings.ToUpper(string(n[2])) == string(n[2]) {
-		tmpName = strings.TrimPrefix(tmpName, "Im")
-	} else if strings.HasPrefix(tmpName, "ig") && len(n) > 2 && strings.ToUpper(string(n[2])) == string(n[2]) {
-		tmpName = strings.TrimPrefix(tmpName, "ig")
+func (n CIdentifier) trimImGuiPrefix() CIdentifier {
+	if HasPrefix(n, "ImGui") {
+		n = TrimPrefix(n, "ImGui")
+	} else if HasPrefix(n, "Im") && len(n) > 2 && strings.ToUpper(string(n[2])) == string(n[2]) {
+		n = TrimPrefix(n, "Im")
+	} else if HasPrefix(n, "ig") && len(n) > 2 && strings.ToUpper(string(n[2])) == string(n[2]) {
+		n = TrimPrefix(n, "ig")
 	}
 
-	return CIdentifier(tmpName)
+	return n
 }
 
 func (n CIdentifier) renameGoIdentifier() GoIdentifier {
@@ -71,24 +70,23 @@ func (n CIdentifier) renameGoIdentifier() GoIdentifier {
 		n = CIdentifier(r)
 	}
 
-	n = trimImGuiPrefix(n)
+	n = n.trimImGuiPrefix()
 	switch {
-	case strings.HasPrefix(string(n), "New"):
-		n = "New" + trimImGuiPrefix(n[3:])
-	case strings.HasPrefix(string(n), "new"):
-		n = "new" + trimImGuiPrefix(n[3:])
-	case strings.HasPrefix(string(n), "*"):
-		n = "*" + trimImGuiPrefix(n[1:])
+	case HasPrefix(n, "New"):
+		n = "New" + n[3:].trimImGuiPrefix()
+	case HasPrefix(n, "new"):
+		n = "new" + n[3:].trimImGuiPrefix()
+	case HasPrefix(n, "*"):
+		n = "*" + n[1:].trimImGuiPrefix()
 	}
 
-	n = CIdentifier(strings.TrimPrefix(string(n), "Get"))
+	n = TrimPrefix(n, "Get")
 	if n != "_" {
-		n = CIdentifier(strings.ReplaceAll(string(n), "_", ""))
+		n = ReplaceAll(n, "_", "")
 	}
 	return GoIdentifier(n)
 }
 
 func (e CIdentifier) renameEnum() GoIdentifier {
-	e = CIdentifier(strings.TrimSuffix(string(e), "_"))
-	return e.renameGoIdentifier()
+	return TrimSuffix(e, "_").renameGoIdentifier()
 }

--- a/cmd/codegen/gengo_enums.go
+++ b/cmd/codegen/gengo_enums.go
@@ -7,26 +7,26 @@ import (
 )
 
 // Generate enums and return enum type names
-func generateGoEnums(prefix string, enums []EnumDef) []string {
+func generateGoEnums(prefix string, enums []EnumDef) []GoIdentifier {
 	var sb strings.Builder
 
 	sb.WriteString(goPackageHeader)
 
-	var enumNames []string
+	var enumNames []GoIdentifier
 	for _, e := range enums {
 		originalName := e.Name
-		eName := renameEnum(e.Name)
+		eName := e.Name.renameEnum()
 
 		enumNames = append(enumNames, eName)
 
 		sb.WriteString(fmt.Sprintf("%s\n", e.CommentAbove))
 		sb.WriteString(fmt.Sprintf("// original name: %s\n", originalName))
-		sb.WriteString(fmt.Sprintf("type %s int32\n", renameGoIdentifier(eName)))
+		sb.WriteString(fmt.Sprintf("type %s int32\n", eName))
 		sb.WriteString("const (\n")
 
 		for _, v := range e.Values {
-			vName := strings.TrimSuffix(v.Name, "_")
-			sb.WriteString(fmt.Sprintf("%s\n\t%s = %d\n", v.Comment, renameGoIdentifier(vName), v.Value))
+			vName := TrimSuffix(v.Name, "_")
+			sb.WriteString(fmt.Sprintf("%s\n\t%s = %d\n", v.Comment, vName.renameGoIdentifier(), v.Value))
 		}
 
 		sb.WriteString(")\n\n")

--- a/cmd/codegen/helpers.go
+++ b/cmd/codegen/helpers.go
@@ -1,0 +1,56 @@
+package main
+
+import "strings"
+
+func HasPrefix[s ~string](str s, prefix string) bool {
+	return strings.HasPrefix(string(str), prefix)
+}
+
+func TrimPrefix[s ~string](str s, prefix string) s {
+	return s(strings.TrimPrefix(string(str), prefix))
+}
+
+func HasSuffix[s ~string](str s, suffix string) bool {
+	return strings.HasSuffix(string(str), suffix)
+}
+
+func TrimSuffix[s ~string](str s, suffix string) s {
+	return s(strings.TrimSuffix(string(str), suffix))
+}
+
+func ReplaceAll[s ~string](str s, old, new string) s {
+	return s(strings.ReplaceAll(string(str), old, new))
+}
+
+func Contains[s ~string](str s, substr string) bool {
+	return strings.Contains(string(str), substr)
+}
+
+func Split[s ~string](str s, sep string) []s {
+	var ret []s
+	for _, x := range strings.Split(string(str), sep) {
+		ret = append(ret, s(x))
+	}
+	return ret
+}
+
+func Replace[s, ot, nt ~string](str s, old ot, new nt, n int) s {
+	return s(strings.Replace(string(str), string(old), string(new), n))
+}
+
+func Join[s ~string](strs []s, sep string) s {
+	return s(strings.Join(func() (ret []string) {
+		for _, x := range strs {
+			ret = append(ret, string(x))
+		}
+		return
+	}(), sep))
+}
+
+func ContainsAny[s ~string](str s, chars string) bool {
+	return strings.ContainsAny(string(str), chars)
+}
+
+func Index[s ~string](str s, substr string) int {
+	return strings.Index(string(str), substr)
+}

--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 )
 
 const (
@@ -14,7 +13,7 @@ const (
 	cppFileHeader   = generatorInfo
 )
 
-func getEnumAndStructNames(enumJsonBytes []byte) (enumNames []string, structNames []string, err error) {
+func getEnumAndStructNames(enumJsonBytes []byte) (enumNames []GoIdentifier, structNames []CIdentifier, err error) {
 	enums, err := getEnumDefs(enumJsonBytes)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot get enum definitions: %w", err)
@@ -26,9 +25,7 @@ func getEnumAndStructNames(enumJsonBytes []byte) (enumNames []string, structName
 	}
 
 	for _, e := range enums {
-		goEnumName := strings.TrimSuffix(e.Name, "_")
-		goEnumName = renameGoIdentifier(goEnumName)
-		enumNames = append(enumNames, goEnumName)
+		enumNames = append(enumNames, e.Name.renameEnum())
 	}
 
 	for _, s := range structs {
@@ -100,7 +97,7 @@ func main() {
 		log.Panic(err)
 	}
 
-	var es, ss = make([]string, 0), make([]string, 0)
+	var es, ss = make([]GoIdentifier, 0), make([]CIdentifier, 0)
 	// generate reference only enum and struct names
 	if len(refEnumJsonBytes) > 0 {
 		es, ss, err = getEnumAndStructNames(refEnumJsonBytes)

--- a/cmd/codegen/structures_deffinition.go
+++ b/cmd/codegen/structures_deffinition.go
@@ -14,17 +14,17 @@ type StructSection struct {
 
 // StructDef represents a definition of an ImGui struct.
 type StructDef struct {
-	Name         string `json:"name"`
+	Name         CIdentifier `json:"name"`
 	CommentAbove string
 	Members      []StructMemberDef `json:"members"`
 }
 
 // StructMemberDef represents a definition of an ImGui struct member.
 type StructMemberDef struct {
-	Name         string `json:"name"`
-	TemplateType string `json:"template_type"`
-	Type         string `json:"type"`
-	Size         int    `json:"size"`
+	Name         CIdentifier `json:"name"`
+	TemplateType CIdentifier `json:"template_type"`
+	Type         CIdentifier `json:"type"`
+	Size         int         `json:"size"`
 	Comment      CommentDef
 	CommentData  json.RawMessage `json:"comment"`
 	Bitfield     string          `json:"bitfield"`
@@ -78,7 +78,7 @@ func getStructDefs(enumJsonBytes []byte) ([]StructDef, error) {
 		}
 
 		str := StructDef{
-			Name:    k,
+			Name:    CIdentifier(k),
 			Members: memberDefs,
 		}
 
@@ -103,8 +103,8 @@ func getStructDefs(enumJsonBytes []byte) ([]StructDef, error) {
 	return structs, nil
 }
 
-func shouldSkipStruct(name string) bool {
-	valueTypeStructs := map[string]bool{
+func shouldSkipStruct(name CIdentifier) bool {
+	valueTypeStructs := map[CIdentifier]bool{
 		"ImVec2ih":    true,
 		"ImVec2":      true,
 		"ImVec4":      true,


### PR DESCRIPTION
add GoIdentifier and CIdentifier

I tought about this since some time and I think that codegen code will be a bit cleaner now

---

_Due to area of this PR I'm going to skip waiting for `Test Source Code / Run Go Unittests (*)` because it doesn't metter_