### PR TITLE
Fix memory leak in igGLFWWindow_SetIcon

### DIFF
--- a/glfw_backend.cpp
+++ b/glfw_backend.cpp
@@ -296,6 +296,7 @@ void igGLFWWindow_SetIcon(GLFWwindow *window, int count, CImage *images) {
     }
 
     glfwSetWindowIcon(window, count, glfwImages);
+    free(glfwImages);
 }
 
 void iggImplGlfw_KeyCallback(GLFWwindow* w, int k,int s,int a,int m) { ImGui_ImplGlfw_KeyCallback(w,k,s,a,m); }


### PR DESCRIPTION
Hello @AllenDang, thanks for your awesome library. I found a potential bug related to memory management.

The `glfwImages` array allocated with malloc was not being freed. Since [`glfwSetWindowIcon` copies the images passed in before it returns](https://www.glfw.org/docs/latest/group__window.html#gadd7ccd39fe7a7d1f0904666ae5932dc5) (so this pointer is not managed by glfw, we should do it), this could lead to memory leaks. This commit fixes it.

Appendix:
![image](https://github.com/AllenDang/cimgui-go/assets/52557189/74dcf67e-3f91-4c4a-906f-dbd9af069687)
