### PR TITLE
datautils: remove tryPin part of WrapVoidPtr

### DIFF
--- a/internal/datautils/type_wrapper.go
+++ b/internal/datautils/type_wrapper.go
@@ -174,20 +174,8 @@ func (buf *StringBuffer) Size() int {
 // WrapVoidPtr uses runtime.Pinner to pin value
 func WrapVoidPtr(value unsafe.Pointer) (wrapped unsafe.Pointer, finisher func()) {
 	p := &runtime.Pinner{}
-	tryPin(value, p)
+	p.Pin(value)
 	return value, func() {
 		p.Unpin()
 	}
-}
-
-// TODO: this is workaround because of bug/feature request in GO.
-// It might be changed after 1.22 release
-func tryPin(value any, pinner *runtime.Pinner) {
-	defer func() {
-		if r := recover(); r != nil {
-			// nothing to do here hehe
-		}
-	}()
-
-	pinner.Pin(value)
 }


### PR DESCRIPTION
this was necessary because of https://github.com/golang/go/issues/62356 fix #213