### PR TITLE
backend/texture: change default texture impl

### DIFF
--- a/backend/texture.go
+++ b/backend/texture.go
@@ -8,7 +8,6 @@ import (
 	_ "image/png"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/AllenDang/cimgui-go/imgui"
 )
@@ -28,13 +27,16 @@ func NewTextureFromRgba(rgba *image.RGBA) *Texture {
 		Height: rgba.Bounds().Dy(),
 	}
 
-	// Set finalizer
-	runtime.SetFinalizer(&texture, (*Texture).release)
+	// I leav it for documentation here:
+	// GC runs in a separated thread so this may not work correctly (will crash opengl)
+	// runtime.SetFinalizer(&texture, (*Texture).release)
 
 	return &texture
 }
 
-func (t *Texture) release() {
+// Release tells OpenGL that this texture is no longer needed.
+// ATTENTION: This will not be automatically handled by GC so remember to do it manually if you have many textures!
+func (t *Texture) Release() {
 	textureManager.DeleteTexture(t.ID)
 }
 

--- a/backend/texture.go
+++ b/backend/texture.go
@@ -12,6 +12,10 @@ import (
 	"github.com/AllenDang/cimgui-go/imgui"
 )
 
+// Texture implements a simple texture loader. It wraps backend's methods to allow creating textures easily.
+// IMPORTANT: as the texture is mainly handled by C OpenGL, it is not covered by Garbae Collector (GC).
+//
+//	Remember to call (*Texture).Release when you no longer need it.
 type Texture struct {
 	ID     imgui.TextureID
 	Width  int


### PR DESCRIPTION
now it does not free texture manually
reasons:
- this caused a crash whenever GC was taking its fingers to the texutre. Was caused by the fact that GC runs in its own goroutine and OpenGL doesn't like it for some reason Now user needs to handle texture freeing manually

fix #350 