### PR TITLE
codegen: Add presets json support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ define generate
 	mkdir -p $(2)
 	cat templates/cflags.go |sed -e "s/^package.*/package $(2)/g" > $(2)/cflags.go
 	cd $(2); \
-		../codegen -p $(1) -pkg $(2) -i ../$(3) -d ../$(4) -e ../$(5) -t ../$(6) $(7)
+		../codegen -preset ../cmd/codegen/cimgui-go-preset.json -p $(1) -pkg $(2) -i ../$(3) -d ../$(4) -e ../$(5) -t ../$(6) $(7)
 	go run mvdan.cc/gofumpt@latest -w $(2)/$(1)_enums.go
 	go run mvdan.cc/gofumpt@latest -w $(2)/$(1)_funcs.go
 	go run mvdan.cc/gofumpt@latest -w $(2)/$(1)_typedefs.go

--- a/cmd/codegen/arguments_wrapper.go
+++ b/cmd/codegen/arguments_wrapper.go
@@ -297,7 +297,7 @@ for i, %[1]sV := range %[1]sArg {
 		return argDeclaration, data, nil
 	}
 
-	_, shouldSkipRefTypedef := skippedTypedefs[pureType]
+	_, shouldSkipRefTypedef := context.preset.SkipTypedefs[pureType]
 	if context.structNames[pureType] || context.typedefsNames[pureType] || (isRefTypedef && !shouldSkipRefTypedef) {
 		srcPkg := context.flags.packageName
 		if isRefTypedef {

--- a/cmd/codegen/arguments_wrapper.go
+++ b/cmd/codegen/arguments_wrapper.go
@@ -137,7 +137,7 @@ func getArgWrapper(
 	}
 
 	if isGetter {
-		argDeclaration = fmt.Sprintf("%s %s", a.Name, a.Type.renameGoIdentifier())
+		argDeclaration = fmt.Sprintf("%s %s", a.Name, a.Type.renameGoIdentifier(context))
 		data = ArgumentWrapperData{
 			ArgDef:      fmt.Sprintf("%[1]sArg, %[1]sFin := %[1]s.Handle()", a.Name),
 			ArgDefNoFin: fmt.Sprintf("%[1]sArg, _ := %[1]s.Handle()", a.Name),
@@ -173,7 +173,7 @@ func getArgWrapper(
 			srcPkg = context.flags.refPackageName
 		}
 
-		goType := prefixGoPackage(goEnumName.renameGoIdentifier(), GoIdentifier(srcPkg), context)
+		goType := prefixGoPackage(goEnumName.renameGoIdentifier(context), GoIdentifier(srcPkg), context)
 
 		if isPointer {
 			argDeclaration = fmt.Sprintf("%s *%s", a.Name, goType)
@@ -304,7 +304,7 @@ for i, %[1]sV := range %[1]sArg {
 			srcPkg = context.flags.refPackageName
 		}
 
-		goType := prefixGoPackage(pureType.renameGoIdentifier(), GoIdentifier(srcPkg), context)
+		goType := prefixGoPackage(pureType.renameGoIdentifier(context), GoIdentifier(srcPkg), context)
 		cType := GoIdentifier(fmt.Sprintf("C.%s", pureType))
 		argType := goType
 		fn := ""

--- a/cmd/codegen/arguments_wrapper.go
+++ b/cmd/codegen/arguments_wrapper.go
@@ -167,7 +167,7 @@ func getArgWrapper(
 	}
 	_, isRefTypedef := context.refTypedefs[pureType]
 
-	if goEnumName := pureType; isEnum(goEnumName, context.enumNames) {
+	if goEnumName := pureType; IsEnum(goEnumName, context.enumNames) {
 		srcPkg := context.flags.packageName
 		if isRefTypedef {
 			srcPkg = context.flags.refPackageName

--- a/cmd/codegen/cimgui-go-preset.json
+++ b/cmd/codegen/cimgui-go-preset.json
@@ -6,7 +6,18 @@
                 "ImFontAtlas_GetTexDataAsAlpha8":  true,
                 "ImFontAtlas_GetTexDataAsAlpha8V": true,
                 "ImFontAtlas_GetTexDataAsRGBA32":  true,
-                "ImFontAtlas_GetTexDataAsRGBA32V": true
+                "ImFontAtlas_GetTexDataAsRGBA32V": true,
+                "ImVec1_GetX":                     true,
+                "ImVec2_GetX":                     true,
+                "ImVec2_GetY":                     true,
+                "ImVec4_GetX":                     true,
+                "ImVec4_GetY":                     true,
+                "ImVec4_GetW":                     true,
+                "ImVec4_GetZ":                     true,
+                "ImRect_GetMin":                   true,
+                "ImRect_GetMax":                   true,
+                "ImPlotPoint_SetX":                true,
+                "ImPlotPoint_SetY":                true
         },
         "SkipStructs": {
                 "ImVec1":     true,
@@ -42,13 +53,13 @@
                 "ImAxis":                  "AxisEnum",
                 "GetItem_ID":              "ItemByID"
         },
-        "TrimPrefix": {
-                "ImGuizmo": true,
-                "imnodes":  true,
-                "ImNodes":  true,
-                "ImPlot":   true,
-                "ImGui":    true,
-                "Im":       true,
-                "ig":       true
-        }
+        "TrimPrefix": [
+                "ImGuizmo",
+                "imnodes",
+                "ImNodes",
+                "ImPlot",
+                "ImGui",
+                "Im",
+                "ig"
+        ]
 }

--- a/cmd/codegen/cimgui-go-preset.json
+++ b/cmd/codegen/cimgui-go-preset.json
@@ -27,5 +27,19 @@
                 "ImU32":                  true,
                 "ImU64":                  true,
                 "ImGuiInputTextCallback": true
+        },
+        "TypedefsPoolSize": 32,
+        "TypedefsCustomPoolSizes": {
+        },
+        "Replace": {
+                "igGetDrawData":           "CurrentDrawData",
+                "igGetDrawListSharedData": "CurrentDrawListSharedData",
+                "igGetFont":               "CurrentFont",
+                "igGetIO":                 "CurrentIO",
+                "igGetPlatformIO":         "CurrentPlatformIO",
+                "igGetStyle":              "CurrentStyle",
+                "igGetMouseCursor":        "CurrentMouseCursor",
+                "ImAxis":                  "AxisEnum",
+                "GetItem_ID":              "ItemByID"
         }
 }

--- a/cmd/codegen/cimgui-go-preset.json
+++ b/cmd/codegen/cimgui-go-preset.json
@@ -7,5 +7,25 @@
                 "ImFontAtlas_GetTexDataAsAlpha8V": true,
                 "ImFontAtlas_GetTexDataAsRGBA32":  true,
                 "ImFontAtlas_GetTexDataAsRGBA32V": true
+        },
+        "SkipStructs": {
+                "ImVec1":     true,
+                "ImVec2":     true,
+                "ImVec2ih":   true,
+                "ImVec4":     true,
+                "ImColor":    true,
+                "ImRect":     true,
+                "ImPlotTime": true
+        },
+        "SkipTypedefs": {
+                "ImS8":                   true,
+                "ImS16":                  true,
+                "ImS32":                  true,
+                "ImS64":                  true,
+                "ImU8":                   true,
+                "ImU16":                  true,
+                "ImU32":                  true,
+                "ImU64":                  true,
+                "ImGuiInputTextCallback": true
         }
 }

--- a/cmd/codegen/cimgui-go-preset.json
+++ b/cmd/codegen/cimgui-go-preset.json
@@ -20,6 +20,15 @@
                 "ImPlotPoint_SetY":                true
         },
         "SkipStructs": {
+                "ImVec2":      true,
+                "ImVec2ih":    true,
+                "ImVec4":      true,
+                "ImColor":     true,
+                "ImRect":      true,
+                "ImPlotTime":  true,
+                "ImPlotPoint": true
+        },
+        "SkipMethods": {
                 "ImVec1":     true,
                 "ImVec2":     true,
                 "ImVec2ih":   true,

--- a/cmd/codegen/cimgui-go-preset.json
+++ b/cmd/codegen/cimgui-go-preset.json
@@ -41,5 +41,14 @@
                 "igGetMouseCursor":        "CurrentMouseCursor",
                 "ImAxis":                  "AxisEnum",
                 "GetItem_ID":              "ItemByID"
+        },
+        "TrimPrefix": {
+                "ImGuizmo": true,
+                "imnodes":  true,
+                "ImNodes":  true,
+                "ImPlot":   true,
+                "ImGui":    true,
+                "Im":       true,
+                "ig":       true
         }
 }

--- a/cmd/codegen/cimgui-go-preset.json
+++ b/cmd/codegen/cimgui-go-preset.json
@@ -61,5 +61,8 @@
                 "ImGui",
                 "Im",
                 "ig"
-        ]
+        ],
+        "OriginReplace": {
+                "TextEditor_GetText": "TextEditor_GetText_alloc"
+        }
 }

--- a/cmd/codegen/cimgui-go-preset.json
+++ b/cmd/codegen/cimgui-go-preset.json
@@ -1,0 +1,11 @@
+{
+        "SkipFuncs": {
+                "igInputText":                     true,
+                "igInputTextWithHint":             true,
+                "igInputTextMultiline":            true,
+                "ImFontAtlas_GetTexDataAsAlpha8":  true,
+                "ImFontAtlas_GetTexDataAsAlpha8V": true,
+                "ImFontAtlas_GetTexDataAsRGBA32":  true,
+                "ImFontAtlas_GetTexDataAsRGBA32V": true
+        }
+}

--- a/cmd/codegen/flags.go
+++ b/cmd/codegen/flags.go
@@ -11,6 +11,7 @@ type flags struct {
 	typedefsJsonpath,
 	refEnumsJsonPath,
 	refTypedefsJsonPath,
+	presetJsonPath,
 	refPackageName, // name for refTypedefs (default: imgui)
 	packageName, // name for current package (e.g. imgui, implot)
 	prefix,
@@ -27,6 +28,7 @@ func parse() *flags {
 	flag.StringVar(&flags.typedefsJsonpath, "t", "", "typedefs dict json file path")
 	flag.StringVar(&flags.refEnumsJsonPath, "r", "", "reference structs and enums json file path")
 	flag.StringVar(&flags.refTypedefsJsonPath, "rt", "", "reference typedefs_dict.json file path")
+	flag.StringVar(&flags.presetJsonPath, "preset", "", "Preset of custom (manual) generator rules. See go doc github.com/AllenDang/cimgui-go/cmd/codegen.Preset for more details.")
 	flag.StringVar(&flags.refPackageName, "refPkg", "imgui", "name for refTypedefs package name")
 	flag.StringVar(&flags.packageName, "pkg", "", "name for current package")
 	flag.StringVar(&flags.prefix, "p", "", "prefix for the generated file")

--- a/cmd/codegen/gencpp.go
+++ b/cmd/codegen/gencpp.go
@@ -7,13 +7,6 @@ import (
 	"unicode"
 )
 
-// cppFunctionsReplace allows to force-replace function name with some other name.
-// Introduced to replace TextEditor_GetText -> TextEditor_GetText_alloc
-// but could be re-used to force use of another function than json tells us to use.
-var cppFunctionsReplace = map[CIdentifier]CIdentifier{
-	"TextEditor_GetText": "TextEditor_GetText_alloc",
-}
-
 // Name of argument in cpp/go files.
 // It is used by functions that has text and text_end arguments.
 // In this case text_end is replaced by this argument (of type int)
@@ -33,7 +26,7 @@ func shouldExportFunc(funcName CIdentifier) bool {
 }
 
 // Generate cpp wrapper and return valid functions
-func generateCppWrapper(prefix, includePath string, funcDefs []FuncDef) ([]FuncDef, error) {
+func generateCppWrapper(prefix, includePath string, funcDefs []FuncDef, ctx *Context) ([]FuncDef, error) {
 	var validFuncs []FuncDef
 
 	// Generate header
@@ -397,7 +390,7 @@ extern "C" {
 			}
 		}
 
-		if v, ok := cppFunctionsReplace[funcName]; ok {
+		if v, ok := ctx.preset.OriginReplace[funcName]; ok {
 			cWrapperFuncName = v
 		}
 

--- a/cmd/codegen/gencpp.go
+++ b/cmd/codegen/gencpp.go
@@ -442,20 +442,8 @@ extern "C" {
 func generateCppStructsAccessor(prefix string, validFuncs []FuncDef, structs []StructDef, context *Context) (accessors []FuncDef, err error) {
 	var structAccessorFuncs []FuncDef
 
-	// TODO: extrac this to some separated function, maybe on top of this file
-	skipFuncNames := map[CIdentifier]bool{
-		"ImVec1_GetX":      true,
-		"ImVec2_GetX":      true,
-		"ImVec2_GetY":      true,
-		"ImVec4_GetX":      true,
-		"ImVec4_GetY":      true,
-		"ImVec4_GetW":      true,
-		"ImVec4_GetZ":      true,
-		"ImRect_GetMin":    true,
-		"ImRect_GetMax":    true,
-		"ImPlotPoint_SetX": true,
-		"ImPlotPoint_SetY": true,
-	}
+	// makes a setsum with context.preset.SkipFUncs
+	skipFuncNames := map[CIdentifier]bool{}
 
 	// Add all valid function's name to skipFuncNames
 	for _, f := range validFuncs {
@@ -491,7 +479,7 @@ extern "C" {
 			}
 
 			setterFuncName := CIdentifier(fmt.Sprintf("%[1]s_Set%[2]s", s.Name, Capitalize(Split(m.Name, "[")[0])))
-			if skipFuncNames[setterFuncName] {
+			if skipFuncNames[setterFuncName] || context.preset.SkipFuncs[setterFuncName] {
 				continue
 			}
 
@@ -556,7 +544,7 @@ extern "C" {
 			}
 
 			getterFuncName := CIdentifier(fmt.Sprintf("%[1]s_Get%[2]s", s.Name, Capitalize(Split(m.Name, "[")[0])))
-			if skipFuncNames[getterFuncName] {
+			if skipFuncNames[getterFuncName] || context.preset.SkipFuncs[getterFuncName] {
 				continue
 			}
 

--- a/cmd/codegen/gengo.go
+++ b/cmd/codegen/gengo.go
@@ -16,24 +16,6 @@ type (
 	GoIdentifier string
 )
 
-const TypedefsPoolSize = 32
-
-var customPoolSize = map[CIdentifier]int{
-	// nothing here for now
-}
-
-var replace = map[CIdentifier]GoIdentifier{
-	"igGetDrawData":           "CurrentDrawData",
-	"igGetDrawListSharedData": "CurrentDrawListSharedData",
-	"igGetFont":               "CurrentFont",
-	"igGetIO":                 "CurrentIO",
-	"igGetPlatformIO":         "CurrentPlatformIO",
-	"igGetStyle":              "CurrentStyle",
-	"igGetMouseCursor":        "CurrentMouseCursor",
-	"ImAxis":                  "AxisEnum",
-	"GetItem_ID":              "ItemByID",
-}
-
 func (c CIdentifier) trimImGuiPrefix() CIdentifier {
 	// order sensitive!
 	prefixes := []string{
@@ -57,8 +39,8 @@ func (c CIdentifier) trimImGuiPrefix() CIdentifier {
 	return c
 }
 
-func (c CIdentifier) renameGoIdentifier() GoIdentifier {
-	if r, ok := replace[c]; ok {
+func (c CIdentifier) renameGoIdentifier(ctx *Context) GoIdentifier {
+	if r, ok := ctx.preset.Replace[c]; ok {
 		c = CIdentifier(r)
 	}
 

--- a/cmd/codegen/gengo.go
+++ b/cmd/codegen/gengo.go
@@ -16,18 +16,6 @@ type (
 	GoIdentifier string
 )
 
-// Skip functions
-// e.g. they are temporarily hard-coded
-var skippedFuncs = map[CIdentifier]bool{
-	"igInputText":                     true,
-	"igInputTextWithHint":             true,
-	"igInputTextMultiline":            true,
-	"ImFontAtlas_GetTexDataAsAlpha8":  true,
-	"ImFontAtlas_GetTexDataAsAlpha8V": true,
-	"ImFontAtlas_GetTexDataAsRGBA32":  true,
-	"ImFontAtlas_GetTexDataAsRGBA32V": true,
-}
-
 // structures that's methods should be skipped
 var skippedStructs = map[CIdentifier]bool{
 	"ImVec1":     true,

--- a/cmd/codegen/gengo.go
+++ b/cmd/codegen/gengo.go
@@ -16,29 +16,6 @@ type (
 	GoIdentifier string
 )
 
-// structures that's methods should be skipped
-var skippedStructs = map[CIdentifier]bool{
-	"ImVec1":     true,
-	"ImVec2":     true,
-	"ImVec2ih":   true,
-	"ImVec4":     true,
-	"ImColor":    true,
-	"ImRect":     true,
-	"ImPlotTime": true,
-}
-
-var skippedTypedefs = map[CIdentifier]bool{
-	"ImU8":                   true,
-	"ImU16":                  true,
-	"ImU32":                  true,
-	"ImU64":                  true,
-	"ImS8":                   true,
-	"ImS16":                  true,
-	"ImS32":                  true,
-	"ImS64":                  true,
-	"ImGuiInputTextCallback": true,
-}
-
 const TypedefsPoolSize = 32
 
 var customPoolSize = map[CIdentifier]int{

--- a/cmd/codegen/gengo.go
+++ b/cmd/codegen/gengo.go
@@ -16,19 +16,8 @@ type (
 	GoIdentifier string
 )
 
-func (c CIdentifier) trimImGuiPrefix() CIdentifier {
-	// order sensitive!
-	prefixes := []string{
-		"ImGuizmo",
-		"imnodes",
-		"ImNodes",
-		"ImPlot",
-		"ImGui",
-		"Im",
-		"ig",
-	}
-
-	for _, prefix := range prefixes {
+func (c CIdentifier) trimImGuiPrefix(ctx *Context) CIdentifier {
+	for _, prefix := range ctx.preset.TrimPrefix {
 		if HasPrefix(c, prefix) &&
 			len(c) > len(prefix) && // check if removing it will not result in an empty string
 			strings.ToUpper(string(c[len(prefix)])) == string(c[len(prefix)]) { // check if the method will still be exported
@@ -46,14 +35,14 @@ func (c CIdentifier) renameGoIdentifier(ctx *Context) GoIdentifier {
 
 	c = TrimSuffix(c, "_Nil")
 
-	c = c.trimImGuiPrefix()
+	c = c.trimImGuiPrefix(ctx)
 	switch {
 	case HasPrefix(c, "New"):
-		c = "New" + c[3:].trimImGuiPrefix()
+		c = "New" + c[3:].trimImGuiPrefix(ctx)
 	case HasPrefix(c, "new"):
-		c = "new" + c[3:].trimImGuiPrefix()
+		c = "new" + c[3:].trimImGuiPrefix(ctx)
 	case HasPrefix(c, "*"):
-		c = "*" + c[1:].trimImGuiPrefix()
+		c = "*" + c[1:].trimImGuiPrefix(ctx)
 	}
 
 	c = TrimPrefix(c, "Get")

--- a/cmd/codegen/gengo.go
+++ b/cmd/codegen/gengo.go
@@ -74,7 +74,7 @@ func IsStructName(name CIdentifier, ctx *Context) bool {
 	return ok
 }
 
-func IsEnumName(name CIdentifier, enums map[CIdentifier]bool) bool {
+func IsEnum(name CIdentifier, enums map[CIdentifier]bool) bool {
 	_, ok := enums[name]
 	return ok
 }

--- a/cmd/codegen/gengo_enums.go
+++ b/cmd/codegen/gengo_enums.go
@@ -15,7 +15,7 @@ func generateGoEnums(prefix string, enums []EnumDef, ctx *Context) ([]CIdentifie
 	var enumNames []CIdentifier
 	for _, e := range enums {
 		originalName := e.Name
-		eName := e.Name.renameEnum().renameGoIdentifier()
+		eName := e.Name.renameEnum().renameGoIdentifier(ctx)
 
 		enumNames = append(enumNames, e.Name.renameEnum())
 
@@ -29,7 +29,7 @@ func generateGoEnums(prefix string, enums []EnumDef, ctx *Context) ([]CIdentifie
 			if v.Comment != "" {
 				sb.WriteString(fmt.Sprintf("%s\n", v.Comment))
 			}
-			sb.WriteString(fmt.Sprintf("\t%s %s = %d\n", vName.renameGoIdentifier(), eName, v.Value))
+			sb.WriteString(fmt.Sprintf("\t%s %s = %d\n", vName.renameGoIdentifier(ctx), eName, v.Value))
 		}
 
 		sb.WriteString(")\n\n")

--- a/cmd/codegen/gengo_funcs.go
+++ b/cmd/codegen/gengo_funcs.go
@@ -425,10 +425,3 @@ func (g *goFuncsGenerator) writeFinishers(shouldDefer bool, finishers []string) 
 	g.sb.WriteString(strings.Join(finishers, "\n"))
 	g.sb.WriteString("\n\n")
 }
-
-// isEnum returns true when given string is a valid enum type.
-func isEnum(argType CIdentifier, enumNames map[CIdentifier]bool) bool {
-	_, ok := enumNames[argType]
-
-	return ok
-}

--- a/cmd/codegen/gengo_funcs.go
+++ b/cmd/codegen/gengo_funcs.go
@@ -175,7 +175,7 @@ func (g *goFuncsGenerator) GenerateFunction(f FuncDef, args []GoIdentifier, argW
 	case returnTypeStructSetter:
 		funcParts := Split(f.FuncName, "_")
 		funcName = TrimPrefix(f.FuncName, string(funcParts[0]+"_"))
-		if len(funcName) == 0 || !HasPrefix(funcName, "Set") || skippedStructs[funcParts[0]] {
+		if len(funcName) == 0 || !HasPrefix(funcName, "Set") || g.context.preset.SkipStructs[funcParts[0]] {
 			return false
 		}
 

--- a/cmd/codegen/gengo_funcs.go
+++ b/cmd/codegen/gengo_funcs.go
@@ -49,7 +49,7 @@ func GenerateGoFuncs(
 
 	for _, f := range validFuncs {
 		// check whether the function shouldn't be skipped
-		if skippedFuncs[f.FuncName] {
+		if context.preset.SkipFuncs[f.FuncName] {
 			continue
 		}
 

--- a/cmd/codegen/gengo_funcs.go
+++ b/cmd/codegen/gengo_funcs.go
@@ -175,7 +175,7 @@ func (g *goFuncsGenerator) GenerateFunction(f FuncDef, args []GoIdentifier, argW
 	case returnTypeStructSetter:
 		funcParts := Split(f.FuncName, "_")
 		funcName = TrimPrefix(f.FuncName, string(funcParts[0]+"_"))
-		if len(funcName) == 0 || !HasPrefix(funcName, "Set") || g.context.preset.SkipStructs[funcParts[0]] {
+		if len(funcName) == 0 || !HasPrefix(funcName, "Set") || g.context.preset.SkipMethods[funcParts[0]] {
 			return false
 		}
 

--- a/cmd/codegen/gengo_funcs.go
+++ b/cmd/codegen/gengo_funcs.go
@@ -179,25 +179,25 @@ func (g *goFuncsGenerator) GenerateFunction(f FuncDef, args []GoIdentifier, argW
 			return false
 		}
 
-		receiver = funcParts[0].renameGoIdentifier()
+		receiver = funcParts[0].renameGoIdentifier(g.context)
 	case returnTypeKnown:
 		shouldDefer = true
 		cReturnType = f.Ret
-		returnType = f.Ret.renameGoIdentifier()
+		returnType = f.Ret.renameGoIdentifier(g.context)
 	case returnTypeStructPtr:
 		// return Im struct ptr
 		shouldDefer = true
 		cReturnType = TrimPrefix(f.Ret, "const ")
-		returnType = cReturnType.renameGoIdentifier()
+		returnType = cReturnType.renameGoIdentifier(g.context)
 	case returnTypeStruct:
 		shouldDefer = true
 		cReturnType = f.Ret
-		returnType = cReturnType.renameGoIdentifier()
+		returnType = cReturnType.renameGoIdentifier(g.context)
 	case returnTypeConstructor:
 		shouldDefer = true
 		parts := Split(f.FuncName, "_")
 		cReturnType = parts[0] + "*"
-		returnType = cReturnType.renameGoIdentifier()
+		returnType = cReturnType.renameGoIdentifier(g.context)
 
 		suffix := ""
 		if len(parts) > 2 {
@@ -296,7 +296,7 @@ func (g *goFuncsGenerator) generateFuncDeclarationStmt(receiver GoIdentifier, fu
 		receiver = GoIdentifier(fmt.Sprintf("(self %s)", receiver))
 	}
 
-	goFuncName := funcName.renameGoIdentifier()
+	goFuncName := funcName.renameGoIdentifier(g.context)
 
 	// if file comes from imgui_internal.h,prefix Internal is added.
 	// ref: https://github.com/AllenDang/cimgui-go/pull/118

--- a/cmd/codegen/gengo_typedefs.go
+++ b/cmd/codegen/gengo_typedefs.go
@@ -67,7 +67,7 @@ func GenerateTypedefs(
 			continue
 		}
 
-		if shouldSkipStruct(k) {
+		if shouldSkipStruct := ctx.preset.SkipStructs[k]; shouldSkipStruct {
 			if ctx.flags.showNotGenerated {
 				glg.Infof("Arbitrarly skipping struct %s", k)
 			}

--- a/cmd/codegen/gengo_typedefs.go
+++ b/cmd/codegen/gengo_typedefs.go
@@ -49,7 +49,7 @@ func GenerateTypedefs(
 
 	for _, k := range keys {
 		typedef := typedefs.data[k]
-		if shouldSkip, ok := skippedTypedefs[k]; ok && shouldSkip {
+		if shouldSkip, ok := ctx.preset.SkipTypedefs[k]; ok && shouldSkip {
 			if ctx.flags.showNotGenerated {
 				glg.Infof("Arbitrarly skipping typedef %s", k)
 			}

--- a/cmd/codegen/gengo_typedefs.go
+++ b/cmd/codegen/gengo_typedefs.go
@@ -76,7 +76,7 @@ func GenerateTypedefs(
 			continue
 		}
 
-		if IsEnumName(k, ctx.enumNames) /*|| IsStructName(k, structs)*/ {
+		if IsEnum(k, ctx.enumNames) /*|| IsStructName(k, structs)*/ {
 			if ctx.flags.showGenerated {
 				glg.Infof("typedef %s has extended deffinition in structs_and_enums.json. Will generate later", k)
 			}

--- a/cmd/codegen/gengo_typedefs.go
+++ b/cmd/codegen/gengo_typedefs.go
@@ -128,7 +128,7 @@ func GenerateTypedefs(
 			generatedTypedefs++
 			validTypeNames = append(validTypeNames, k)
 		case IsCallbackTypedef(typedefs.data[k]):
-			if err := generator.writeCallback(k, typedef); err != nil {
+			if err := generator.writeCallback(k, typedef, ctx); err != nil {
 				if ctx.flags.showNotGenerated {
 					glg.Failf("cannot write callback %s: %v", k, err)
 					continue
@@ -272,7 +272,7 @@ func New%[1]sFromC[SRC any](cvalue SRC) *%[1]s {
 	return &%[1]s{Data: (uintptr)(C.%[6]s_toUintptr(*internal.ReinterpretCast[*C.%[6]s](cvalue)))}
 }
 `,
-		k.renameGoIdentifier(),
+		k.renameGoIdentifier(g.ctx),
 		known.argType.ArgType,
 
 		known.ptrArgType.ArgDef,
@@ -314,7 +314,7 @@ func New%[1]sFromC[SRC any](cvalue SRC) *%[1]s {
 	return (*%[1]s)(%[10]s)
 }
 `,
-		k.renameGoIdentifier(),
+		k.renameGoIdentifier(g.ctx),
 		known.argType.ArgType,
 
 		known.ptrArgType.ArgDef,
@@ -357,7 +357,7 @@ func New%[1]sFromC[SRC any](cvalue SRC) *%[1]s {
 	return &%[1]s{Data: %[7]s}
 }
 `,
-		k.renameGoIdentifier(),
+		k.renameGoIdentifier(g.ctx),
 		known.argType.ArgType,
 
 		known.argType.ArgDef,
@@ -384,7 +384,7 @@ func (self %[1]s) C() (C.%[2]s, func()) {
 	result, fn := self.Handle()
 	return *result, fn
 }
-`, name.renameGoIdentifier(), name)
+`, name.renameGoIdentifier(g.ctx), name)
 	}
 
 	// we need to make it a struct, because we need to hide C type (otherwise it will duplicate methods)
@@ -405,7 +405,7 @@ func (self *%[1]s) Handle() (result *C.%[2]s, fin func()) {
 func New%[1]sFromC[SRC any](cvalue SRC) *%[1]s {
 	return &%[1]s{CData: internal.ReinterpretCast[*C.%[2]s](cvalue)}
 }
-`, name.renameGoIdentifier(), name, toPlainValue)
+`, name.renameGoIdentifier(g.ctx), name, toPlainValue)
 }
 
 func (g *typedefsGenerator) saveToDisk() error {

--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -243,7 +243,7 @@ func main() {
 	context.structNames = SliceToMap(callbacks)
 
 	// 1.3. Generate C wrapper
-	validFuncs, err := generateCppWrapper(flags.prefix, flags.include, context.funcs)
+	validFuncs, err := generateCppWrapper(flags.prefix, flags.include, context.funcs, context)
 	if err != nil {
 		log.Panic(err)
 	}

--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -64,7 +65,9 @@ type jsonData struct {
 	defs,
 
 	refStructAndEnums,
-	refTypedefs []byte
+	refTypedefs,
+
+	preset []byte
 }
 
 func loadData(f *flags) (*jsonData, error) {
@@ -101,6 +104,13 @@ func loadData(f *flags) (*jsonData, error) {
 		}
 	}
 
+	if len(f.presetJsonPath) > 0 {
+		result.preset, err = os.ReadFile(f.presetJsonPath)
+		if err != nil {
+			log.Panic(err)
+		}
+	}
+
 	return result, nil
 }
 
@@ -126,6 +136,8 @@ type Context struct {
 
 	// TODO: might want to remove this
 	flags *flags
+
+	preset *Preset
 }
 
 func parseJson(jsonData *jsonData) (*Context, error) {
@@ -133,6 +145,7 @@ func parseJson(jsonData *jsonData) (*Context, error) {
 
 	result := &Context{
 		arrayIndexGetters: make(map[CIdentifier]CIdentifier),
+		preset:            &Preset{},
 	}
 
 	// get definitions from json file
@@ -186,6 +199,10 @@ func parseJson(jsonData *jsonData) (*Context, error) {
 		}
 
 		result.refStructNames = SliceToMap(refStructs)
+	}
+
+	if len(jsonData.preset) > 0 {
+		json.Unmarshal(jsonData.preset, result.preset)
 	}
 
 	return result, nil

--- a/cmd/codegen/presets.go
+++ b/cmd/codegen/presets.go
@@ -23,5 +23,5 @@ type Preset struct {
 	// TrimPrefix allows to remove unwanted prefixes from everything during C->Go renaming.
 	// NOTE: order sensitive!
 	// NOTE: Case sensitive
-	TrimPrefix map[string]string
+	TrimPrefix []string
 }

--- a/cmd/codegen/presets.go
+++ b/cmd/codegen/presets.go
@@ -24,4 +24,8 @@ type Preset struct {
 	// NOTE: order sensitive!
 	// NOTE: Case sensitive
 	TrimPrefix []string
+	// OriginReplace allows to force-replace function name with some other name.
+	// Introduced to replace TextEditor_GetText -> TextEditor_GetText_alloc
+	// but could be re-used to force use of another function than json tells us to use.
+	OriginReplace map[CIdentifier]CIdentifier
 }

--- a/cmd/codegen/presets.go
+++ b/cmd/codegen/presets.go
@@ -6,8 +6,10 @@ type Preset struct {
 	// SkipFuncs functions (from definitions.json) to be skipped
 	// e.g. they are temporarily hard-coded
 	SkipFuncs map[CIdentifier]bool
-	// SkipStructs structs from structs_and_enums.json to be skipped
+	// SkipStructs struct names from structs_and_enums.json.
+	// structures that's METHODS should be skipped
 	SkipStructs map[CIdentifier]bool
 	// SkipTypedefs typedefs from typedefs_dict.json to be skipped
+	// e.g. for hardcoded typedefs or typedefs which are obvious (e.g. ImU16 becomes uint16 without extra type information)
 	SkipTypedefs map[CIdentifier]bool
 }

--- a/cmd/codegen/presets.go
+++ b/cmd/codegen/presets.go
@@ -12,4 +12,12 @@ type Preset struct {
 	// SkipTypedefs typedefs from typedefs_dict.json to be skipped
 	// e.g. for hardcoded typedefs or typedefs which are obvious (e.g. ImU16 becomes uint16 without extra type information)
 	SkipTypedefs map[CIdentifier]bool
+	// TypedefsPoolSize sets a default size for callbacks pool.
+	// Rembmber to set this as it defaults to 0 and you'll get no callbacks!
+	TypedefsPoolSize int
+	// TypedefsCustomPoolSizes allows to override TypedefsPoolSize for certain types.
+	TypedefsCustomPoolSizes map[CIdentifier]int
+	// Replace is a map for C -> Go names conversion.
+	// It allows you to force-rename anything (including functions and enums)
+	Replace map[CIdentifier]GoIdentifier
 }

--- a/cmd/codegen/presets.go
+++ b/cmd/codegen/presets.go
@@ -20,4 +20,8 @@ type Preset struct {
 	// Replace is a map for C -> Go names conversion.
 	// It allows you to force-rename anything (including functions and enums)
 	Replace map[CIdentifier]GoIdentifier
+	// TrimPrefix allows to remove unwanted prefixes from everything during C->Go renaming.
+	// NOTE: order sensitive!
+	// NOTE: Case sensitive
+	TrimPrefix map[string]string
 }

--- a/cmd/codegen/presets.go
+++ b/cmd/codegen/presets.go
@@ -6,9 +6,11 @@ type Preset struct {
 	// SkipFuncs functions (from definitions.json) to be skipped
 	// e.g. they are temporarily hard-coded
 	SkipFuncs map[CIdentifier]bool
-	// SkipStructs struct names from structs_and_enums.json.
-	// structures that's METHODS should be skipped
+	// SkipStructs allows to specify struct names that will be skipped.
 	SkipStructs map[CIdentifier]bool
+	// SkipMethods struct names from structs_and_enums.json.
+	// structures that's METHODS should be skipped
+	SkipMethods map[CIdentifier]bool
 	// SkipTypedefs typedefs from typedefs_dict.json to be skipped
 	// e.g. for hardcoded typedefs or typedefs which are obvious (e.g. ImU16 becomes uint16 without extra type information)
 	SkipTypedefs map[CIdentifier]bool

--- a/cmd/codegen/presets.go
+++ b/cmd/codegen/presets.go
@@ -1,0 +1,13 @@
+package main
+
+// Preset is a set of rules iperative to XXX_templates/ json files.
+// They are used to manually set some properties of the generator.
+type Preset struct {
+	// SkipFuncs functions (from definitions.json) to be skipped
+	// e.g. they are temporarily hard-coded
+	SkipFuncs map[CIdentifier]bool
+	// SkipStructs structs from structs_and_enums.json to be skipped
+	SkipStructs map[CIdentifier]bool
+	// SkipTypedefs typedefs from typedefs_dict.json to be skipped
+	SkipTypedefs map[CIdentifier]bool
+}

--- a/cmd/codegen/return_wrapper.go
+++ b/cmd/codegen/return_wrapper.go
@@ -79,7 +79,7 @@ func getReturnWrapper(
 	// check if pureType is a declared type (struct or something else from typedefs)
 	_, isRefStruct := context.refStructNames[pureType]
 	_, isRefTypedef := context.refTypedefs[pureType]
-	_, shouldSkipRefTypedef := skippedTypedefs[pureType]
+	_, shouldSkipRefTypedef := context.preset.SkipTypedefs[pureType]
 	_, isStruct := context.structNames[pureType]
 	isStruct = isStruct || ((isRefStruct || (isRefTypedef && !isEnum(pureType, context.refEnumNames))) && !shouldSkipRefTypedef)
 	w, known := returnWrapperMap[t]

--- a/cmd/codegen/return_wrapper.go
+++ b/cmd/codegen/return_wrapper.go
@@ -100,13 +100,13 @@ func getReturnWrapper(
 		// case (context.structNames[t] || context.refStructNames[t]) && !shouldSkipStruct(t):
 	case !HasSuffix(t, "*") && isStruct && !shouldSkipStruct(pureType):
 		return returnWrapper{
-			returnType: prefixGoPackage(t.renameGoIdentifier(), srcPackage, context),
+			returnType: prefixGoPackage(t.renameGoIdentifier(context), srcPackage, context),
 			// this is a small trick as using prefixGoPackage isn't in fact intended to be used in such a way, but it should treat the whole string as a "type" and prefix it correctly
-			returnStmt: string(prefixGoPackage(GoIdentifier(fmt.Sprintf("*New%sFromC(func() *C.%s {result := %%s; return &result}())", t.renameGoIdentifier(), t)), srcPackage, context)),
+			returnStmt: string(prefixGoPackage(GoIdentifier(fmt.Sprintf("*New%sFromC(func() *C.%s {result := %%s; return &result}())", t.renameGoIdentifier(context), t)), srcPackage, context)),
 			CType:      GoIdentifier(fmt.Sprintf("*C.%s", t)),
 		}, nil
 	case isEnum(t, context.enumNames):
-		goType := prefixGoPackage(t.renameGoIdentifier(), srcPackage, context)
+		goType := prefixGoPackage(t.renameGoIdentifier(context), srcPackage, context)
 		return returnWrapper{
 			returnType: goType,
 			returnStmt: fmt.Sprintf("%s(%%s)", goType),
@@ -131,17 +131,17 @@ func getReturnWrapper(
 			CType:      GoIdentifier(fmt.Sprintf("*C.%s", t)),
 		}, nil
 	case HasSuffix(t, "*") && isEnum(TrimSuffix(t, "*"), context.enumNames):
-		goType := prefixGoPackage("*"+TrimSuffix(t, "*").renameGoIdentifier(), srcPackage, context)
+		goType := prefixGoPackage("*"+TrimSuffix(t, "*").renameGoIdentifier(context), srcPackage, context)
 		return returnWrapper{
 			returnType: goType,
 			returnStmt: fmt.Sprintf("(%s)(%%s)", goType),
 			CType:      GoIdentifier(fmt.Sprintf("*C.%s", TrimSuffix(t, "*"))),
 		}, nil
 	case HasSuffix(t, "*") && isStruct && !shouldSkipStruct(pureType):
-		goType := prefixGoPackage("*"+TrimPrefix(TrimSuffix(t, "*"), "const ").renameGoIdentifier(), srcPackage, context)
+		goType := prefixGoPackage("*"+TrimPrefix(TrimSuffix(t, "*"), "const ").renameGoIdentifier(context), srcPackage, context)
 		return returnWrapper{
 			returnType: goType,
-			returnStmt: string(prefixGoPackage(GoIdentifier(fmt.Sprintf("New%sFromC(%%s)", TrimPrefix(TrimSuffix(t, "*"), "const ").renameGoIdentifier())), srcPackage, context)),
+			returnStmt: string(prefixGoPackage(GoIdentifier(fmt.Sprintf("New%sFromC(%%s)", TrimPrefix(TrimSuffix(t, "*"), "const ").renameGoIdentifier(context))), srcPackage, context)),
 			CType:      GoIdentifier(fmt.Sprintf("*C.%s", TrimPrefix(TrimSuffix(t, "*"), "const "))),
 		}, nil
 	case isArray:

--- a/cmd/codegen/return_wrapper.go
+++ b/cmd/codegen/return_wrapper.go
@@ -81,7 +81,7 @@ func getReturnWrapper(
 	_, isRefTypedef := context.refTypedefs[pureType]
 	_, shouldSkipRefTypedef := context.preset.SkipTypedefs[pureType]
 	_, isStruct := context.structNames[pureType]
-	isStruct = isStruct || ((isRefStruct || (isRefTypedef && !isEnum(pureType, context.refEnumNames))) && !shouldSkipRefTypedef)
+	isStruct = isStruct || ((isRefStruct || (isRefTypedef && !IsEnum(pureType, context.refEnumNames))) && !shouldSkipRefTypedef)
 	w, known := returnWrapperMap[t]
 	// check if is array (match regex)
 	isArray, err := regexp.Match(".*\\[\\d+\\]", []byte(t))
@@ -107,7 +107,7 @@ func getReturnWrapper(
 			returnStmt: string(prefixGoPackage(GoIdentifier(fmt.Sprintf("*New%sFromC(func() *C.%s {result := %%s; return &result}())", t.renameGoIdentifier(context), t)), srcPackage, context)),
 			CType:      GoIdentifier(fmt.Sprintf("*C.%s", t)),
 		}, nil
-	case isEnum(t, context.enumNames):
+	case IsEnum(t, context.enumNames):
 		goType := prefixGoPackage(t.renameGoIdentifier(context), srcPackage, context)
 		return returnWrapper{
 			returnType: goType,
@@ -132,7 +132,7 @@ func getReturnWrapper(
 			returnStmt: fmt.Sprintf("vectors.NewVectorFromC(%%[1]s.Size, %%[1]s.Capacity, %s)", fmt.Sprintf(rw.returnStmt, "%[1]s.Data")),
 			CType:      GoIdentifier(fmt.Sprintf("*C.%s", t)),
 		}, nil
-	case HasSuffix(t, "*") && isEnum(TrimSuffix(t, "*"), context.enumNames):
+	case HasSuffix(t, "*") && IsEnum(TrimSuffix(t, "*"), context.enumNames):
 		goType := prefixGoPackage("*"+TrimSuffix(t, "*").renameGoIdentifier(context), srcPackage, context)
 		return returnWrapper{
 			returnType: goType,

--- a/cmd/codegen/return_wrapper.go
+++ b/cmd/codegen/return_wrapper.go
@@ -94,11 +94,13 @@ func getReturnWrapper(
 		srcPackage = GoIdentifier(context.flags.refPackageName)
 	}
 
+	_, shouldSkipStruct := context.preset.SkipStructs[pureType]
+
 	switch {
 	case known:
 		return w, nil
 		// case (context.structNames[t] || context.refStructNames[t]) && !shouldSkipStruct(t):
-	case !HasSuffix(t, "*") && isStruct && !shouldSkipStruct(pureType):
+	case !HasSuffix(t, "*") && isStruct && !shouldSkipStruct:
 		return returnWrapper{
 			returnType: prefixGoPackage(t.renameGoIdentifier(context), srcPackage, context),
 			// this is a small trick as using prefixGoPackage isn't in fact intended to be used in such a way, but it should treat the whole string as a "type" and prefix it correctly
@@ -137,7 +139,7 @@ func getReturnWrapper(
 			returnStmt: fmt.Sprintf("(%s)(%%s)", goType),
 			CType:      GoIdentifier(fmt.Sprintf("*C.%s", TrimSuffix(t, "*"))),
 		}, nil
-	case HasSuffix(t, "*") && isStruct && !shouldSkipStruct(pureType):
+	case HasSuffix(t, "*") && isStruct && !shouldSkipStruct:
 		goType := prefixGoPackage("*"+TrimPrefix(TrimSuffix(t, "*"), "const ").renameGoIdentifier(context), srcPackage, context)
 		return returnWrapper{
 			returnType: goType,

--- a/cmd/codegen/structures_deffinition.go
+++ b/cmd/codegen/structures_deffinition.go
@@ -102,22 +102,3 @@ func getStructDefs(enumJsonBytes []byte) ([]StructDef, error) {
 
 	return structs, nil
 }
-
-func shouldSkipStruct(name CIdentifier) bool {
-	valueTypeStructs := map[CIdentifier]bool{
-		"ImVec2ih":    true,
-		"ImVec2":      true,
-		"ImVec4":      true,
-		"ImRect":      true,
-		"ImColor":     true,
-		"ImPlotPoint": true,
-		"ImPlotTime":  true,
-	}
-
-	// Skip all value type struct
-	if valueTypeStructs[name] {
-		return true
-	}
-
-	return false
-}


### PR DESCRIPTION
What is this?
currently, `gengo.go` (and randomly other files) have various maps with hardcoded strings.
The purpose of this change is, to move all of them and store as a single object.
I've decided to split this into 2 parts:
- `presets.go` contains a go struct. Its instance is stored inside of a Context.
- `cimgu-go-preset.json` contains actual values compatible with cimgui-go.

Why?
- To put everything hard-coded in 1 place
- To make our codegen independent on hardcoded values (maybe someone will use it somewhere else?)

There is a new `codegen -preset` flag to set path for this json file.