### PR TITLE
texture.go: remove go:build directive

### DIFF
--- a/texture.go
+++ b/texture.go
@@ -1,6 +1,3 @@
-//go:build !exclude_cimgui_glfw
-// +build !exclude_cimgui_glfw
-
 package imgui
 
 import (


### PR DESCRIPTION
this file does not rely on glfw stuff

https://github.com/AllenDang/cimgui-go/issues/41#issuecomment-1956086126