### PR TITLE
 refactor(glfwbackend): move clear buffer before render loop 

### DIFF
--- a/backend/glfwbackend/glfw_backend.cpp
+++ b/backend/glfwbackend/glfw_backend.cpp
@@ -129,6 +129,13 @@ void glfw_render(GLFWwindow *window, VoidCallback renderLoop) {
 
   glfwSetWindowUserPointer(window, (void *)renderLoop);
 
+  int display_w, display_h;
+  glfwGetFramebufferSize(window, &display_w, &display_h);
+  glViewport(0, 0, display_w, display_h);
+  glClearColor(clear_color.x * clear_color.w, clear_color.y * clear_color.w, clear_color.z * clear_color.w,
+               clear_color.w);
+  glClear(GL_COLOR_BUFFER_BIT);
+
   // Do ui stuff here
   if (renderLoop != NULL) {
     renderLoop();
@@ -136,12 +143,6 @@ void glfw_render(GLFWwindow *window, VoidCallback renderLoop) {
 
   // Rendering
   igRender();
-  int display_w, display_h;
-  glfwGetFramebufferSize(window, &display_w, &display_h);
-  glViewport(0, 0, display_w, display_h);
-  glClearColor(clear_color.x * clear_color.w, clear_color.y * clear_color.w, clear_color.z * clear_color.w,
-               clear_color.w);
-  glClear(GL_COLOR_BUFFER_BIT);
   ImGui_ImplOpenGL3_RenderDrawData(igGetDrawData());
 
   ImGuiIO *io = igGetIO();

--- a/backend/glfwbackend/glfw_backend.cpp
+++ b/backend/glfwbackend/glfw_backend.cpp
@@ -115,7 +115,7 @@ GLFWwindow *igCreateGLFWWindow(const char *title, int width, int height,
 
   // Install extra callback
   glfwSetWindowRefreshCallback(window, glfw_window_refresh_callback);
-  glfwMakeContextCurrent(NULL);
+  // glfwMakeContextCurrent(NULL);
   return window;
 }
 

--- a/backend/glfwbackend/glfw_backend.cpp
+++ b/backend/glfwbackend/glfw_backend.cpp
@@ -115,7 +115,6 @@ GLFWwindow *igCreateGLFWWindow(const char *title, int width, int height,
 
   // Install extra callback
   glfwSetWindowRefreshCallback(window, glfw_window_refresh_callback);
-  // glfwMakeContextCurrent(NULL);
   return window;
 }
 


### PR DESCRIPTION
- 08dd44f45c8cf20e23460ad79c451fd0d2731db2 **refactor(glfwbackend): move clear buffer before render loop**: allow end user to use OpenGL before render ImGui
- c5bb73897cd4752993e93710449596eb897a4025 **refactor(glfwbackend): keep glfw context after window creation**: allow end user to use OpenGL after window creation