### PR TITLE
Add OS thread locking in example code

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"image"
+	"runtime"
 
 	imgui "github.com/AllenDang/cimgui-go"
 )
@@ -107,6 +108,10 @@ func loop() {
 
 func beforeDestroyContext() {
 	imgui.PlotDestroyContext()
+}
+
+func init() {
+	runtime.LockOSThread()
 }
 
 func main() {


### PR DESCRIPTION
If you're using this example code as the base for a project and start running other code in goroutines and getting the scheduler involved, the C bindings do not like this very much and the GUI will completely lock up when the scheduler automatically switches the imgui calls between OS threads.