### PR TITLE
codegen: fix enums generation

### DIFF
--- a/cmd/codegen/arguments_wrapper.go
+++ b/cmd/codegen/arguments_wrapper.go
@@ -175,11 +175,20 @@ func getArgWrapper(
 
 		goType := prefixGoPackage(goEnumName.renameGoIdentifier(), GoIdentifier(srcPkg), context)
 
-		argDeclaration = fmt.Sprintf("%s %s", a.Name, goType)
-		data = ArgumentWrapperData{
-			ArgType: goType,
-			VarName: fmt.Sprintf("C.%s(%s)", pureType, a.Name),
-			CType:   GoIdentifier(fmt.Sprintf("C.%s", a.Type)),
+		if isPointer {
+			argDeclaration = fmt.Sprintf("%s *%s", a.Name, goType)
+			data = ArgumentWrapperData{
+				ArgType: GoIdentifier(fmt.Sprintf("*%s", goType)),
+				VarName: fmt.Sprintf("(*C.%s)(%s)", pureType, a.Name),
+				CType:   GoIdentifier(fmt.Sprintf("*C.%s", a.Type)),
+			}
+		} else {
+			argDeclaration = fmt.Sprintf("%s %s", a.Name, goType)
+			data = ArgumentWrapperData{
+				ArgType: goType,
+				VarName: fmt.Sprintf("C.%s(%s)", pureType, a.Name),
+				CType:   GoIdentifier(fmt.Sprintf("C.%s", a.Type)),
+			}
 		}
 
 		return

--- a/cmd/codegen/arguments_wrapper.go
+++ b/cmd/codegen/arguments_wrapper.go
@@ -167,7 +167,7 @@ func getArgWrapper(
 	}
 	_, isRefTypedef := context.refTypedefs[pureType]
 
-	if goEnumName := a.Type; isEnum(goEnumName, context.enumNames) {
+	if goEnumName := pureType; isEnum(goEnumName, context.enumNames) {
 		srcPkg := context.flags.packageName
 		if isRefTypedef {
 			srcPkg = context.flags.refPackageName
@@ -178,7 +178,7 @@ func getArgWrapper(
 		argDeclaration = fmt.Sprintf("%s %s", a.Name, goType)
 		data = ArgumentWrapperData{
 			ArgType: goType,
-			VarName: fmt.Sprintf("C.%s(%s)", a.Type, a.Name),
+			VarName: fmt.Sprintf("C.%s(%s)", pureType, a.Name),
 			CType:   GoIdentifier(fmt.Sprintf("C.%s", a.Type)),
 		}
 


### PR DESCRIPTION
now arguments_wrapper uses pureType to search for enums and considers isPointer