### PR TITLE
hotfix(datautils): WrapNumberPtr now works as expected

### DIFF
--- a/datautils/type_wrapper.go
+++ b/datautils/type_wrapper.go
@@ -55,17 +55,7 @@ type Number interface {
 
 // WrapNumberPtr is a generic method to convert GOTYPE (int32/float32 e.t.c.) into CTYPE (c_int/c_float e.t.c.)
 func WrapNumberPtr[CTYPE Number, GOTYPE Number](goValue *GOTYPE) (wrapped *CTYPE, finisher func()) {
-	if goValue != nil {
-		cValue := CTYPE(*goValue)
-		wrapped = &cValue
-		finisher = func() {
-			*goValue = GOTYPE(cValue)
-		}
-	} else {
-		finisher = func() {}
-	}
-
-	return
+	return ConvertCTypes[*CTYPE](goValue), func() {}
 }
 
 // WrapString converts Go string to C char*


### PR DESCRIPTION
while debugging ImGuizmo it turned out that WrapNumberPtr didn't work at all

In short it took pointer X, dereferenced it, converted into valid C type and returned as pointer Y.

Now it forces pointer cast via ConvertCTypes function.