### PR TITLE
Codegen: fix unexported funcs

### DIFF
--- a/cmd/codegen/gencpp.go
+++ b/cmd/codegen/gencpp.go
@@ -12,19 +12,6 @@ import (
 // In this case text_end is replaced by this argument (of type int)
 const textLenRegisteredName = "text_len"
 
-// Returns if should export func
-func shouldExportFunc(funcName CIdentifier) bool {
-	switch {
-	case unicode.IsUpper(rune(funcName[0])):
-		return true
-	case HasPrefix(funcName, "ig"):
-		return len(funcName) > 2 && unicode.IsUpper(rune(funcName[2]))
-	case HasPrefix(funcName, "imnodes_") && unicode.IsUpper(rune(TrimPrefix(funcName, "imnodes_")[0])):
-		return true
-	}
-	return false
-}
-
 // Generate cpp wrapper and return valid functions
 func generateCppWrapper(prefix, includePath string, funcDefs []FuncDef, ctx *Context) ([]FuncDef, error) {
 	var validFuncs []FuncDef
@@ -83,11 +70,6 @@ extern "C" {
 
 		// check if func name is valid
 		if len(f.FuncName) == 0 {
-			shouldSkip = true
-		}
-
-		// Check lower case for function
-		if !shouldExportFunc(f.FuncName) {
 			shouldSkip = true
 		}
 

--- a/cmd/codegen/gengo_funcs.go
+++ b/cmd/codegen/gengo_funcs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"unicode"
 
 	"github.com/kpango/glg"
 )
@@ -297,6 +298,8 @@ func (g *goFuncsGenerator) generateFuncDeclarationStmt(receiver GoIdentifier, fu
 	}
 
 	goFuncName := funcName.renameGoIdentifier(g.context)
+	// make sure goFuncName is exported
+	goFuncName = GoIdentifier(unicode.ToUpper(rune(goFuncName[0]))) + goFuncName[1:]
 
 	// if file comes from imgui_internal.h,prefix Internal is added.
 	// ref: https://github.com/AllenDang/cimgui-go/pull/118

--- a/imgui/cimgui_funcs.go
+++ b/imgui/cimgui_funcs.go
@@ -2914,7 +2914,7 @@ func (self *TextBuffer) Begin() string {
 	}()
 }
 
-func (self *TextBuffer) cstr() string {
+func (self *TextBuffer) Cstr() string {
 	selfArg, selfFin := self.Handle()
 
 	defer func() {
@@ -3064,7 +3064,7 @@ func (self *TextIndex) InternalClear() {
 	selfFin()
 }
 
-func (self *TextIndex) Internalgetlinebegin(base string, n int32) string {
+func (self *TextIndex) InternalGetlinebegin(base string, n int32) string {
 	selfArg, selfFin := self.Handle()
 	baseArg, baseFin := internal.WrapString[C.char](base)
 
@@ -3079,7 +3079,7 @@ func (self *TextIndex) Internalgetlinebegin(base string, n int32) string {
 	}()
 }
 
-func (self *TextIndex) Internalgetlineend(base string, n int32) string {
+func (self *TextIndex) InternalGetlineend(base string, n int32) string {
 	selfArg, selfFin := self.Handle()
 	baseArg, baseFin := internal.WrapString[C.char](base)
 

--- a/immarkdown/cimmarkdown_funcs.go
+++ b/immarkdown/cimmarkdown_funcs.go
@@ -122,6 +122,29 @@ func UnderLine(col_ imgui.Color) {
 	C.UnderLine(internal.ReinterpretCast[C.ImColor](col_.ToC()))
 }
 
+func DefaultMarkdownFormatCallback(markdownFormatInfo_ MarkdownFormatInfo, start_ bool) {
+	markdownFormatInfo_Arg, markdownFormatInfo_Fin := markdownFormatInfo_.C()
+	C.defaultMarkdownFormatCallback(internal.ReinterpretCast[C.MarkdownFormatInfo](markdownFormatInfo_Arg), C.bool(start_))
+
+	markdownFormatInfo_Fin()
+}
+
+func DefaultMarkdownTooltipCallback(data_ MarkdownTooltipCallbackData) {
+	data_Arg, data_Fin := data_.C()
+	C.defaultMarkdownTooltipCallback(internal.ReinterpretCast[C.MarkdownTooltipCallbackData](data_Arg))
+
+	data_Fin()
+}
+
+func Size(self *TextBlock) int32 {
+	selfArg, selfFin := self.Handle()
+
+	defer func() {
+		selfFin()
+	}()
+	return int32(C.size(internal.ReinterpretCast[*C.TextBlock](selfArg)))
+}
+
 func RenderLinkTextWrapped(self *TextRegion, text_ string, link_ Link, markdown_ string, mdConfig_ MarkdownConfig, linkHoverStart_ []string) {
 	selfArg, selfFin := self.Handle()
 	text_Arg, text_Fin := internal.WrapString[C.char](text_)


### PR DESCRIPTION
mainly for defaultMarktownFormatCallback