### PR TITLE
hotfix(glfwbackend): revert part of #348

### DIFF
--- a/backend/glfwbackend/glfw_backend.cpp
+++ b/backend/glfwbackend/glfw_backend.cpp
@@ -115,6 +115,7 @@ GLFWwindow *igCreateGLFWWindow(const char *title, int width, int height,
 
   // Install extra callback
   glfwSetWindowRefreshCallback(window, glfw_window_refresh_callback);
+  glfwMakeContextCurrent(NULL);
   return window;
 }
 


### PR DESCRIPTION
caused ERROR: ImGui_ImplOpenGL3_CreateDeviceObjects: failed to compile fragment shader! With GLSL: #version 130

> I've investigated a bit more to justify this:
it causes because giu uses mainthread to call Run() in mainthread.
possibly caused by the fact that CreateWindow might be called in another goroutine than Render loop

