### PR TITLE
Change the SDL backend of SetCursor to accept global positions.

### DIFF
--- a/backend/sdlbackend/sdl_backend.cpp
+++ b/backend/sdlbackend/sdl_backend.cpp
@@ -81,6 +81,11 @@ SDL_Window* igCreateSDLWindow(const char* title, int width, int height,VoidCallb
     SDL_Window* window = SDL_CreateWindow(title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height, sdl_flags);
     sdl_flags = (SDL_WindowFlags)(SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI); // reset default flags
     SDL_GLContext gl_context = SDL_GL_CreateContext(window);
+    if (!gl_context)
+    {
+        printf("Error creating SDL context %s\n", SDL_GetError());
+        exit(1);
+    }
     SDL_GL_MakeCurrent(window, gl_context);
     SDL_GL_SetSwapInterval(1); // Enable vsync
 

--- a/backend/sdlbackend/sdl_backend.go
+++ b/backend/sdlbackend/sdl_backend.go
@@ -509,8 +509,10 @@ func (b *SDLBackend) SetSwapInterval(interval SDLWindowFlags) error {
 	return nil
 }
 
+// the SDL backend gives mouse positions in global coordinates, so to make it possible to
+// "lock" the mouse in one place, SetCursorPos will set the mouse in global coordinates
 func (b *SDLBackend) SetCursorPos(x, y float64) {
-	C.SDL_WarpMouseInWindow(b.handle(), C.int(x), C.int(y))
+	C.SDL_WarpMouseGlobal(C.int(x), C.int(y))
 }
 
 func (b *SDLBackend) SetInputMode(mode SDLWindowFlags, value SDLWindowFlags) {


### PR DESCRIPTION
imgui.MousePos returns global positions in the SDL backend, so it makes sense that SetCursor would accept the same position.  Typically used to lock a mouse in place.
