### PR TITLE
Codegen refactor

### DIFF
--- a/cimgui_funcs.go
+++ b/cimgui_funcs.go
@@ -13152,9 +13152,7 @@ func (self *DrawCmd) TextureId() TextureID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImDrawCmd_GetTextureId(selfArg)
-	return *newTextureIDFromC(func() *C.ImTextureID { result := result; return &result }())
+	return *newTextureIDFromC(func() *C.ImTextureID { result := C.wrap_ImDrawCmd_GetTextureId(selfArg); return &result }())
 }
 
 func (self DrawCmd) SetVtxOffset(v uint32) {
@@ -13246,9 +13244,7 @@ func (self *DrawCmdHeader) TextureId() TextureID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImDrawCmdHeader_GetTextureId(selfArg)
-	return *newTextureIDFromC(func() *C.ImTextureID { result := result; return &result }())
+	return *newTextureIDFromC(func() *C.ImTextureID { result := C.wrap_ImDrawCmdHeader_GetTextureId(selfArg); return &result }())
 }
 
 func (self DrawCmdHeader) SetVtxOffset(v uint32) {
@@ -13580,9 +13576,7 @@ func (self *DrawList) CmdHeader() DrawCmdHeader {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImDrawList_Get_CmdHeader(selfArg)
-	return *newDrawCmdHeaderFromC(func() *C.ImDrawCmdHeader { result := result; return &result }())
+	return *newDrawCmdHeaderFromC(func() *C.ImDrawCmdHeader { result := C.wrap_ImDrawList_Get_CmdHeader(selfArg); return &result }())
 }
 
 func (self DrawList) SetSplitter(v DrawListSplitter) {
@@ -13599,9 +13593,7 @@ func (self *DrawList) Splitter() DrawListSplitter {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImDrawList_Get_Splitter(selfArg)
-	return *newDrawListSplitterFromC(func() *C.ImDrawListSplitter { result := result; return &result }())
+	return *newDrawListSplitterFromC(func() *C.ImDrawListSplitter { result := C.wrap_ImDrawList_Get_Splitter(selfArg); return &result }())
 }
 
 func (self DrawList) SetFringeScale(v float32) {
@@ -15343,9 +15335,7 @@ func (self *Context) IO() IO {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetIO(selfArg)
-	return *newIOFromC(func() *C.ImGuiIO { result := result; return &result }())
+	return *newIOFromC(func() *C.ImGuiIO { result := C.wrap_ImGuiContext_GetIO(selfArg); return &result }())
 }
 
 func (self Context) SetPlatformIO(v PlatformIO) {
@@ -15362,9 +15352,7 @@ func (self *Context) PlatformIO() PlatformIO {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetPlatformIO(selfArg)
-	return *newPlatformIOFromC(func() *C.ImGuiPlatformIO { result := result; return &result }())
+	return *newPlatformIOFromC(func() *C.ImGuiPlatformIO { result := C.wrap_ImGuiContext_GetPlatformIO(selfArg); return &result }())
 }
 
 func (self Context) SetStyle(v Style) {
@@ -15381,9 +15369,7 @@ func (self *Context) Style() Style {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetStyle(selfArg)
-	return *newStyleFromC(func() *C.ImGuiStyle { result := result; return &result }())
+	return *newStyleFromC(func() *C.ImGuiStyle { result := C.wrap_ImGuiContext_GetStyle(selfArg); return &result }())
 }
 
 func (self Context) SetConfigFlagsCurrFrame(v ConfigFlags) {
@@ -15477,9 +15463,10 @@ func (self *Context) DrawListSharedData() DrawListSharedData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetDrawListSharedData(selfArg)
-	return *newDrawListSharedDataFromC(func() *C.ImDrawListSharedData { result := result; return &result }())
+	return *newDrawListSharedDataFromC(func() *C.ImDrawListSharedData {
+		result := C.wrap_ImGuiContext_GetDrawListSharedData(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetTime(v float64) {
@@ -15760,9 +15747,7 @@ func (self *Context) WindowsById() Storage {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetWindowsById(selfArg)
-	return *newStorageFromC(func() *C.ImGuiStorage { result := result; return &result }())
+	return *newStorageFromC(func() *C.ImGuiStorage { result := C.wrap_ImGuiContext_GetWindowsById(selfArg); return &result }())
 }
 
 func (self Context) SetWindowsActiveCount(v int32) {
@@ -15809,9 +15794,7 @@ func (self *Context) DebugBreakInWindow() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetDebugBreakInWindow(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetDebugBreakInWindow(selfArg); return &result }())
 }
 
 func (self Context) SetCurrentWindow(v *Window) {
@@ -16003,9 +15986,7 @@ func (self *Context) DebugHookIdInfo() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetDebugHookIdInfo(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetDebugHookIdInfo(selfArg); return &result }())
 }
 
 func (self Context) SetHoveredId(v ID) {
@@ -16022,9 +16003,7 @@ func (self *Context) HoveredId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetHoveredId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetHoveredId(selfArg); return &result }())
 }
 
 func (self Context) SetHoveredIdPreviousFrame(v ID) {
@@ -16041,9 +16020,7 @@ func (self *Context) HoveredIdPreviousFrame() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetHoveredIdPreviousFrame(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetHoveredIdPreviousFrame(selfArg); return &result }())
 }
 
 func (self Context) SetHoveredIdAllowOverlap(v bool) {
@@ -16120,9 +16097,7 @@ func (self *Context) ActiveId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetActiveId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetActiveId(selfArg); return &result }())
 }
 
 func (self Context) SetActiveIdIsAlive(v ID) {
@@ -16139,9 +16114,7 @@ func (self *Context) ActiveIdIsAlive() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetActiveIdIsAlive(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetActiveIdIsAlive(selfArg); return &result }())
 }
 
 func (self Context) SetActiveIdTimer(v float32) {
@@ -16340,9 +16313,7 @@ func (self *Context) ActiveIdPreviousFrame() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetActiveIdPreviousFrame(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetActiveIdPreviousFrame(selfArg); return &result }())
 }
 
 func (self Context) SetActiveIdPreviousFrameIsAlive(v bool) {
@@ -16406,9 +16377,7 @@ func (self *Context) LastActiveId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetLastActiveId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetLastActiveId(selfArg); return &result }())
 }
 
 func (self Context) SetLastActiveIdTimer(v float32) {
@@ -16501,9 +16470,10 @@ func (self *Context) KeysRoutingTable() KeyRoutingTable {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetKeysRoutingTable(selfArg)
-	return *newKeyRoutingTableFromC(func() *C.ImGuiKeyRoutingTable { result := result; return &result }())
+	return *newKeyRoutingTableFromC(func() *C.ImGuiKeyRoutingTable {
+		result := C.wrap_ImGuiContext_GetKeysRoutingTable(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetActiveIdUsingNavDirMask(v uint32) {
@@ -16550,9 +16520,10 @@ func (self *Context) DebugBreakInShortcutRouting() KeyChord {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetDebugBreakInShortcutRouting(selfArg)
-	return *newKeyChordFromC(func() *C.ImGuiKeyChord { result := result; return &result }())
+	return *newKeyChordFromC(func() *C.ImGuiKeyChord {
+		result := C.wrap_ImGuiContext_GetDebugBreakInShortcutRouting(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetCurrentFocusScopeId(v ID) {
@@ -16569,9 +16540,7 @@ func (self *Context) CurrentFocusScopeId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetCurrentFocusScopeId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetCurrentFocusScopeId(selfArg); return &result }())
 }
 
 func (self Context) SetCurrentItemFlags(v ItemFlags) {
@@ -16603,9 +16572,7 @@ func (self *Context) DebugLocateId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetDebugLocateId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetDebugLocateId(selfArg); return &result }())
 }
 
 func (self Context) SetNextItemData(v NextItemData) {
@@ -16622,9 +16589,7 @@ func (self *Context) NextItemData() NextItemData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetNextItemData(selfArg)
-	return *newNextItemDataFromC(func() *C.ImGuiNextItemData { result := result; return &result }())
+	return *newNextItemDataFromC(func() *C.ImGuiNextItemData { result := C.wrap_ImGuiContext_GetNextItemData(selfArg); return &result }())
 }
 
 func (self Context) SetLastItemData(v LastItemData) {
@@ -16641,9 +16606,7 @@ func (self *Context) LastItemData() LastItemData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetLastItemData(selfArg)
-	return *newLastItemDataFromC(func() *C.ImGuiLastItemData { result := result; return &result }())
+	return *newLastItemDataFromC(func() *C.ImGuiLastItemData { result := C.wrap_ImGuiContext_GetLastItemData(selfArg); return &result }())
 }
 
 func (self Context) SetNextWindowData(v NextWindowData) {
@@ -16660,9 +16623,10 @@ func (self *Context) NextWindowData() NextWindowData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetNextWindowData(selfArg)
-	return *newNextWindowDataFromC(func() *C.ImGuiNextWindowData { result := result; return &result }())
+	return *newNextWindowDataFromC(func() *C.ImGuiNextWindowData {
+		result := C.wrap_ImGuiContext_GetNextWindowData(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetDebugShowGroupRects(v bool) {
@@ -16945,9 +16909,10 @@ func (self *Context) PlatformLastFocusedViewportId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetPlatformLastFocusedViewportId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID {
+		result := C.wrap_ImGuiContext_GetPlatformLastFocusedViewportId(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetFallbackMonitor(v PlatformMonitor) {
@@ -16964,9 +16929,10 @@ func (self *Context) FallbackMonitor() PlatformMonitor {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetFallbackMonitor(selfArg)
-	return *newPlatformMonitorFromC(func() *C.ImGuiPlatformMonitor { result := result; return &result }())
+	return *newPlatformMonitorFromC(func() *C.ImGuiPlatformMonitor {
+		result := C.wrap_ImGuiContext_GetFallbackMonitor(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetPlatformMonitorsFullWorkRect(v Rect) {
@@ -17060,9 +17026,7 @@ func (self *Context) NavId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetNavId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetNavId(selfArg); return &result }())
 }
 
 func (self Context) SetNavFocusScopeId(v ID) {
@@ -17079,9 +17043,7 @@ func (self *Context) NavFocusScopeId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetNavFocusScopeId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetNavFocusScopeId(selfArg); return &result }())
 }
 
 func (self Context) SetNavFocusRoute(v Vector[*FocusScopeData]) {
@@ -17121,9 +17083,7 @@ func (self *Context) NavActivateId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetNavActivateId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetNavActivateId(selfArg); return &result }())
 }
 
 func (self Context) SetNavActivateDownId(v ID) {
@@ -17140,9 +17100,7 @@ func (self *Context) NavActivateDownId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetNavActivateDownId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetNavActivateDownId(selfArg); return &result }())
 }
 
 func (self Context) SetNavActivatePressedId(v ID) {
@@ -17159,9 +17117,7 @@ func (self *Context) NavActivatePressedId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetNavActivatePressedId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetNavActivatePressedId(selfArg); return &result }())
 }
 
 func (self Context) SetNavActivateFlags(v ActivateFlags) {
@@ -17193,9 +17149,7 @@ func (self *Context) NavHighlightActivatedId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetNavHighlightActivatedId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetNavHighlightActivatedId(selfArg); return &result }())
 }
 
 func (self Context) SetNavHighlightActivatedTimer(v float32) {
@@ -17227,9 +17181,7 @@ func (self *Context) NavJustMovedToId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetNavJustMovedToId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetNavJustMovedToId(selfArg); return &result }())
 }
 
 func (self Context) SetNavJustMovedToFocusScopeId(v ID) {
@@ -17246,9 +17198,10 @@ func (self *Context) NavJustMovedToFocusScopeId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetNavJustMovedToFocusScopeId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID {
+		result := C.wrap_ImGuiContext_GetNavJustMovedToFocusScopeId(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetNavJustMovedToKeyMods(v KeyChord) {
@@ -17265,9 +17218,10 @@ func (self *Context) NavJustMovedToKeyMods() KeyChord {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetNavJustMovedToKeyMods(selfArg)
-	return *newKeyChordFromC(func() *C.ImGuiKeyChord { result := result; return &result }())
+	return *newKeyChordFromC(func() *C.ImGuiKeyChord {
+		result := C.wrap_ImGuiContext_GetNavJustMovedToKeyMods(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetNavNextActivateId(v ID) {
@@ -17284,9 +17238,7 @@ func (self *Context) NavNextActivateId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetNavNextActivateId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetNavNextActivateId(selfArg); return &result }())
 }
 
 func (self Context) SetNavNextActivateFlags(v ActivateFlags) {
@@ -17453,9 +17405,7 @@ func (self *Context) NavInitResult() NavItemData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetNavInitResult(selfArg)
-	return *newNavItemDataFromC(func() *C.ImGuiNavItemData { result := result; return &result }())
+	return *newNavItemDataFromC(func() *C.ImGuiNavItemData { result := C.wrap_ImGuiContext_GetNavInitResult(selfArg); return &result }())
 }
 
 func (self Context) SetNavMoveSubmitted(v bool) {
@@ -17547,9 +17497,7 @@ func (self *Context) NavMoveKeyMods() KeyChord {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetNavMoveKeyMods(selfArg)
-	return *newKeyChordFromC(func() *C.ImGuiKeyChord { result := result; return &result }())
+	return *newKeyChordFromC(func() *C.ImGuiKeyChord { result := C.wrap_ImGuiContext_GetNavMoveKeyMods(selfArg); return &result }())
 }
 
 func (self Context) SetNavMoveDir(v Dir) {
@@ -17686,9 +17634,10 @@ func (self *Context) NavMoveResultLocal() NavItemData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetNavMoveResultLocal(selfArg)
-	return *newNavItemDataFromC(func() *C.ImGuiNavItemData { result := result; return &result }())
+	return *newNavItemDataFromC(func() *C.ImGuiNavItemData {
+		result := C.wrap_ImGuiContext_GetNavMoveResultLocal(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetNavMoveResultLocalVisible(v NavItemData) {
@@ -17705,9 +17654,10 @@ func (self *Context) NavMoveResultLocalVisible() NavItemData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetNavMoveResultLocalVisible(selfArg)
-	return *newNavItemDataFromC(func() *C.ImGuiNavItemData { result := result; return &result }())
+	return *newNavItemDataFromC(func() *C.ImGuiNavItemData {
+		result := C.wrap_ImGuiContext_GetNavMoveResultLocalVisible(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetNavMoveResultOther(v NavItemData) {
@@ -17724,9 +17674,10 @@ func (self *Context) NavMoveResultOther() NavItemData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetNavMoveResultOther(selfArg)
-	return *newNavItemDataFromC(func() *C.ImGuiNavItemData { result := result; return &result }())
+	return *newNavItemDataFromC(func() *C.ImGuiNavItemData {
+		result := C.wrap_ImGuiContext_GetNavMoveResultOther(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetNavTabbingResultFirst(v NavItemData) {
@@ -17743,9 +17694,10 @@ func (self *Context) NavTabbingResultFirst() NavItemData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetNavTabbingResultFirst(selfArg)
-	return *newNavItemDataFromC(func() *C.ImGuiNavItemData { result := result; return &result }())
+	return *newNavItemDataFromC(func() *C.ImGuiNavItemData {
+		result := C.wrap_ImGuiContext_GetNavTabbingResultFirst(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetConfigNavWindowingKeyNext(v KeyChord) {
@@ -17762,9 +17714,10 @@ func (self *Context) ConfigNavWindowingKeyNext() KeyChord {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetConfigNavWindowingKeyNext(selfArg)
-	return *newKeyChordFromC(func() *C.ImGuiKeyChord { result := result; return &result }())
+	return *newKeyChordFromC(func() *C.ImGuiKeyChord {
+		result := C.wrap_ImGuiContext_GetConfigNavWindowingKeyNext(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetConfigNavWindowingKeyPrev(v KeyChord) {
@@ -17781,9 +17734,10 @@ func (self *Context) ConfigNavWindowingKeyPrev() KeyChord {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetConfigNavWindowingKeyPrev(selfArg)
-	return *newKeyChordFromC(func() *C.ImGuiKeyChord { result := result; return &result }())
+	return *newKeyChordFromC(func() *C.ImGuiKeyChord {
+		result := C.wrap_ImGuiContext_GetConfigNavWindowingKeyPrev(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetNavWindowingTarget(v *Window) {
@@ -18046,9 +18000,7 @@ func (self *Context) DragDropPayload() Payload {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetDragDropPayload(selfArg)
-	return *newPayloadFromC(func() *C.ImGuiPayload { result := result; return &result }())
+	return *newPayloadFromC(func() *C.ImGuiPayload { result := C.wrap_ImGuiContext_GetDragDropPayload(selfArg); return &result }())
 }
 
 func (self Context) SetDragDropTargetRect(v Rect) {
@@ -18095,9 +18047,7 @@ func (self *Context) DragDropTargetId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetDragDropTargetId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetDragDropTargetId(selfArg); return &result }())
 }
 
 func (self Context) SetDragDropAcceptFlags(v DragDropFlags) {
@@ -18144,9 +18094,7 @@ func (self *Context) DragDropAcceptIdCurr() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetDragDropAcceptIdCurr(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetDragDropAcceptIdCurr(selfArg); return &result }())
 }
 
 func (self Context) SetDragDropAcceptIdPrev(v ID) {
@@ -18163,9 +18111,7 @@ func (self *Context) DragDropAcceptIdPrev() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetDragDropAcceptIdPrev(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetDragDropAcceptIdPrev(selfArg); return &result }())
 }
 
 func (self Context) SetDragDropAcceptFrameCount(v int32) {
@@ -18197,9 +18143,7 @@ func (self *Context) DragDropHoldJustPressedId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetDragDropHoldJustPressedId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetDragDropHoldJustPressedId(selfArg); return &result }())
 }
 
 func (self Context) SetDragDropPayloadBufLocal(v *[16]uint) {
@@ -18286,9 +18230,7 @@ func (self *Context) DebugBreakInTable() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetDebugBreakInTable(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetDebugBreakInTable(selfArg); return &result }())
 }
 
 func (self Context) SetTablesTempDataStacked(v int32) {
@@ -18452,9 +18394,7 @@ func (self *Context) HoverItemDelayId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetHoverItemDelayId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetHoverItemDelayId(selfArg); return &result }())
 }
 
 func (self Context) SetHoverItemDelayIdPreviousFrame(v ID) {
@@ -18471,9 +18411,10 @@ func (self *Context) HoverItemDelayIdPreviousFrame() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetHoverItemDelayIdPreviousFrame(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID {
+		result := C.wrap_ImGuiContext_GetHoverItemDelayIdPreviousFrame(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetHoverItemDelayTimer(v float32) {
@@ -18520,9 +18461,10 @@ func (self *Context) HoverItemUnlockedStationaryId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetHoverItemUnlockedStationaryId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID {
+		result := C.wrap_ImGuiContext_GetHoverItemUnlockedStationaryId(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetHoverWindowUnlockedStationaryId(v ID) {
@@ -18539,9 +18481,10 @@ func (self *Context) HoverWindowUnlockedStationaryId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetHoverWindowUnlockedStationaryId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID {
+		result := C.wrap_ImGuiContext_GetHoverWindowUnlockedStationaryId(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetMouseCursor(v MouseCursor) {
@@ -18603,9 +18546,10 @@ func (self *Context) InputTextState() InputTextState {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetInputTextState(selfArg)
-	return *newInputTextStateFromC(func() *C.ImGuiInputTextState { result := result; return &result }())
+	return *newInputTextStateFromC(func() *C.ImGuiInputTextState {
+		result := C.wrap_ImGuiContext_GetInputTextState(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetInputTextDeactivatedState(v InputTextDeactivatedState) {
@@ -18622,9 +18566,10 @@ func (self *Context) InputTextDeactivatedState() InputTextDeactivatedState {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetInputTextDeactivatedState(selfArg)
-	return *newInputTextDeactivatedStateFromC(func() *C.ImGuiInputTextDeactivatedState { result := result; return &result }())
+	return *newInputTextDeactivatedStateFromC(func() *C.ImGuiInputTextDeactivatedState {
+		result := C.wrap_ImGuiContext_GetInputTextDeactivatedState(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetInputTextPasswordFont(v Font) {
@@ -18641,9 +18586,7 @@ func (self *Context) InputTextPasswordFont() Font {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetInputTextPasswordFont(selfArg)
-	return *newFontFromC(func() *C.ImFont { result := result; return &result }())
+	return *newFontFromC(func() *C.ImFont { result := C.wrap_ImGuiContext_GetInputTextPasswordFont(selfArg); return &result }())
 }
 
 func (self Context) SetTempInputId(v ID) {
@@ -18660,9 +18603,7 @@ func (self *Context) TempInputId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetTempInputId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetTempInputId(selfArg); return &result }())
 }
 
 func (self Context) SetBeginMenuDepth(v int32) {
@@ -18724,9 +18665,7 @@ func (self *Context) ColorEditCurrentID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetColorEditCurrentID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetColorEditCurrentID(selfArg); return &result }())
 }
 
 func (self Context) SetColorEditSavedID(v ID) {
@@ -18743,9 +18682,7 @@ func (self *Context) ColorEditSavedID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetColorEditSavedID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetColorEditSavedID(selfArg); return &result }())
 }
 
 func (self Context) SetColorEditSavedHue(v float32) {
@@ -18822,9 +18759,10 @@ func (self *Context) ComboPreviewData() ComboPreviewData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetComboPreviewData(selfArg)
-	return *newComboPreviewDataFromC(func() *C.ImGuiComboPreviewData { result := result; return &result }())
+	return *newComboPreviewDataFromC(func() *C.ImGuiComboPreviewData {
+		result := C.wrap_ImGuiContext_GetComboPreviewData(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetWindowResizeBorderExpectedRect(v Rect) {
@@ -19082,9 +19020,10 @@ func (self *Context) TypingSelectState() TypingSelectState {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetTypingSelectState(selfArg)
-	return *newTypingSelectStateFromC(func() *C.ImGuiTypingSelectState { result := result; return &result }())
+	return *newTypingSelectStateFromC(func() *C.ImGuiTypingSelectState {
+		result := C.wrap_ImGuiContext_GetTypingSelectState(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetPlatformImeData(v PlatformImeData) {
@@ -19101,9 +19040,10 @@ func (self *Context) PlatformImeData() PlatformImeData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetPlatformImeData(selfArg)
-	return *newPlatformImeDataFromC(func() *C.ImGuiPlatformImeData { result := result; return &result }())
+	return *newPlatformImeDataFromC(func() *C.ImGuiPlatformImeData {
+		result := C.wrap_ImGuiContext_GetPlatformImeData(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetPlatformImeDataPrev(v PlatformImeData) {
@@ -19120,9 +19060,10 @@ func (self *Context) PlatformImeDataPrev() PlatformImeData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetPlatformImeDataPrev(selfArg)
-	return *newPlatformImeDataFromC(func() *C.ImGuiPlatformImeData { result := result; return &result }())
+	return *newPlatformImeDataFromC(func() *C.ImGuiPlatformImeData {
+		result := C.wrap_ImGuiContext_GetPlatformImeDataPrev(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetPlatformImeViewport(v ID) {
@@ -19139,9 +19080,7 @@ func (self *Context) PlatformImeViewport() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetPlatformImeViewport(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetPlatformImeViewport(selfArg); return &result }())
 }
 
 func (self Context) SetDockContext(v DockContext) {
@@ -19158,9 +19097,7 @@ func (self *Context) DockContext() DockContext {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetDockContext(selfArg)
-	return *newDockContextFromC(func() *C.ImGuiDockContext { result := result; return &result }())
+	return *newDockContextFromC(func() *C.ImGuiDockContext { result := C.wrap_ImGuiContext_GetDockContext(selfArg); return &result }())
 }
 
 func (self Context) SetSettingsLoaded(v bool) {
@@ -19207,9 +19144,7 @@ func (self *Context) SettingsIniData() TextBuffer {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetSettingsIniData(selfArg)
-	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := result; return &result }())
+	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := C.wrap_ImGuiContext_GetSettingsIniData(selfArg); return &result }())
 }
 
 func (self Context) SetSettingsHandlers(v Vector[*SettingsHandler]) {
@@ -19272,9 +19207,7 @@ func (self *Context) HookIdNext() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetHookIdNext(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetHookIdNext(selfArg); return &result }())
 }
 
 func (self Context) SetLocalizationTable(v *[11]string) {
@@ -19337,9 +19270,7 @@ func (self *Context) LogBuffer() TextBuffer {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetLogBuffer(selfArg)
-	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := result; return &result }())
+	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := C.wrap_ImGuiContext_GetLogBuffer(selfArg); return &result }())
 }
 
 func (self Context) SetLogNextPrefix(v string) {
@@ -19480,9 +19411,7 @@ func (self *Context) DebugLogBuf() TextBuffer {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetDebugLogBuf(selfArg)
-	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := result; return &result }())
+	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := C.wrap_ImGuiContext_GetDebugLogBuf(selfArg); return &result }())
 }
 
 func (self Context) SetDebugLogIndex(v TextIndex) {
@@ -19499,9 +19428,7 @@ func (self *Context) DebugLogIndex() TextIndex {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetDebugLogIndex(selfArg)
-	return *newTextIndexFromC(func() *C.ImGuiTextIndex { result := result; return &result }())
+	return *newTextIndexFromC(func() *C.ImGuiTextIndex { result := C.wrap_ImGuiContext_GetDebugLogIndex(selfArg); return &result }())
 }
 
 func (self Context) SetDebugLogAutoDisableFlags(v DebugLogFlags) {
@@ -19578,9 +19505,7 @@ func (self *Context) DebugBreakKeyChord() KeyChord {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetDebugBreakKeyChord(selfArg)
-	return *newKeyChordFromC(func() *C.ImGuiKeyChord { result := result; return &result }())
+	return *newKeyChordFromC(func() *C.ImGuiKeyChord { result := C.wrap_ImGuiContext_GetDebugBreakKeyChord(selfArg); return &result }())
 }
 
 func (self Context) SetDebugBeginReturnValueCullDepth(v int) {
@@ -19642,9 +19567,7 @@ func (self *Context) DebugItemPickerBreakId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetDebugItemPickerBreakId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContext_GetDebugItemPickerBreakId(selfArg); return &result }())
 }
 
 func (self Context) SetDebugFlashStyleColorTime(v float32) {
@@ -19691,9 +19614,10 @@ func (self *Context) DebugMetricsConfig() MetricsConfig {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetDebugMetricsConfig(selfArg)
-	return *newMetricsConfigFromC(func() *C.ImGuiMetricsConfig { result := result; return &result }())
+	return *newMetricsConfigFromC(func() *C.ImGuiMetricsConfig {
+		result := C.wrap_ImGuiContext_GetDebugMetricsConfig(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetDebugIDStackTool(v IDStackTool) {
@@ -19710,9 +19634,7 @@ func (self *Context) DebugIDStackTool() IDStackTool {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetDebugIDStackTool(selfArg)
-	return *newIDStackToolFromC(func() *C.ImGuiIDStackTool { result := result; return &result }())
+	return *newIDStackToolFromC(func() *C.ImGuiIDStackTool { result := C.wrap_ImGuiContext_GetDebugIDStackTool(selfArg); return &result }())
 }
 
 func (self Context) SetDebugAllocInfo(v DebugAllocInfo) {
@@ -19729,9 +19651,10 @@ func (self *Context) DebugAllocInfo() DebugAllocInfo {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContext_GetDebugAllocInfo(selfArg)
-	return *newDebugAllocInfoFromC(func() *C.ImGuiDebugAllocInfo { result := result; return &result }())
+	return *newDebugAllocInfoFromC(func() *C.ImGuiDebugAllocInfo {
+		result := C.wrap_ImGuiContext_GetDebugAllocInfo(selfArg)
+		return &result
+	}())
 }
 
 func (self Context) SetDebugHoveredDockNode(v *DockNode) {
@@ -19908,9 +19831,7 @@ func (self *ContextHook) HookId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContextHook_GetHookId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContextHook_GetHookId(selfArg); return &result }())
 }
 
 func (self ContextHook) SetType(v ContextHookType) {
@@ -19942,9 +19863,7 @@ func (self *ContextHook) Owner() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiContextHook_GetOwner(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiContextHook_GetOwner(selfArg); return &result }())
 }
 
 func (self ContextHook) SetUserData(v uintptr) {
@@ -20208,9 +20127,7 @@ func (self *DockContext) Nodes() Storage {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiDockContext_GetNodes(selfArg)
-	return *newStorageFromC(func() *C.ImGuiStorage { result := result; return &result }())
+	return *newStorageFromC(func() *C.ImGuiStorage { result := C.wrap_ImGuiDockContext_GetNodes(selfArg); return &result }())
 }
 
 func (self DockContext) SetRequests(v Vector[*DockRequest]) {
@@ -20288,9 +20205,7 @@ func (self *DockNode) ID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiDockNode_GetID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiDockNode_GetID(selfArg); return &result }())
 }
 
 func (self DockNode) SetSharedFlags(v DockNodeFlags) {
@@ -20477,9 +20392,7 @@ func (self *DockNode) WindowClass() WindowClass {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiDockNode_GetWindowClass(selfArg)
-	return *newWindowClassFromC(func() *C.ImGuiWindowClass { result := result; return &result }())
+	return *newWindowClassFromC(func() *C.ImGuiWindowClass { result := C.wrap_ImGuiDockNode_GetWindowClass(selfArg); return &result }())
 }
 
 func (self DockNode) SetLastBgColor(v uint32) {
@@ -20639,9 +20552,7 @@ func (self *DockNode) LastFocusedNodeId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiDockNode_GetLastFocusedNodeId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiDockNode_GetLastFocusedNodeId(selfArg); return &result }())
 }
 
 func (self DockNode) SetSelectedTabId(v ID) {
@@ -20658,9 +20569,7 @@ func (self *DockNode) SelectedTabId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiDockNode_GetSelectedTabId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiDockNode_GetSelectedTabId(selfArg); return &result }())
 }
 
 func (self DockNode) SetWantCloseTabId(v ID) {
@@ -20677,9 +20586,7 @@ func (self *DockNode) WantCloseTabId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiDockNode_GetWantCloseTabId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiDockNode_GetWantCloseTabId(selfArg); return &result }())
 }
 
 func (self DockNode) SetRefViewportId(v ID) {
@@ -20696,9 +20603,7 @@ func (self *DockNode) RefViewportId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiDockNode_GetRefViewportId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiDockNode_GetRefViewportId(selfArg); return &result }())
 }
 
 func (self DockNode) SetAuthorityForPos(v DataAuthority) {
@@ -20925,9 +20830,7 @@ func (self *FocusScopeData) ID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiFocusScopeData_GetID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiFocusScopeData_GetID(selfArg); return &result }())
 }
 
 func (self FocusScopeData) SetWindowID(v ID) {
@@ -20944,9 +20847,7 @@ func (self *FocusScopeData) WindowID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiFocusScopeData_GetWindowID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiFocusScopeData_GetWindowID(selfArg); return &result }())
 }
 
 func (self GroupData) SetWindowID(v ID) {
@@ -20963,9 +20864,7 @@ func (self *GroupData) WindowID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiGroupData_GetWindowID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiGroupData_GetWindowID(selfArg); return &result }())
 }
 
 func (self GroupData) SetBackupCursorPos(v Vec2) {
@@ -21027,9 +20926,7 @@ func (self *GroupData) BackupIndent() Vec1 {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiGroupData_GetBackupIndent(selfArg)
-	return *newVec1FromC(func() *C.ImVec1 { result := result; return &result }())
+	return *newVec1FromC(func() *C.ImVec1 { result := C.wrap_ImGuiGroupData_GetBackupIndent(selfArg); return &result }())
 }
 
 func (self GroupData) SetBackupGroupOffset(v Vec1) {
@@ -21046,9 +20943,7 @@ func (self *GroupData) BackupGroupOffset() Vec1 {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiGroupData_GetBackupGroupOffset(selfArg)
-	return *newVec1FromC(func() *C.ImVec1 { result := result; return &result }())
+	return *newVec1FromC(func() *C.ImVec1 { result := C.wrap_ImGuiGroupData_GetBackupGroupOffset(selfArg); return &result }())
 }
 
 func (self GroupData) SetBackupCurrLineSize(v Vec2) {
@@ -21095,9 +20990,7 @@ func (self *GroupData) BackupActiveIdIsAlive() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiGroupData_GetBackupActiveIdIsAlive(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiGroupData_GetBackupActiveIdIsAlive(selfArg); return &result }())
 }
 
 func (self GroupData) SetBackupActiveIdPreviousFrameIsAlive(v bool) {
@@ -21204,9 +21097,7 @@ func (self *IDStackTool) QueryId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiIDStackTool_GetQueryId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiIDStackTool_GetQueryId(selfArg); return &result }())
 }
 
 func (self IDStackTool) SetResults(v Vector[*StackLevelInfo]) {
@@ -22280,9 +22171,7 @@ func (self *IO) MouseHoveredViewport() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiIO_GetMouseHoveredViewport(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiIO_GetMouseHoveredViewport(selfArg); return &result }())
 }
 
 func (self IO) SetKeyCtrl(v bool) {
@@ -22359,9 +22248,7 @@ func (self *IO) KeyMods() KeyChord {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiIO_GetKeyMods(selfArg)
-	return *newKeyChordFromC(func() *C.ImGuiKeyChord { result := result; return &result }())
+	return *newKeyChordFromC(func() *C.ImGuiKeyChord { result := C.wrap_ImGuiIO_GetKeyMods(selfArg); return &result }())
 }
 
 func (self IO) SetKeysData(v *[154]KeyData) {
@@ -22942,9 +22829,10 @@ func (self *InputEventMouseViewport) HoveredViewportID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiInputEventMouseViewport_GetHoveredViewportID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID {
+		result := C.wrap_ImGuiInputEventMouseViewport_GetHoveredViewportID(selfArg)
+		return &result
+	}())
 }
 
 func (self InputEventMouseWheel) SetWheelX(v float32) {
@@ -23220,9 +23108,7 @@ func (self *InputTextDeactivatedState) ID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiInputTextDeactivatedState_GetID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiInputTextDeactivatedState_GetID(selfArg); return &result }())
 }
 
 func (self InputTextDeactivatedState) SetTextA(v Vector[string]) {
@@ -23279,9 +23165,7 @@ func (self *InputTextState) ID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiInputTextState_GetID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiInputTextState_GetID(selfArg); return &result }())
 }
 
 func (self InputTextState) SetCurLenW(v int32) {
@@ -23442,9 +23326,7 @@ func (self *InputTextState) Stb() STBTexteditState {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiInputTextState_GetStb(selfArg)
-	return *newSTBTexteditStateFromC(func() *C.STB_TexteditState { result := result; return &result }())
+	return *newSTBTexteditStateFromC(func() *C.STB_TexteditState { result := C.wrap_ImGuiInputTextState_GetStb(selfArg); return &result }())
 }
 
 func (self InputTextState) SetCursorAnim(v float32) {
@@ -23641,9 +23523,7 @@ func (self *KeyOwnerData) OwnerCurr() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiKeyOwnerData_GetOwnerCurr(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiKeyOwnerData_GetOwnerCurr(selfArg); return &result }())
 }
 
 func (self KeyOwnerData) SetOwnerNext(v ID) {
@@ -23660,9 +23540,7 @@ func (self *KeyOwnerData) OwnerNext() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiKeyOwnerData_GetOwnerNext(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiKeyOwnerData_GetOwnerNext(selfArg); return &result }())
 }
 
 func (self KeyOwnerData) SetLockThisFrame(v bool) {
@@ -23754,9 +23632,7 @@ func (self *KeyRoutingData) RoutingCurr() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiKeyRoutingData_GetRoutingCurr(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiKeyRoutingData_GetRoutingCurr(selfArg); return &result }())
 }
 
 func (self KeyRoutingData) SetRoutingNext(v ID) {
@@ -23773,9 +23649,7 @@ func (self *KeyRoutingData) RoutingNext() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiKeyRoutingData_GetRoutingNext(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiKeyRoutingData_GetRoutingNext(selfArg); return &result }())
 }
 
 func (self KeyRoutingTable) SetEntries(v Vector[*KeyRoutingData]) {
@@ -23838,9 +23712,7 @@ func (self *LastItemData) ID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiLastItemData_GetID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiLastItemData_GetID(selfArg); return &result }())
 }
 
 func (self LastItemData) SetInFlags(v ItemFlags) {
@@ -24561,9 +24433,7 @@ func (self *MetricsConfig) HighlightViewportID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiMetricsConfig_GetHighlightViewportID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiMetricsConfig_GetHighlightViewportID(selfArg); return &result }())
 }
 
 func (self NavItemData) SetWindow(v *Window) {
@@ -24597,9 +24467,7 @@ func (self *NavItemData) ID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiNavItemData_GetID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiNavItemData_GetID(selfArg); return &result }())
 }
 
 func (self NavItemData) SetFocusScopeId(v ID) {
@@ -24616,9 +24484,7 @@ func (self *NavItemData) FocusScopeId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiNavItemData_GetFocusScopeId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiNavItemData_GetFocusScopeId(selfArg); return &result }())
 }
 
 func (self NavItemData) SetRectRel(v Rect) {
@@ -24710,9 +24576,7 @@ func (self *NavTreeNodeData) ID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiNavTreeNodeData_GetID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiNavTreeNodeData_GetID(selfArg); return &result }())
 }
 
 func (self NavTreeNodeData) SetInFlags(v ItemFlags) {
@@ -24804,9 +24668,7 @@ func (self *NextItemData) Shortcut() KeyChord {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiNextItemData_GetShortcut(selfArg)
-	return *newKeyChordFromC(func() *C.ImGuiKeyChord { result := result; return &result }())
+	return *newKeyChordFromC(func() *C.ImGuiKeyChord { result := C.wrap_ImGuiNextItemData_GetShortcut(selfArg); return &result }())
 }
 
 func (self NextItemData) SetOpenVal(v bool) {
@@ -25093,9 +24955,7 @@ func (self *NextWindowData) ViewportId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiNextWindowData_GetViewportId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiNextWindowData_GetViewportId(selfArg); return &result }())
 }
 
 func (self NextWindowData) SetDockId(v ID) {
@@ -25112,9 +24972,7 @@ func (self *NextWindowData) DockId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiNextWindowData_GetDockId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiNextWindowData_GetDockId(selfArg); return &result }())
 }
 
 func (self NextWindowData) SetWindowClass(v WindowClass) {
@@ -25131,9 +24989,10 @@ func (self *NextWindowData) WindowClass() WindowClass {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiNextWindowData_GetWindowClass(selfArg)
-	return *newWindowClassFromC(func() *C.ImGuiWindowClass { result := result; return &result }())
+	return *newWindowClassFromC(func() *C.ImGuiWindowClass {
+		result := C.wrap_ImGuiNextWindowData_GetWindowClass(selfArg)
+		return &result
+	}())
 }
 
 func (self NextWindowData) SetMenuBarOffsetMinVal(v Vec2) {
@@ -25225,9 +25084,7 @@ func (self *OldColumns) ID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiOldColumns_GetID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiOldColumns_GetID(selfArg); return &result }())
 }
 
 func (self OldColumns) SetFlags(v OldColumnFlags) {
@@ -25477,9 +25334,7 @@ func (self *OldColumns) Splitter() DrawListSplitter {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiOldColumns_GetSplitter(selfArg)
-	return *newDrawListSplitterFromC(func() *C.ImDrawListSplitter { result := result; return &result }())
+	return *newDrawListSplitterFromC(func() *C.ImDrawListSplitter { result := C.wrap_ImGuiOldColumns_GetSplitter(selfArg); return &result }())
 }
 
 func (self OnceUponAFrame) SetRefFrame(v int32) {
@@ -25541,9 +25396,7 @@ func (self *Payload) SourceId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiPayload_GetSourceId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiPayload_GetSourceId(selfArg); return &result }())
 }
 
 func (self Payload) SetSourceParentId(v ID) {
@@ -25560,9 +25413,7 @@ func (self *Payload) SourceParentId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiPayload_GetSourceParentId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiPayload_GetSourceParentId(selfArg); return &result }())
 }
 
 func (self Payload) SetDataFrameCount(v int32) {
@@ -25797,9 +25648,7 @@ func (self *PopupData) PopupId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiPopupData_GetPopupId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiPopupData_GetPopupId(selfArg); return &result }())
 }
 
 func (self PopupData) SetWindow(v *Window) {
@@ -25880,9 +25729,7 @@ func (self *PopupData) OpenParentId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiPopupData_GetOpenParentId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiPopupData_GetOpenParentId(selfArg); return &result }())
 }
 
 func (self PopupData) SetOpenPopupPos(v Vec2) {
@@ -25976,9 +25823,7 @@ func (self *SettingsHandler) TypeHash() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiSettingsHandler_GetTypeHash(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiSettingsHandler_GetTypeHash(selfArg); return &result }())
 }
 
 func (self SettingsHandler) SetUserData(v uintptr) {
@@ -26115,9 +25960,7 @@ func (self *StackLevelInfo) ID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiStackLevelInfo_GetID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiStackLevelInfo_GetID(selfArg); return &result }())
 }
 
 func (self StackLevelInfo) SetQueryFrameCount(v int) {
@@ -26352,9 +26195,7 @@ func (self *StoragePair) Key() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiStoragePair_GetKey(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiStoragePair_GetKey(selfArg); return &result }())
 }
 
 func (self Style) SetAlpha(v float32) {
@@ -27204,9 +27045,7 @@ func (self *TabBar) ID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTabBar_GetID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiTabBar_GetID(selfArg); return &result }())
 }
 
 func (self TabBar) SetSelectedTabId(v ID) {
@@ -27223,9 +27062,7 @@ func (self *TabBar) SelectedTabId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTabBar_GetSelectedTabId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiTabBar_GetSelectedTabId(selfArg); return &result }())
 }
 
 func (self TabBar) SetNextSelectedTabId(v ID) {
@@ -27242,9 +27079,7 @@ func (self *TabBar) NextSelectedTabId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTabBar_GetNextSelectedTabId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiTabBar_GetNextSelectedTabId(selfArg); return &result }())
 }
 
 func (self TabBar) SetVisibleTabId(v ID) {
@@ -27261,9 +27096,7 @@ func (self *TabBar) VisibleTabId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTabBar_GetVisibleTabId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiTabBar_GetVisibleTabId(selfArg); return &result }())
 }
 
 func (self TabBar) SetCurrFrameVisible(v int32) {
@@ -27505,9 +27338,7 @@ func (self *TabBar) ReorderRequestTabId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTabBar_GetReorderRequestTabId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiTabBar_GetReorderRequestTabId(selfArg); return &result }())
 }
 
 func (self TabBar) SetReorderRequestOffset(v int) {
@@ -27674,9 +27505,7 @@ func (self *TabBar) TabsNames() TextBuffer {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTabBar_GetTabsNames(selfArg)
-	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := result; return &result }())
+	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := C.wrap_ImGuiTabBar_GetTabsNames(selfArg); return &result }())
 }
 
 func (self TabItem) SetID(v ID) {
@@ -27693,9 +27522,7 @@ func (self *TabItem) ID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTabItem_GetID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiTabItem_GetID(selfArg); return &result }())
 }
 
 func (self TabItem) SetFlags(v TabItemFlags) {
@@ -27894,9 +27721,7 @@ func (self *Table) ID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTable_GetID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiTable_GetID(selfArg); return &result }())
 }
 
 func (self Table) SetFlags(v TableFlags) {
@@ -27960,9 +27785,10 @@ func (self *Table) EnabledMaskByDisplayOrder() BitArrayPtr {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTable_GetEnabledMaskByDisplayOrder(selfArg)
-	return *newBitArrayPtrFromC(func() *C.ImBitArrayPtr { result := result; return &result }())
+	return *newBitArrayPtrFromC(func() *C.ImBitArrayPtr {
+		result := C.wrap_ImGuiTable_GetEnabledMaskByDisplayOrder(selfArg)
+		return &result
+	}())
 }
 
 func (self Table) SetEnabledMaskByIndex(v BitArrayPtr) {
@@ -27979,9 +27805,7 @@ func (self *Table) EnabledMaskByIndex() BitArrayPtr {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTable_GetEnabledMaskByIndex(selfArg)
-	return *newBitArrayPtrFromC(func() *C.ImBitArrayPtr { result := result; return &result }())
+	return *newBitArrayPtrFromC(func() *C.ImBitArrayPtr { result := C.wrap_ImGuiTable_GetEnabledMaskByIndex(selfArg); return &result }())
 }
 
 func (self Table) SetVisibleMaskByIndex(v BitArrayPtr) {
@@ -27998,9 +27822,7 @@ func (self *Table) VisibleMaskByIndex() BitArrayPtr {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTable_GetVisibleMaskByIndex(selfArg)
-	return *newBitArrayPtrFromC(func() *C.ImBitArrayPtr { result := result; return &result }())
+	return *newBitArrayPtrFromC(func() *C.ImBitArrayPtr { result := C.wrap_ImGuiTable_GetVisibleMaskByIndex(selfArg); return &result }())
 }
 
 func (self Table) SetSettingsLoadedFlags(v TableFlags) {
@@ -28741,9 +28563,7 @@ func (self *Table) ColumnsNames() TextBuffer {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTable_GetColumnsNames(selfArg)
-	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := result; return &result }())
+	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := C.wrap_ImGuiTable_GetColumnsNames(selfArg); return &result }())
 }
 
 func (self Table) SetDrawSplitter(v *DrawListSplitter) {
@@ -28777,9 +28597,10 @@ func (self *Table) InstanceDataFirst() TableInstanceData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTable_GetInstanceDataFirst(selfArg)
-	return *newTableInstanceDataFromC(func() *C.ImGuiTableInstanceData { result := result; return &result }())
+	return *newTableInstanceDataFromC(func() *C.ImGuiTableInstanceData {
+		result := C.wrap_ImGuiTable_GetInstanceDataFirst(selfArg)
+		return &result
+	}())
 }
 
 func (self Table) SetInstanceDataExtra(v Vector[*TableInstanceData]) {
@@ -28819,9 +28640,10 @@ func (self *Table) SortSpecsSingle() TableColumnSortSpecs {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTable_GetSortSpecsSingle(selfArg)
-	return *newTableColumnSortSpecsFromC(func() *C.ImGuiTableColumnSortSpecs { result := result; return &result }())
+	return *newTableColumnSortSpecsFromC(func() *C.ImGuiTableColumnSortSpecs {
+		result := C.wrap_ImGuiTable_GetSortSpecsSingle(selfArg)
+		return &result
+	}())
 }
 
 func (self Table) SetSortSpecsMulti(v Vector[*TableColumnSortSpecs]) {
@@ -28861,9 +28683,7 @@ func (self *Table) SortSpecs() TableSortSpecs {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTable_GetSortSpecs(selfArg)
-	return *newTableSortSpecsFromC(func() *C.ImGuiTableSortSpecs { result := result; return &result }())
+	return *newTableSortSpecsFromC(func() *C.ImGuiTableSortSpecs { result := C.wrap_ImGuiTable_GetSortSpecs(selfArg); return &result }())
 }
 
 func (self Table) SetDummyDrawChannel(v TableDrawChannelIdx) {
@@ -28880,9 +28700,10 @@ func (self *Table) DummyDrawChannel() TableDrawChannelIdx {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTable_GetDummyDrawChannel(selfArg)
-	return *newTableDrawChannelIdxFromC(func() *C.ImGuiTableDrawChannelIdx { result := result; return &result }())
+	return *newTableDrawChannelIdxFromC(func() *C.ImGuiTableDrawChannelIdx {
+		result := C.wrap_ImGuiTable_GetDummyDrawChannel(selfArg)
+		return &result
+	}())
 }
 
 func (self Table) SetBg2DrawChannelCurrent(v TableDrawChannelIdx) {
@@ -28899,9 +28720,10 @@ func (self *Table) Bg2DrawChannelCurrent() TableDrawChannelIdx {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTable_GetBg2DrawChannelCurrent(selfArg)
-	return *newTableDrawChannelIdxFromC(func() *C.ImGuiTableDrawChannelIdx { result := result; return &result }())
+	return *newTableDrawChannelIdxFromC(func() *C.ImGuiTableDrawChannelIdx {
+		result := C.wrap_ImGuiTable_GetBg2DrawChannelCurrent(selfArg)
+		return &result
+	}())
 }
 
 func (self Table) SetBg2DrawChannelUnfrozen(v TableDrawChannelIdx) {
@@ -28918,9 +28740,10 @@ func (self *Table) Bg2DrawChannelUnfrozen() TableDrawChannelIdx {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTable_GetBg2DrawChannelUnfrozen(selfArg)
-	return *newTableDrawChannelIdxFromC(func() *C.ImGuiTableDrawChannelIdx { result := result; return &result }())
+	return *newTableDrawChannelIdxFromC(func() *C.ImGuiTableDrawChannelIdx {
+		result := C.wrap_ImGuiTable_GetBg2DrawChannelUnfrozen(selfArg)
+		return &result
+	}())
 }
 
 func (self Table) SetIsLayoutLocked(v bool) {
@@ -29387,9 +29210,7 @@ func (self *TableColumn) UserID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTableColumn_GetUserID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiTableColumn_GetUserID(selfArg); return &result }())
 }
 
 func (self TableColumn) SetWorkMinX(v float32) {
@@ -29526,9 +29347,10 @@ func (self *TableColumn) DrawChannelCurrent() TableDrawChannelIdx {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTableColumn_GetDrawChannelCurrent(selfArg)
-	return *newTableDrawChannelIdxFromC(func() *C.ImGuiTableDrawChannelIdx { result := result; return &result }())
+	return *newTableDrawChannelIdxFromC(func() *C.ImGuiTableDrawChannelIdx {
+		result := C.wrap_ImGuiTableColumn_GetDrawChannelCurrent(selfArg)
+		return &result
+	}())
 }
 
 func (self TableColumn) SetDrawChannelFrozen(v TableDrawChannelIdx) {
@@ -29545,9 +29367,10 @@ func (self *TableColumn) DrawChannelFrozen() TableDrawChannelIdx {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTableColumn_GetDrawChannelFrozen(selfArg)
-	return *newTableDrawChannelIdxFromC(func() *C.ImGuiTableDrawChannelIdx { result := result; return &result }())
+	return *newTableDrawChannelIdxFromC(func() *C.ImGuiTableDrawChannelIdx {
+		result := C.wrap_ImGuiTableColumn_GetDrawChannelFrozen(selfArg)
+		return &result
+	}())
 }
 
 func (self TableColumn) SetDrawChannelUnfrozen(v TableDrawChannelIdx) {
@@ -29564,9 +29387,10 @@ func (self *TableColumn) DrawChannelUnfrozen() TableDrawChannelIdx {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTableColumn_GetDrawChannelUnfrozen(selfArg)
-	return *newTableDrawChannelIdxFromC(func() *C.ImGuiTableDrawChannelIdx { result := result; return &result }())
+	return *newTableDrawChannelIdxFromC(func() *C.ImGuiTableDrawChannelIdx {
+		result := C.wrap_ImGuiTableColumn_GetDrawChannelUnfrozen(selfArg)
+		return &result
+	}())
 }
 
 func (self TableColumn) SetIsEnabled(v bool) {
@@ -29823,9 +29647,7 @@ func (self *TableColumnSettings) UserID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTableColumnSettings_GetUserID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiTableColumnSettings_GetUserID(selfArg); return &result }())
 }
 
 func (self TableColumnSettings) SetSortDirection(v byte) {
@@ -29887,9 +29709,7 @@ func (self *TableColumnSortSpecs) ColumnUserID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTableColumnSortSpecs_GetColumnUserID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiTableColumnSortSpecs_GetColumnUserID(selfArg); return &result }())
 }
 
 func (self TableColumnSortSpecs) SetColumnIndex(v int) {
@@ -29951,9 +29771,7 @@ func (self *TableInstanceData) TableInstanceID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTableInstanceData_GetTableInstanceID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiTableInstanceData_GetTableInstanceID(selfArg); return &result }())
 }
 
 func (self TableInstanceData) SetLastOuterHeight(v float32) {
@@ -30045,9 +29863,7 @@ func (self *TableSettings) ID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTableSettings_GetID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiTableSettings_GetID(selfArg); return &result }())
 }
 
 func (self TableSettings) SetSaveFlags(v TableFlags) {
@@ -30216,9 +30032,10 @@ func (self *TableTempData) DrawSplitter() DrawListSplitter {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTableTempData_GetDrawSplitter(selfArg)
-	return *newDrawListSplitterFromC(func() *C.ImDrawListSplitter { result := result; return &result }())
+	return *newDrawListSplitterFromC(func() *C.ImDrawListSplitter {
+		result := C.wrap_ImGuiTableTempData_GetDrawSplitter(selfArg)
+		return &result
+	}())
 }
 
 func (self TableTempData) SetHostBackupWorkRect(v Rect) {
@@ -30310,9 +30127,10 @@ func (self *TableTempData) HostBackupColumnsOffset() Vec1 {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTableTempData_GetHostBackupColumnsOffset(selfArg)
-	return *newVec1FromC(func() *C.ImVec1 { result := result; return &result }())
+	return *newVec1FromC(func() *C.ImVec1 {
+		result := C.wrap_ImGuiTableTempData_GetHostBackupColumnsOffset(selfArg)
+		return &result
+	}())
 }
 
 func (self TableTempData) SetHostBackupItemWidth(v float32) {
@@ -30599,9 +30417,10 @@ func (self *TypingSelectState) Request() TypingSelectRequest {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTypingSelectState_GetRequest(selfArg)
-	return *newTypingSelectRequestFromC(func() *C.ImGuiTypingSelectRequest { result := result; return &result }())
+	return *newTypingSelectRequestFromC(func() *C.ImGuiTypingSelectRequest {
+		result := C.wrap_ImGuiTypingSelectState_GetRequest(selfArg)
+		return &result
+	}())
 }
 
 func (self TypingSelectState) SetSearchBuffer(v *[64]rune) {
@@ -30633,9 +30452,7 @@ func (self *TypingSelectState) FocusScope() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiTypingSelectState_GetFocusScope(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiTypingSelectState_GetFocusScope(selfArg); return &result }())
 }
 
 func (self TypingSelectState) SetLastRequestFrame(v int32) {
@@ -30697,9 +30514,7 @@ func (self *Viewport) ID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiViewport_GetID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiViewport_GetID(selfArg); return &result }())
 }
 
 func (self Viewport) SetFlags(v ViewportFlags) {
@@ -30806,9 +30621,7 @@ func (self *Viewport) ParentViewportId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiViewport_GetParentViewportId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiViewport_GetParentViewportId(selfArg); return &result }())
 }
 
 func (self Viewport) SetDrawData(v *DrawData) {
@@ -30962,9 +30775,7 @@ func (self *ViewportP) ImGuiViewport() Viewport {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiViewportP_Get_ImGuiViewport(selfArg)
-	return *newViewportFromC(func() *C.ImGuiViewport { result := result; return &result }())
+	return *newViewportFromC(func() *C.ImGuiViewport { result := C.wrap_ImGuiViewportP_Get_ImGuiViewport(selfArg); return &result }())
 }
 
 func (self ViewportP) SetWindow(v *Window) {
@@ -31043,9 +30854,7 @@ func (self *ViewportP) LastNameHash() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiViewportP_GetLastNameHash(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiViewportP_GetLastNameHash(selfArg); return &result }())
 }
 
 func (self ViewportP) SetLastPos(v Vec2) {
@@ -31168,9 +30977,7 @@ func (self *ViewportP) DrawDataP() DrawData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiViewportP_GetDrawDataP(selfArg)
-	return *newDrawDataFromC(func() *C.ImDrawData { result := result; return &result }())
+	return *newDrawDataFromC(func() *C.ImDrawData { result := C.wrap_ImGuiViewportP_GetDrawDataP(selfArg); return &result }())
 }
 
 func (self ViewportP) SetDrawDataBuilder(v DrawDataBuilder) {
@@ -31187,9 +30994,10 @@ func (self *ViewportP) DrawDataBuilder() DrawDataBuilder {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiViewportP_GetDrawDataBuilder(selfArg)
-	return *newDrawDataBuilderFromC(func() *C.ImDrawDataBuilder { result := result; return &result }())
+	return *newDrawDataBuilderFromC(func() *C.ImDrawDataBuilder {
+		result := C.wrap_ImGuiViewportP_GetDrawDataBuilder(selfArg)
+		return &result
+	}())
 }
 
 func (self ViewportP) SetLastPlatformPos(v Vec2) {
@@ -31345,9 +31153,7 @@ func (self *Window) ID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindow_GetID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiWindow_GetID(selfArg); return &result }())
 }
 
 func (self Window) SetFlags(v WindowFlags) {
@@ -31409,9 +31215,7 @@ func (self *Window) WindowClass() WindowClass {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindow_GetWindowClass(selfArg)
-	return *newWindowClassFromC(func() *C.ImGuiWindowClass { result := result; return &result }())
+	return *newWindowClassFromC(func() *C.ImGuiWindowClass { result := C.wrap_ImGuiWindow_GetWindowClass(selfArg); return &result }())
 }
 
 func (self Window) SetViewport(v *ViewportP) {
@@ -31445,9 +31249,7 @@ func (self *Window) ViewportId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindow_GetViewportId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiWindow_GetViewportId(selfArg); return &result }())
 }
 
 func (self Window) SetViewportPos(v Vec2) {
@@ -31734,9 +31536,7 @@ func (self *Window) MoveId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindow_GetMoveId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiWindow_GetMoveId(selfArg); return &result }())
 }
 
 func (self Window) SetTabId(v ID) {
@@ -31753,9 +31553,7 @@ func (self *Window) TabId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindow_GetTabId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiWindow_GetTabId(selfArg); return &result }())
 }
 
 func (self Window) SetChildId(v ID) {
@@ -31772,9 +31570,7 @@ func (self *Window) ChildId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindow_GetChildId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiWindow_GetChildId(selfArg); return &result }())
 }
 
 func (self Window) SetScroll(v Vec2) {
@@ -32166,9 +31962,7 @@ func (self *Window) PopupId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindow_GetPopupId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiWindow_GetPopupId(selfArg); return &result }())
 }
 
 func (self Window) SetAutoFitFramesX(v int) {
@@ -32418,9 +32212,7 @@ func (self *Window) DC() WindowTempData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindow_GetDC(selfArg)
-	return *newWindowTempDataFromC(func() *C.ImGuiWindowTempData { result := result; return &result }())
+	return *newWindowTempDataFromC(func() *C.ImGuiWindowTempData { result := C.wrap_ImGuiWindow_GetDC(selfArg); return &result }())
 }
 
 func (self Window) SetOuterRectClipped(v Rect) {
@@ -32602,9 +32394,7 @@ func (self *Window) StateStorage() Storage {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindow_GetStateStorage(selfArg)
-	return *newStorageFromC(func() *C.ImGuiStorage { result := result; return &result }())
+	return *newStorageFromC(func() *C.ImGuiStorage { result := C.wrap_ImGuiWindow_GetStateStorage(selfArg); return &result }())
 }
 
 func (self Window) SetColumnsStorage(v Vector[*OldColumns]) {
@@ -32706,9 +32496,7 @@ func (self *Window) DrawListInst() DrawList {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindow_GetDrawListInst(selfArg)
-	return *newDrawListFromC(func() *C.ImDrawList { result := result; return &result }())
+	return *newDrawListFromC(func() *C.ImDrawList { result := C.wrap_ImGuiWindow_GetDrawListInst(selfArg); return &result }())
 }
 
 func (self Window) SetParentWindow(v *Window) {
@@ -32923,9 +32711,7 @@ func (self *Window) NavRootFocusScopeId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindow_GetNavRootFocusScopeId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiWindow_GetNavRootFocusScopeId(selfArg); return &result }())
 }
 
 func (self Window) SetMemoryDrawListIdxCapacity(v int32) {
@@ -33062,9 +32848,7 @@ func (self *Window) DockStyle() WindowDockStyle {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindow_GetDockStyle(selfArg)
-	return *newWindowDockStyleFromC(func() *C.ImGuiWindowDockStyle { result := result; return &result }())
+	return *newWindowDockStyleFromC(func() *C.ImGuiWindowDockStyle { result := C.wrap_ImGuiWindow_GetDockStyle(selfArg); return &result }())
 }
 
 func (self Window) SetDockNode(v *DockNode) {
@@ -33115,9 +32899,7 @@ func (self *Window) DockId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindow_GetDockId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiWindow_GetDockId(selfArg); return &result }())
 }
 
 func (self Window) SetDockTabItemStatusFlags(v ItemStatusFlags) {
@@ -33164,9 +32946,7 @@ func (self *WindowClass) ClassId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindowClass_GetClassId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiWindowClass_GetClassId(selfArg); return &result }())
 }
 
 func (self WindowClass) SetParentViewportId(v ID) {
@@ -33183,9 +32963,7 @@ func (self *WindowClass) ParentViewportId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindowClass_GetParentViewportId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiWindowClass_GetParentViewportId(selfArg); return &result }())
 }
 
 func (self WindowClass) SetFocusRouteParentWindowId(v ID) {
@@ -33202,9 +32980,10 @@ func (self *WindowClass) FocusRouteParentWindowId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindowClass_GetFocusRouteParentWindowId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID {
+		result := C.wrap_ImGuiWindowClass_GetFocusRouteParentWindowId(selfArg)
+		return &result
+	}())
 }
 
 func (self WindowClass) SetViewportFlagsOverrideSet(v ViewportFlags) {
@@ -33326,9 +33105,7 @@ func (self *WindowSettings) ID() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindowSettings_GetID(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiWindowSettings_GetID(selfArg); return &result }())
 }
 
 func (self WindowSettings) SetViewportId(v ID) {
@@ -33345,9 +33122,7 @@ func (self *WindowSettings) ViewportId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindowSettings_GetViewportId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiWindowSettings_GetViewportId(selfArg); return &result }())
 }
 
 func (self WindowSettings) SetDockId(v ID) {
@@ -33364,9 +33139,7 @@ func (self *WindowSettings) DockId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindowSettings_GetDockId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiWindowSettings_GetDockId(selfArg); return &result }())
 }
 
 func (self WindowSettings) SetClassId(v ID) {
@@ -33383,9 +33156,7 @@ func (self *WindowSettings) ClassId() ID {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindowSettings_GetClassId(selfArg)
-	return *newIDFromC(func() *C.ImGuiID { result := result; return &result }())
+	return *newIDFromC(func() *C.ImGuiID { result := C.wrap_ImGuiWindowSettings_GetClassId(selfArg); return &result }())
 }
 
 func (self WindowSettings) SetDockOrder(v int16) {
@@ -33494,9 +33265,10 @@ func (self *WindowStackData) ParentLastItemDataBackup() LastItemData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindowStackData_GetParentLastItemDataBackup(selfArg)
-	return *newLastItemDataFromC(func() *C.ImGuiLastItemData { result := result; return &result }())
+	return *newLastItemDataFromC(func() *C.ImGuiLastItemData {
+		result := C.wrap_ImGuiWindowStackData_GetParentLastItemDataBackup(selfArg)
+		return &result
+	}())
 }
 
 func (self WindowStackData) SetStackSizesOnBegin(v StackSizes) {
@@ -33513,9 +33285,10 @@ func (self *WindowStackData) StackSizesOnBegin() StackSizes {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindowStackData_GetStackSizesOnBegin(selfArg)
-	return *newStackSizesFromC(func() *C.ImGuiStackSizes { result := result; return &result }())
+	return *newStackSizesFromC(func() *C.ImGuiStackSizes {
+		result := C.wrap_ImGuiWindowStackData_GetStackSizesOnBegin(selfArg)
+		return &result
+	}())
 }
 
 func (self WindowTempData) SetCursorPos(v Vec2) {
@@ -33697,9 +33470,7 @@ func (self *WindowTempData) Indent() Vec1 {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindowTempData_GetIndent(selfArg)
-	return *newVec1FromC(func() *C.ImVec1 { result := result; return &result }())
+	return *newVec1FromC(func() *C.ImVec1 { result := C.wrap_ImGuiWindowTempData_GetIndent(selfArg); return &result }())
 }
 
 func (self WindowTempData) SetColumnsOffset(v Vec1) {
@@ -33716,9 +33487,7 @@ func (self *WindowTempData) ColumnsOffset() Vec1 {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindowTempData_GetColumnsOffset(selfArg)
-	return *newVec1FromC(func() *C.ImVec1 { result := result; return &result }())
+	return *newVec1FromC(func() *C.ImVec1 { result := C.wrap_ImGuiWindowTempData_GetColumnsOffset(selfArg); return &result }())
 }
 
 func (self WindowTempData) SetGroupOffset(v Vec1) {
@@ -33735,9 +33504,7 @@ func (self *WindowTempData) GroupOffset() Vec1 {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindowTempData_GetGroupOffset(selfArg)
-	return *newVec1FromC(func() *C.ImVec1 { result := result; return &result }())
+	return *newVec1FromC(func() *C.ImVec1 { result := C.wrap_ImGuiWindowTempData_GetGroupOffset(selfArg); return &result }())
 }
 
 func (self WindowTempData) SetCursorStartPosLossyness(v Vec2) {
@@ -33889,9 +33656,10 @@ func (self *WindowTempData) MenuColumns() MenuColumns {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImGuiWindowTempData_GetMenuColumns(selfArg)
-	return *newMenuColumnsFromC(func() *C.ImGuiMenuColumns { result := result; return &result }())
+	return *newMenuColumnsFromC(func() *C.ImGuiMenuColumns {
+		result := C.wrap_ImGuiWindowTempData_GetMenuColumns(selfArg)
+		return &result
+	}())
 }
 
 func (self WindowTempData) SetTreeDepth(v int32) {
@@ -34217,9 +33985,7 @@ func (self *STBTexteditState) TexteditStateGetUndostate() StbUndoState {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_STB_TexteditState_GetUndostate(selfArg)
-	return *newStbUndoStateFromC(func() *C.StbUndoState { result := result; return &result }())
+	return *newStbUndoStateFromC(func() *C.StbUndoState { result := C.wrap_STB_TexteditState_GetUndostate(selfArg); return &result }())
 }
 
 func (self StbTexteditRow) SetX0(v float32) {

--- a/cimmarkdown_funcs.go
+++ b/cimmarkdown_funcs.go
@@ -169,9 +169,7 @@ func (self *Emphasis) Text() TextBlock {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_Emphasis_GetText(selfArg)
-	return *newTextBlockFromC(func() *C.TextBlock { result := result; return &result }())
+	return *newTextBlockFromC(func() *C.TextBlock { result := C.wrap_Emphasis_GetText(selfArg); return &result }())
 }
 
 func (self Emphasis) SetSym(v rune) {
@@ -368,9 +366,7 @@ func (self *Link) Text() TextBlock {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_Link_GetText(selfArg)
-	return *newTextBlockFromC(func() *C.TextBlock { result := result; return &result }())
+	return *newTextBlockFromC(func() *C.TextBlock { result := C.wrap_Link_GetText(selfArg); return &result }())
 }
 
 func (self Link) SetUrl(v TextBlock) {
@@ -387,9 +383,7 @@ func (self *Link) Url() TextBlock {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_Link_GetUrl(selfArg)
-	return *newTextBlockFromC(func() *C.TextBlock { result := result; return &result }())
+	return *newTextBlockFromC(func() *C.TextBlock { result := C.wrap_Link_GetUrl(selfArg); return &result }())
 }
 
 func (self Link) SetIsImage(v bool) {
@@ -770,9 +764,10 @@ func (self *MarkdownTooltipCallbackData) LinkData() MarkdownLinkCallbackData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_MarkdownTooltipCallbackData_GetLinkData(selfArg)
-	return *newMarkdownLinkCallbackDataFromC(func() *C.MarkdownLinkCallbackData { result := result; return &result }())
+	return *newMarkdownLinkCallbackDataFromC(func() *C.MarkdownLinkCallbackData {
+		result := C.wrap_MarkdownTooltipCallbackData_GetLinkData(selfArg)
+		return &result
+	}())
 }
 
 func (self MarkdownTooltipCallbackData) SetLinkIcon(v string) {

--- a/cimnodes_funcs.go
+++ b/cimnodes_funcs.go
@@ -638,9 +638,10 @@ func (self *NodesIO) EmulateThreeButtonMouse() EmulateThreeButtonMouse {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImNodesIO_GetEmulateThreeButtonMouse(selfArg)
-	return *newEmulateThreeButtonMouseFromC(func() *C.EmulateThreeButtonMouse { result := result; return &result }())
+	return *newEmulateThreeButtonMouseFromC(func() *C.EmulateThreeButtonMouse {
+		result := C.wrap_ImNodesIO_GetEmulateThreeButtonMouse(selfArg)
+		return &result
+	}())
 }
 
 func (self NodesIO) SetLinkDetachWithModifierClick(v LinkDetachWithModifierClick) {
@@ -657,9 +658,10 @@ func (self *NodesIO) LinkDetachWithModifierClick() LinkDetachWithModifierClick {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImNodesIO_GetLinkDetachWithModifierClick(selfArg)
-	return *newLinkDetachWithModifierClickFromC(func() *C.LinkDetachWithModifierClick { result := result; return &result }())
+	return *newLinkDetachWithModifierClickFromC(func() *C.LinkDetachWithModifierClick {
+		result := C.wrap_ImNodesIO_GetLinkDetachWithModifierClick(selfArg)
+		return &result
+	}())
 }
 
 func (self NodesIO) SetMultipleSelectModifier(v MultipleSelectModifier) {
@@ -676,9 +678,10 @@ func (self *NodesIO) MultipleSelectModifier() MultipleSelectModifier {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImNodesIO_GetMultipleSelectModifier(selfArg)
-	return *newMultipleSelectModifierFromC(func() *C.MultipleSelectModifier { result := result; return &result }())
+	return *newMultipleSelectModifierFromC(func() *C.MultipleSelectModifier {
+		result := C.wrap_ImNodesIO_GetMultipleSelectModifier(selfArg)
+		return &result
+	}())
 }
 
 func (self NodesIO) SetAltMouseButton(v int32) {

--- a/cimplot_funcs.go
+++ b/cimplot_funcs.go
@@ -13496,9 +13496,7 @@ func (self *FormatterTimeData) TimeDataGetSpec() PlotDateTimeSpec {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_Formatter_Time_Data_GetSpec(selfArg)
-	return *newPlotDateTimeSpecFromC(func() *C.ImPlotDateTimeSpec { result := result; return &result }())
+	return *newPlotDateTimeSpecFromC(func() *C.ImPlotDateTimeSpec { result := C.wrap_Formatter_Time_Data_GetSpec(selfArg); return &result }())
 }
 
 func (self *FormatterTimeData) TimeDataGetUserFormatterData() uintptr {
@@ -13712,9 +13710,10 @@ func (self *PlotAnnotationCollection) TextBuffer() TextBuffer {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotAnnotationCollection_GetTextBuffer(selfArg)
-	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := result; return &result }())
+	return *newTextBufferFromC(func() *C.ImGuiTextBuffer {
+		result := C.wrap_ImPlotAnnotationCollection_GetTextBuffer(selfArg)
+		return &result
+	}())
 }
 
 func (self PlotAnnotationCollection) SetSize(v int32) {
@@ -13784,9 +13783,7 @@ func (self *PlotAxis) Range() PlotRange {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotAxis_GetRange(selfArg)
-	return *newPlotRangeFromC(func() *C.ImPlotRange { result := result; return &result }())
+	return *newPlotRangeFromC(func() *C.ImPlotRange { result := C.wrap_ImPlotAxis_GetRange(selfArg); return &result }())
 }
 
 func (self PlotAxis) SetRangeCond(v PlotCond) {
@@ -13833,9 +13830,7 @@ func (self *PlotAxis) FitExtents() PlotRange {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotAxis_GetFitExtents(selfArg)
-	return *newPlotRangeFromC(func() *C.ImPlotRange { result := result; return &result }())
+	return *newPlotRangeFromC(func() *C.ImPlotRange { result := C.wrap_ImPlotAxis_GetFitExtents(selfArg); return &result }())
 }
 
 func (self PlotAxis) SetOrthoAxis(v *PlotAxis) {
@@ -13869,9 +13864,7 @@ func (self *PlotAxis) ConstraintRange() PlotRange {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotAxis_GetConstraintRange(selfArg)
-	return *newPlotRangeFromC(func() *C.ImPlotRange { result := result; return &result }())
+	return *newPlotRangeFromC(func() *C.ImPlotRange { result := C.wrap_ImPlotAxis_GetConstraintRange(selfArg); return &result }())
 }
 
 func (self PlotAxis) SetConstraintZoom(v PlotRange) {
@@ -13888,9 +13881,7 @@ func (self *PlotAxis) ConstraintZoom() PlotRange {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotAxis_GetConstraintZoom(selfArg)
-	return *newPlotRangeFromC(func() *C.ImPlotRange { result := result; return &result }())
+	return *newPlotRangeFromC(func() *C.ImPlotRange { result := C.wrap_ImPlotAxis_GetConstraintZoom(selfArg); return &result }())
 }
 
 func (self PlotAxis) SetTicker(v PlotTicker) {
@@ -13907,9 +13898,7 @@ func (self *PlotAxis) Ticker() PlotTicker {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotAxis_GetTicker(selfArg)
-	return *newPlotTickerFromC(func() *C.ImPlotTicker { result := result; return &result }())
+	return *newPlotTickerFromC(func() *C.ImPlotTicker { result := C.wrap_ImPlotAxis_GetTicker(selfArg); return &result }())
 }
 
 func (self PlotAxis) SetFormatterData(v uintptr) {
@@ -14554,9 +14543,7 @@ func (self *PlotColormapData) Text() TextBuffer {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotColormapData_GetText(selfArg)
-	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := result; return &result }())
+	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := C.wrap_ImPlotColormapData_GetText(selfArg); return &result }())
 }
 
 func (self PlotColormapData) SetTextOffsets(v Vector[*int32]) {
@@ -14610,9 +14597,7 @@ func (self *PlotColormapData) Map() Storage {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotColormapData_GetMap(selfArg)
-	return *newStorageFromC(func() *C.ImGuiStorage { result := result; return &result }())
+	return *newStorageFromC(func() *C.ImGuiStorage { result := C.wrap_ImPlotColormapData_GetMap(selfArg); return &result }())
 }
 
 func (self PlotColormapData) SetCount(v int32) {
@@ -14729,9 +14714,7 @@ func (self *PlotContext) CTicker() PlotTicker {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotContext_GetCTicker(selfArg)
-	return *newPlotTickerFromC(func() *C.ImPlotTicker { result := result; return &result }())
+	return *newPlotTickerFromC(func() *C.ImPlotTicker { result := C.wrap_ImPlotContext_GetCTicker(selfArg); return &result }())
 }
 
 func (self PlotContext) SetAnnotations(v PlotAnnotationCollection) {
@@ -14748,9 +14731,10 @@ func (self *PlotContext) Annotations() PlotAnnotationCollection {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotContext_GetAnnotations(selfArg)
-	return *newPlotAnnotationCollectionFromC(func() *C.ImPlotAnnotationCollection { result := result; return &result }())
+	return *newPlotAnnotationCollectionFromC(func() *C.ImPlotAnnotationCollection {
+		result := C.wrap_ImPlotContext_GetAnnotations(selfArg)
+		return &result
+	}())
 }
 
 func (self PlotContext) SetTags(v PlotTagCollection) {
@@ -14767,9 +14751,7 @@ func (self *PlotContext) Tags() PlotTagCollection {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotContext_GetTags(selfArg)
-	return *newPlotTagCollectionFromC(func() *C.ImPlotTagCollection { result := result; return &result }())
+	return *newPlotTagCollectionFromC(func() *C.ImPlotTagCollection { result := C.wrap_ImPlotContext_GetTags(selfArg); return &result }())
 }
 
 func (self PlotContext) SetStyle(v PlotStyle) {
@@ -14786,9 +14768,7 @@ func (self *PlotContext) Style() PlotStyle {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotContext_GetStyle(selfArg)
-	return *newPlotStyleFromC(func() *C.ImPlotStyle { result := result; return &result }())
+	return *newPlotStyleFromC(func() *C.ImPlotStyle { result := C.wrap_ImPlotContext_GetStyle(selfArg); return &result }())
 }
 
 func (self PlotContext) SetColorModifiers(v Vector[*ColorMod]) {
@@ -14851,9 +14831,7 @@ func (self *PlotContext) ColormapData() PlotColormapData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotContext_GetColormapData(selfArg)
-	return *newPlotColormapDataFromC(func() *C.ImPlotColormapData { result := result; return &result }())
+	return *newPlotColormapDataFromC(func() *C.ImPlotColormapData { result := C.wrap_ImPlotContext_GetColormapData(selfArg); return &result }())
 }
 
 func (self *PlotContext) ColormapModifiers() Vector[*PlotColormap] {
@@ -14978,9 +14956,7 @@ func (self *PlotContext) NextPlotData() PlotNextPlotData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotContext_GetNextPlotData(selfArg)
-	return *newPlotNextPlotDataFromC(func() *C.ImPlotNextPlotData { result := result; return &result }())
+	return *newPlotNextPlotDataFromC(func() *C.ImPlotNextPlotData { result := C.wrap_ImPlotContext_GetNextPlotData(selfArg); return &result }())
 }
 
 func (self PlotContext) SetNextItemData(v PlotNextItemData) {
@@ -14997,9 +14973,7 @@ func (self *PlotContext) NextItemData() PlotNextItemData {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotContext_GetNextItemData(selfArg)
-	return *newPlotNextItemDataFromC(func() *C.ImPlotNextItemData { result := result; return &result }())
+	return *newPlotNextItemDataFromC(func() *C.ImPlotNextItemData { result := C.wrap_ImPlotContext_GetNextItemData(selfArg); return &result }())
 }
 
 func (self PlotContext) SetInputMap(v PlotInputMap) {
@@ -15016,9 +14990,7 @@ func (self *PlotContext) InputMap() PlotInputMap {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotContext_GetInputMap(selfArg)
-	return *newPlotInputMapFromC(func() *C.ImPlotInputMap { result := result; return &result }())
+	return *newPlotInputMapFromC(func() *C.ImPlotInputMap { result := C.wrap_ImPlotContext_GetInputMap(selfArg); return &result }())
 }
 
 func (self PlotContext) SetOpenContextThisFrame(v bool) {
@@ -15050,9 +15022,10 @@ func (self *PlotContext) MousePosStringBuilder() TextBuffer {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotContext_GetMousePosStringBuilder(selfArg)
-	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := result; return &result }())
+	return *newTextBufferFromC(func() *C.ImGuiTextBuffer {
+		result := C.wrap_ImPlotContext_GetMousePosStringBuilder(selfArg)
+		return &result
+	}())
 }
 
 func (self PlotContext) SetSortItems(v *PlotItemGroup) {
@@ -15466,9 +15439,7 @@ func (self *PlotItemGroup) Legend() PlotLegend {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotItemGroup_GetLegend(selfArg)
-	return *newPlotLegendFromC(func() *C.ImPlotLegend { result := result; return &result }())
+	return *newPlotLegendFromC(func() *C.ImPlotLegend { result := C.wrap_ImPlotItemGroup_GetLegend(selfArg); return &result }())
 }
 
 func (self PlotItemGroup) SetColormapIdx(v int32) {
@@ -15598,9 +15569,7 @@ func (self *PlotLegend) Labels() TextBuffer {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotLegend_GetLabels(selfArg)
-	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := result; return &result }())
+	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := C.wrap_ImPlotLegend_GetLabels(selfArg); return &result }())
 }
 
 func (self PlotLegend) SetRect(v Rect) {
@@ -16124,9 +16093,7 @@ func (self *PlotPlot) TextBuffer() TextBuffer {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotPlot_GetTextBuffer(selfArg)
-	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := result; return &result }())
+	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := C.wrap_ImPlotPlot_GetTextBuffer(selfArg); return &result }())
 }
 
 func (self PlotPlot) SetItems(v PlotItemGroup) {
@@ -16143,9 +16110,7 @@ func (self *PlotPlot) Items() PlotItemGroup {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotPlot_GetItems(selfArg)
-	return *newPlotItemGroupFromC(func() *C.ImPlotItemGroup { result := result; return &result }())
+	return *newPlotItemGroupFromC(func() *C.ImPlotItemGroup { result := C.wrap_ImPlotPlot_GetItems(selfArg); return &result }())
 }
 
 func (self PlotPlot) SetCurrentX(v PlotAxisEnum) {
@@ -16522,9 +16487,7 @@ func (self *PlotRect) X() PlotRange {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotRect_GetX(selfArg)
-	return *newPlotRangeFromC(func() *C.ImPlotRange { result := result; return &result }())
+	return *newPlotRangeFromC(func() *C.ImPlotRange { result := C.wrap_ImPlotRect_GetX(selfArg); return &result }())
 }
 
 func (self PlotRect) SetY(v PlotRange) {
@@ -16541,9 +16504,7 @@ func (self *PlotRect) Y() PlotRange {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotRect_GetY(selfArg)
-	return *newPlotRangeFromC(func() *C.ImPlotRange { result := result; return &result }())
+	return *newPlotRangeFromC(func() *C.ImPlotRange { result := C.wrap_ImPlotRect_GetY(selfArg); return &result }())
 }
 
 func (self PlotStyle) SetLineWeight(v float32) {
@@ -17078,9 +17039,7 @@ func (self *PlotSubplot) Items() PlotItemGroup {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotSubplot_GetItems(selfArg)
-	return *newPlotItemGroupFromC(func() *C.ImPlotItemGroup { result := result; return &result }())
+	return *newPlotItemGroupFromC(func() *C.ImPlotItemGroup { result := C.wrap_ImPlotSubplot_GetItems(selfArg); return &result }())
 }
 
 func (self PlotSubplot) SetRows(v int32) {
@@ -17468,9 +17427,7 @@ func (self *PlotTagCollection) TextBuffer() TextBuffer {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotTagCollection_GetTextBuffer(selfArg)
-	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := result; return &result }())
+	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := C.wrap_ImPlotTagCollection_GetTextBuffer(selfArg); return &result }())
 }
 
 func (self PlotTagCollection) SetSize(v int32) {
@@ -17645,9 +17602,7 @@ func (self *PlotTicker) TextBuffer() TextBuffer {
 	defer func() {
 		selfFin()
 	}()
-
-	result := C.wrap_ImPlotTicker_GetTextBuffer(selfArg)
-	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := result; return &result }())
+	return *newTextBufferFromC(func() *C.ImGuiTextBuffer { result := C.wrap_ImPlotTicker_GetTextBuffer(selfArg); return &result }())
 }
 
 func (self PlotTicker) SetMaxSize(v Vec2) {

--- a/cmd/codegen/arguments_wrapper.go
+++ b/cmd/codegen/arguments_wrapper.go
@@ -34,7 +34,7 @@ type argumentWrapper func(arg ArgDef) ArgumentWrapperData
 func getArgWrapper(
 	a *ArgDef,
 	makeFirstArgReceiver, isGetter bool,
-	context *DataPack,
+	context *Context,
 ) (argDeclaration string, data ArgumentWrapperData, err error) {
 	argWrapperMap := map[CIdentifier]argumentWrapper{
 		"char":                simpleW("rune", "C.char"),

--- a/cmd/codegen/arguments_wrapper.go
+++ b/cmd/codegen/arguments_wrapper.go
@@ -36,7 +36,7 @@ func getArgWrapper(
 	makeFirstArgReceiver, isGetter bool,
 	structNames map[CIdentifier]bool,
 	enumNames map[GoIdentifier]bool,
-	refTypedefs map[CIdentifier]string, // <- this may be empty map if generating cimgui and should be cimgui's typedefs_dict.json for other
+	refTypedefs map[CIdentifier]bool, // <- this may be empty map if generating cimgui and should be cimgui's typedefs_dict.json for other
 ) (argDeclaration string, data ArgumentWrapperData, err error) {
 	argWrapperMap := map[CIdentifier]argumentWrapper{
 		"char":                simpleW("rune", "C.char"),

--- a/cmd/codegen/flags.go
+++ b/cmd/codegen/flags.go
@@ -2,12 +2,34 @@ package main
 
 import "flag"
 
-var flags struct {
-	showGenerated    bool
+type flags struct {
+	// TODO
+	showGenerated bool
+	// TODO
 	showNotGenerated bool
+
+	defJsonPath,
+	enumsJsonpath,
+	typedefsJsonpath,
+	refEnumsJsonPath,
+	refTypedefsJsonPath,
+	prefix,
+	include string
 }
 
-func parse() {
+func parse() *flags {
+	flags := &flags{}
 	flag.BoolVar(&flags.showGenerated, "generated", false, "Log about functions that was generated.")
 	flag.BoolVar(&flags.showNotGenerated, "not-generated", true, "Log about functions that was NOT generated.")
+
+	flag.StringVar(&flags.defJsonPath, "d", "", "definitions json file path")
+	flag.StringVar(&flags.enumsJsonpath, "e", "", "structs and enums json file path")
+	flag.StringVar(&flags.typedefsJsonpath, "t", "", "typedefs dict json file path")
+	flag.StringVar(&flags.refEnumsJsonPath, "r", "", "reference structs and enums json file path")
+	flag.StringVar(&flags.refTypedefsJsonPath, "rt", "", "reference typedefs_dict.json file path")
+	flag.StringVar(&flags.prefix, "p", "", "prefix for the generated file")
+	flag.StringVar(&flags.include, "i", "", "include header file")
+	flag.Parse()
+
+	return flags
 }

--- a/cmd/codegen/gengo_funcs.go
+++ b/cmd/codegen/gengo_funcs.go
@@ -35,13 +35,13 @@ const (
 // generateGoFuncs generates given list of functions and writes them to file
 func generateGoFuncs(
 	validFuncs []FuncDef,
-	data *DataPack) error {
+	context *Context) error {
 	generator := &goFuncsGenerator{
-		prefix:      data.prefix,
-		structNames: data.typedefsNames,
-		enumNames:   data.enumNames,
-		refTypedefs: data.refTypedefs,
-		context:     data,
+		prefix:      context.prefix,
+		structNames: context.typedefsNames,
+		enumNames:   context.enumNames,
+		refTypedefs: context.refTypedefs,
+		context:     context,
 	}
 
 	generator.writeFuncsFileHeader()
@@ -60,12 +60,12 @@ func generateGoFuncs(
 
 		// stop, when the function should not be generated
 		if !generator.shouldGenerate {
-			if data.flags.showNotGenerated {
+			if context.flags.showNotGenerated {
 				glg.Failf("not generated: %s%s", f.FuncName, f.Args)
 			}
 			continue
 		} else {
-			if data.flags.showGenerated {
+			if context.flags.showGenerated {
 				glg.Successf("generated: %s%s", f.FuncName, f.Args)
 			}
 		}
@@ -81,7 +81,7 @@ func generateGoFuncs(
 		100*float32(generator.convertedFuncCount)/float32(len(validFuncs)),
 	)
 
-	goFile, err := os.Create(fmt.Sprintf("%s_funcs.go", data.prefix))
+	goFile, err := os.Create(fmt.Sprintf("%s_funcs.go", context.prefix))
 	if err != nil {
 		panic(err.Error())
 	}
@@ -107,7 +107,7 @@ type goFuncsGenerator struct {
 	convertedFuncCount int
 	shouldGenerate     bool
 
-	context *DataPack
+	context *Context
 }
 
 // writeFuncsFileHeader writes a header of the generated file

--- a/cmd/codegen/gengo_funcs.go
+++ b/cmd/codegen/gengo_funcs.go
@@ -41,6 +41,7 @@ func generateGoFuncs(
 		structNames: data.typedefsNames,
 		enumNames:   data.enumNames,
 		refTypedefs: data.refTypedefs,
+		context:     data,
 	}
 
 	generator.writeFuncsFileHeader()
@@ -104,8 +105,9 @@ type goFuncsGenerator struct {
 
 	sb                 strings.Builder
 	convertedFuncCount int
+	shouldGenerate     bool
 
-	shouldGenerate bool
+	context *DataPack
 }
 
 // writeFuncsFileHeader writes a header of the generated file
@@ -131,7 +133,7 @@ func (g *goFuncsGenerator) GenerateFunction(f FuncDef, args []GoIdentifier, argW
 
 	// determine kind of function:
 	returnTypeType := returnTypeUnknown
-	_, err := getReturnWrapper(f.Ret, g.structNames, g.enumNames, g.refTypedefs) // TODO: we call this twice now
+	_, err := getReturnWrapper(f.Ret, g.context) // TODO: we call this twice now
 	if err == nil {
 		returnTypeType = returnTypeKnown
 	}
@@ -206,7 +208,7 @@ func (g *goFuncsGenerator) GenerateFunction(f FuncDef, args []GoIdentifier, argW
 		return false
 	}
 
-	rw, err := getReturnWrapper(cReturnType, g.structNames, g.enumNames, g.refTypedefs)
+	rw, err := getReturnWrapper(cReturnType, g.context)
 	if err != nil {
 		switch returnTypeType {
 		case returnTypeKnown, returnTypeStructPtr, returnTypeConstructor, returnTypeStruct:
@@ -360,9 +362,7 @@ func (g *goFuncsGenerator) generateFuncArgs(f FuncDef) (args []GoIdentifier, arg
 			&a,
 			i == 0 && f.StructSetter,
 			f.StructGetter && g.structNames[a.Type],
-			g.structNames,
-			g.enumNames,
-			g.refTypedefs,
+			g.context,
 		)
 		if err != nil {
 			glg.Debugf("Unknown argument type \"%s\" in function %s", a.Type, f.FuncName)

--- a/cmd/codegen/gengo_funcs.go
+++ b/cmd/codegen/gengo_funcs.go
@@ -33,20 +33,14 @@ const (
 )
 
 // generateGoFuncs generates given list of functions and writes them to file
-func generateGoFuncs(prefix string, validFuncs []FuncDef, enumNames []GoIdentifier, structNames []CIdentifier, refTypedefs map[CIdentifier]string) error {
+func generateGoFuncs(
+	validFuncs []FuncDef,
+	data *DataPack) error {
 	generator := &goFuncsGenerator{
-		prefix:      prefix,
-		structNames: make(map[CIdentifier]bool),
-		enumNames:   make(map[GoIdentifier]bool),
-		refTypedefs: refTypedefs,
-	}
-
-	for _, v := range structNames {
-		generator.structNames[v] = true
-	}
-
-	for _, v := range enumNames {
-		generator.enumNames[v] = true
+		prefix:      data.prefix,
+		structNames: data.typedefsNames,
+		enumNames:   data.enumNames,
+		refTypedefs: data.refTypedefs,
 	}
 
 	generator.writeFuncsFileHeader()
@@ -65,12 +59,12 @@ func generateGoFuncs(prefix string, validFuncs []FuncDef, enumNames []GoIdentifi
 
 		// stop, when the function should not be generated
 		if !generator.shouldGenerate {
-			if flags.showNotGenerated {
+			if data.flags.showNotGenerated {
 				glg.Failf("not generated: %s%s", f.FuncName, f.Args)
 			}
 			continue
 		} else {
-			if flags.showGenerated {
+			if data.flags.showGenerated {
 				glg.Successf("generated: %s%s", f.FuncName, f.Args)
 			}
 		}
@@ -86,7 +80,7 @@ func generateGoFuncs(prefix string, validFuncs []FuncDef, enumNames []GoIdentifi
 		100*float32(generator.convertedFuncCount)/float32(len(validFuncs)),
 	)
 
-	goFile, err := os.Create(fmt.Sprintf("%s_funcs.go", prefix))
+	goFile, err := os.Create(fmt.Sprintf("%s_funcs.go", data.prefix))
 	if err != nil {
 		panic(err.Error())
 	}
@@ -106,7 +100,7 @@ type goFuncsGenerator struct {
 	prefix      string
 	structNames map[CIdentifier]bool
 	enumNames   map[GoIdentifier]bool
-	refTypedefs map[CIdentifier]string
+	refTypedefs map[CIdentifier]bool
 
 	sb                 strings.Builder
 	convertedFuncCount int

--- a/cmd/codegen/gengo_typedefs.go
+++ b/cmd/codegen/gengo_typedefs.go
@@ -109,16 +109,12 @@ extern "C" {
 		// - short* -> *int16 (for newXXXFromC)
 		knownReturnType, returnTypeErr = getReturnWrapper(
 			CIdentifier(typedef),
-			map[CIdentifier]bool{},
-			map[GoIdentifier]bool{},
-			map[CIdentifier]bool{},
+			data, // TODO: this might be empty
 		)
 
 		knownPtrReturnType, ptrReturnTypeErr = getReturnWrapper(
 			CIdentifier(typedef)+"*",
-			map[CIdentifier]bool{},
-			map[GoIdentifier]bool{},
-			map[CIdentifier]bool{},
+			data, // TODO: this might be empty
 		)
 
 		_, knownArgType, argTypeErr = getArgWrapper(
@@ -127,9 +123,7 @@ extern "C" {
 				Type: CIdentifier(typedef),
 			},
 			false, false,
-			map[CIdentifier]bool{},
-			map[GoIdentifier]bool{},
-			map[CIdentifier]bool{},
+			data, // TODO: this might be empty
 		)
 
 		_, knownPtrArgType, ptrArgTypeErr = getArgWrapper(
@@ -138,9 +132,7 @@ extern "C" {
 				Type: CIdentifier(typedef) + "*",
 			},
 			false, false,
-			map[CIdentifier]bool{},
-			map[GoIdentifier]bool{},
-			map[CIdentifier]bool{},
+			data, // TODO: this might be empty
 		)
 
 		// check if k is a name of struct from structDefs

--- a/cmd/codegen/gengo_typedefs.go
+++ b/cmd/codegen/gengo_typedefs.go
@@ -13,10 +13,16 @@ import (
 // - everything that satisfies IsCallbackTypedef
 func proceedTypedefs(
 	typedefs *Typedefs,
+	structs []StructDef,
 	data *DataPack) (validTypeNames []CIdentifier, err error) {
 	// quick counter for coverage control
 	generatedTypedefs := 0
 	maxTypedefs := len(typedefs.data)
+
+	structsMap := make(map[CIdentifier]StructDef)
+	for _, s := range structs {
+		structsMap[s.Name] = s
+	}
 
 	// we need FILES
 	callbacksGoSb := &strings.Builder{}
@@ -271,7 +277,7 @@ func new%[1]sFromC(cvalue *C.%[6]s) *%[1]s {
 		case IsCallbackTypedef(typedefs.data[k]):
 			glg.Infof("typedef %s is a callback. Not implemented yet", k)
 		case HasPrefix(typedefs.data[k], "struct"):
-			isOpaque := !IsStructName(k, data.structNames)
+			isOpaque := !IsStructName(k, structsMap)
 			glg.Infof("typedef %s is a struct (is opaque? %v).", k, isOpaque)
 			writeOpaqueStruct(k, isOpaque, callbacksGoSb)
 			generatedTypedefs++
@@ -331,7 +337,7 @@ func new%[1]sFromC(cvalue *C.%[2]s) *%[1]s {
 `, name.renameGoIdentifier(), name, toPlainValue)
 }
 
-func IsStructName(name CIdentifier, structs map[CIdentifier]bool) bool {
+func IsStructName[T any](name CIdentifier, structs map[CIdentifier]T) bool {
 	_, ok := structs[name]
 	return ok
 }

--- a/cmd/codegen/gengo_typedefs.go
+++ b/cmd/codegen/gengo_typedefs.go
@@ -11,7 +11,9 @@ import (
 // this function will proceed the following typedefs:
 // - all structs thatare not present in struct_and_enums.json (they are supposed to be epaque)
 // - everything that satisfies IsCallbackTypedef
-func proceedTypedefs(prefix string, typedefs *Typedefs, structs []StructDef, enums []EnumDef, refTypedefs map[CIdentifier]string) (validTypeNames []CIdentifier, err error) {
+func proceedTypedefs(
+	typedefs *Typedefs,
+	data *DataPack) (validTypeNames []CIdentifier, err error) {
 	// quick counter for coverage control
 	generatedTypedefs := 0
 	maxTypedefs := len(typedefs.data)
@@ -28,7 +30,7 @@ func proceedTypedefs(prefix string, typedefs *Typedefs, structs []StructDef, enu
 import "C"
 import "unsafe"
 
-`, prefix)
+`, data.prefix)
 
 	typedefsHeaderSb := &strings.Builder{}
 	typedefsHeaderSb.WriteString(cppFileHeader)
@@ -41,14 +43,14 @@ import "unsafe"
 #ifdef __cplusplus
 extern "C" {
 #endif
-`, prefix)
+`, data.prefix)
 	typedefsCppSb := &strings.Builder{}
 	typedefsCppSb.WriteString(cppFileHeader)
 	fmt.Fprintf(typedefsCppSb,
 		`
 #include "%[1]s_typedefs.h"
 #include "cimgui/%[1]s.h"
-`, prefix)
+`, data.prefix)
 
 	// because go ranges through maps as if it was drunken, we need to sort keys.
 	keys := make([]CIdentifier, 0, len(typedefs.data))
@@ -67,7 +69,7 @@ extern "C" {
 			continue
 		}
 
-		if _, exists := refTypedefs[k]; exists {
+		if _, exists := data.refTypedefs[k]; exists {
 			glg.Infof("Duplicate of %s in reference typedefs. Skipping.", k)
 			maxTypedefs--
 			continue
@@ -79,7 +81,7 @@ extern "C" {
 			continue
 		}
 
-		if IsEnumName(k, enums) /*|| IsStructName(k, structs)*/ {
+		if IsEnumName(k, data.enumNames) /*|| IsStructName(k, structs)*/ {
 			glg.Infof("typedef %s has extended deffinition in structs_and_enums.json. Will generate later", k)
 			maxTypedefs--
 			continue
@@ -277,7 +279,7 @@ func new%[1]sFromC(cvalue *C.%[6]s) *%[1]s {
 		case IsCallbackTypedef(typedefs.data[k]):
 			glg.Infof("typedef %s is a callback. Not implemented yet", k)
 		case HasPrefix(typedefs.data[k], "struct"):
-			isOpaque := !IsStructName(k, structs)
+			isOpaque := !IsStructName(k, data.structNames)
 			glg.Infof("typedef %s is a struct (is opaque? %v).", k, isOpaque)
 			writeOpaqueStruct(k, isOpaque, callbacksGoSb)
 			generatedTypedefs++
@@ -291,16 +293,16 @@ func new%[1]sFromC(cvalue *C.%[6]s) *%[1]s {
 }
 #endif`)
 
-	if err := os.WriteFile(fmt.Sprintf("%s_typedefs.go", prefix), []byte(callbacksGoSb.String()), 0644); err != nil {
-		return nil, fmt.Errorf("cannot write %s_typedefs.go: %w", prefix, err)
+	if err := os.WriteFile(fmt.Sprintf("%s_typedefs.go", data.prefix), []byte(callbacksGoSb.String()), 0644); err != nil {
+		return nil, fmt.Errorf("cannot write %s_typedefs.go: %w", data.prefix, err)
 	}
 
-	if err := os.WriteFile(fmt.Sprintf("%s_typedefs.cpp", prefix), []byte(typedefsCppSb.String()), 0644); err != nil {
-		return nil, fmt.Errorf("cannot write %s_typedefs.cpp: %w", prefix, err)
+	if err := os.WriteFile(fmt.Sprintf("%s_typedefs.cpp", data.prefix), []byte(typedefsCppSb.String()), 0644); err != nil {
+		return nil, fmt.Errorf("cannot write %s_typedefs.cpp: %w", data.prefix, err)
 	}
 
-	if err := os.WriteFile(fmt.Sprintf("%s_typedefs.h", prefix), []byte(typedefsHeaderSb.String()), 0644); err != nil {
-		return nil, fmt.Errorf("cannot write %s_typedefs.h: %w", prefix, err)
+	if err := os.WriteFile(fmt.Sprintf("%s_typedefs.h", data.prefix), []byte(typedefsHeaderSb.String()), 0644); err != nil {
+		return nil, fmt.Errorf("cannot write %s_typedefs.h: %w", data.prefix, err)
 	}
 
 	glg.Infof("Typedefs generation complete. Generated %d/%d (%.2f%%) typedefs.", generatedTypedefs, maxTypedefs, float32(generatedTypedefs*100)/float32(maxTypedefs))
@@ -337,24 +339,14 @@ func new%[1]sFromC(cvalue *C.%[2]s) *%[1]s {
 `, name.renameGoIdentifier(), name, toPlainValue)
 }
 
-func IsStructName(name CIdentifier, structs []StructDef) bool {
-	for _, s := range structs {
-		if s.Name == name {
-			return true
-		}
-	}
-
-	return false
+func IsStructName(name CIdentifier, structs map[CIdentifier]bool) bool {
+	_, ok := structs[name]
+	return ok
 }
 
-func IsEnumName(name CIdentifier, enums []EnumDef) bool {
-	for _, e := range enums {
-		if e.Name.renameEnum() == name.renameEnum() { // compare GO equivalents because C names has _ at their end
-			return true
-		}
-	}
-
-	return false
+func IsEnumName(name CIdentifier, enums map[GoIdentifier]bool) bool {
+	_, ok := enums[name.renameEnum()]
+	return ok
 }
 
 func IsTemplateTypedef(s string) bool {

--- a/cmd/codegen/gengo_typedefs.go
+++ b/cmd/codegen/gengo_typedefs.go
@@ -14,7 +14,7 @@ import (
 func proceedTypedefs(
 	typedefs *Typedefs,
 	structs []StructDef,
-	data *DataPack) (validTypeNames []CIdentifier, err error) {
+	data *Context) (validTypeNames []CIdentifier, err error) {
 	// quick counter for coverage control
 	generatedTypedefs := 0
 	maxTypedefs := len(typedefs.data)

--- a/cmd/codegen/gengo_typedefs.go
+++ b/cmd/codegen/gengo_typedefs.go
@@ -111,14 +111,14 @@ extern "C" {
 			CIdentifier(typedef),
 			map[CIdentifier]bool{},
 			map[GoIdentifier]bool{},
-			map[CIdentifier]string{},
+			map[CIdentifier]bool{},
 		)
 
 		knownPtrReturnType, ptrReturnTypeErr = getReturnWrapper(
 			CIdentifier(typedef)+"*",
 			map[CIdentifier]bool{},
 			map[GoIdentifier]bool{},
-			map[CIdentifier]string{},
+			map[CIdentifier]bool{},
 		)
 
 		_, knownArgType, argTypeErr = getArgWrapper(
@@ -129,7 +129,7 @@ extern "C" {
 			false, false,
 			map[CIdentifier]bool{},
 			map[GoIdentifier]bool{},
-			map[CIdentifier]string{},
+			map[CIdentifier]bool{},
 		)
 
 		_, knownPtrArgType, ptrArgTypeErr = getArgWrapper(
@@ -140,7 +140,7 @@ extern "C" {
 			false, false,
 			map[CIdentifier]bool{},
 			map[GoIdentifier]bool{},
-			map[CIdentifier]string{},
+			map[CIdentifier]bool{},
 		)
 
 		// check if k is a name of struct from structDefs

--- a/cmd/codegen/helpers.go
+++ b/cmd/codegen/helpers.go
@@ -75,3 +75,22 @@ func SliceToMap[T comparable](s []T) map[T]bool {
 	}
 	return m
 }
+
+func MergeMaps[T comparable](maps ...map[T]bool) map[T]bool {
+	result := make(map[T]bool)
+	for _, m := range maps {
+		for k, v := range m {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+func RemoveMapValues[T comparable, S any](m map[T]S) map[T]bool {
+	result := make(map[T]bool)
+	for k := range m {
+		result[k] = true
+	}
+
+	return result
+}

--- a/cmd/codegen/helpers.go
+++ b/cmd/codegen/helpers.go
@@ -67,3 +67,11 @@ func SortStrings[s ~string](str []s) {
 		return str[i] < str[j]
 	})
 }
+
+func SliceToMap[T comparable](s []T) map[T]bool {
+	m := make(map[T]bool, len(s))
+	for _, v := range s {
+		m[v] = true
+	}
+	return m
+}

--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -220,7 +220,7 @@ func main() {
 	data.enumNames = MergeMaps(SliceToMap(enumNames), objectsData.refEnums)
 
 	// 1.2. Generate Go typedefs
-	callbacks, err := proceedTypedefs(objectsData.typedefs, data)
+	callbacks, err := proceedTypedefs(objectsData.typedefs, objectsData.structs, data)
 	if err != nil {
 		log.Panic(err)
 	}

--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -55,39 +55,59 @@ func validateFiles(f *flags) {
 	}
 }
 
+type jsonData struct {
+	structAndEnums,
+	typedefs,
+	defs,
+
+	refStructAndEnums,
+	refTypedefs []byte
+}
+
+func loadData(f *flags) (*jsonData, error) {
+	var err error
+
+	result := &jsonData{}
+
+	result.defs, err = os.ReadFile(f.defJsonPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read definitions json file: %w", err)
+	}
+
+	result.typedefs, err = os.ReadFile(f.typedefsJsonpath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read typedefs json file: %w", err)
+	}
+
+	result.structAndEnums, err = os.ReadFile(f.enumsJsonpath)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	if len(f.refEnumsJsonPath) > 0 {
+		result.refStructAndEnums, err = os.ReadFile(f.refEnumsJsonPath)
+		if err != nil {
+			return nil, fmt.Errorf("cannot read reference struct and enums json file: %w", err)
+		}
+	}
+
+	if len(f.refTypedefsJsonPath) > 0 {
+		result.refTypedefs, err = os.ReadFile(f.refTypedefsJsonPath)
+		if err != nil {
+			return nil, fmt.Errorf("cannot read reference typedefs json file: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
 func main() {
 	flags := parse()
 	validateFiles(flags)
 
-	defJsonBytes, err := os.ReadFile(*defJsonPath)
+	fileData, err := loadData(flags)
 	if err != nil {
-		log.Panic(err)
-	}
-
-	typedefsJsonBytes, err := os.ReadFile(*typedefsJsonpath)
-	if err != nil {
-		log.Panic(err)
-	}
-
-	enumJsonBytes, err := os.ReadFile(*enumsJsonpath)
-	if err != nil {
-		log.Panic(err)
-	}
-
-	var refEnumJsonBytes []byte
-	if len(*refEnumsJsonPath) > 0 {
-		refEnumJsonBytes, err = os.ReadFile(*refEnumsJsonPath)
-		if err != nil {
-			log.Panic(err)
-		}
-	}
-
-	var refTypedefsJsonBytes []byte
-	if len(*refTypedefsJsonPath) > 0 {
-		refTypedefsJsonBytes, err = os.ReadFile(*refTypedefsJsonPath)
-		if err != nil {
-			log.Panic(err)
-		}
+		glg.Fatalf("cannot load data: %v", err)
 	}
 
 	// get definitions from json file

--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"flag"
 	"fmt"
+	"github.com/kpango/glg"
 	"log"
 	"os"
 )
@@ -13,6 +13,7 @@ const (
 	cppFileHeader   = generatorInfo
 )
 
+// this cextracts enums and structs names from json file.
 func getEnumAndStructNames(enumJsonBytes []byte) (enumNames []GoIdentifier, structNames []CIdentifier, err error) {
 	enums, err := getEnumDefs(enumJsonBytes)
 	if err != nil {
@@ -37,28 +38,26 @@ func getEnumAndStructNames(enumJsonBytes []byte) (enumNames []GoIdentifier, stru
 	return
 }
 
+func validateFiles(f *flags) {
+	stat, err := os.Stat(f.defJsonPath)
+	if err != nil || stat.IsDir() {
+		glg.Fatal("Invalid definitions json file path")
+	}
+
+	stat, err = os.Stat(f.enumsJsonpath)
+	if err != nil || stat.IsDir() {
+		glg.Fatal("Invalid enum json file path")
+	}
+
+	stat, err = os.Stat(f.typedefsJsonpath)
+	if err != nil || stat.IsDir() {
+		glg.Fatal("Invalid typedefs json file path")
+	}
+}
+
 func main() {
-	defJsonPath := flag.String("d", "", "definitions json file path")
-	enumsJsonpath := flag.String("e", "", "structs and enums json file path")
-	typedefsJsonpath := flag.String("t", "", "typedefs dict json file path")
-	refEnumsJsonPath := flag.String("r", "", "reference structs and enums json file path")
-	refTypedefsJsonPath := flag.String("rt", "", "reference typedefs_dict.json file path")
-	prefix := flag.String("p", "", "prefix for the generated file")
-	include := flag.String("i", "", "include header file")
-
-	parse()
-
-	flag.Parse()
-
-	stat, err := os.Stat(*defJsonPath)
-	if err != nil || stat.IsDir() {
-		log.Panic("Invalid definitions json file path")
-	}
-
-	stat, err = os.Stat(*enumsJsonpath)
-	if err != nil || stat.IsDir() {
-		log.Panic("Invalid enum json file path")
-	}
+	flags := parse()
+	validateFiles(flags)
 
 	defJsonBytes, err := os.ReadFile(*defJsonPath)
 	if err != nil {

--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -176,15 +176,16 @@ func parseJson(jsonData *jsonData) (*objectsDats, error) {
 type DataPack struct {
 	prefix string
 
-	funcNames    map[CIdentifier]bool
-	enumNames    map[GoIdentifier]bool
-	refEnumNames map[GoIdentifier]bool
+	funcNames map[CIdentifier]bool
+	enumNames map[GoIdentifier]bool
 
-	structNames    map[CIdentifier]bool
-	refStructNames map[CIdentifier]bool
+	structNames map[CIdentifier]bool
 
 	typedefsNames map[CIdentifier]bool
-	refTypedefs   map[CIdentifier]bool
+
+	refStructNames map[CIdentifier]bool
+	refEnumNames   map[GoIdentifier]bool
+	refTypedefs    map[CIdentifier]bool
 
 	// TODO: might want to remove this
 	flags *flags
@@ -205,10 +206,12 @@ func main() {
 	}
 
 	data := &DataPack{
-		prefix:      flags.prefix,
-		flags:       flags,
-		structNames: objectsData.structNames,
-		refTypedefs: objectsData.refTypedefs,
+		prefix: flags.prefix,
+		flags:  flags,
+
+		refStructNames: objectsData.refStructs,
+		refEnumNames:   objectsData.refEnums,
+		refTypedefs:    objectsData.refTypedefs,
 	}
 
 	// 1. Generate code
@@ -222,7 +225,7 @@ func main() {
 		log.Panic(err)
 	}
 
-	data.typedefsNames = SliceToMap(callbacks)
+	data.structNames = SliceToMap(callbacks)
 
 	// 1.3. Generate C wrapper
 	validFuncs, err := generateCppWrapper(flags.prefix, flags.include, objectsData.funcs)

--- a/cmd/codegen/return_wrapper.go
+++ b/cmd/codegen/return_wrapper.go
@@ -12,7 +12,7 @@ type returnWrapper struct {
 
 func getReturnWrapper(
 	t CIdentifier,
-	data *DataPack,
+	data *Context,
 ) (returnWrapper, error) {
 	returnWrapperMap := map[CIdentifier]returnWrapper{
 		"bool":           {"bool", "%s == C.bool(true)"},


### PR DESCRIPTION
We all love object programming right? :smile:
I've organised `main.go` int a few, handy objects.
One of these objects called `Context` is passed through the whole generator (instead of a bunch of maps).
Also, now all generators uses maps by default so that checking if certain name is present in map is super easy.