### PR TITLE
change(backend): dont take Backend as an arg to WIndowCloseCallback

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -118,7 +118,7 @@ type (
 	SizeChangeCallback func(w, h int)
 )
 
-type WindowCloseCallback[BackendFlagsT ~int] func(b Backend[BackendFlagsT])
+type WindowCloseCallback func()
 
 //export closeCallback
 func closeCallback(wnd unsafe.Pointer) {
@@ -161,7 +161,7 @@ type Backend[BackendFlagsT ~int] interface {
 	SetTargetFPS(fps uint)
 
 	SetDropCallback(DropCallback)
-	SetCloseCallback(WindowCloseCallback[BackendFlagsT])
+	SetCloseCallback(WindowCloseCallback)
 	SetKeyCallback(KeyCallback)
 	SetSizeChangeCallback(SizeChangeCallback)
 	// SetWindowFlags selected hint to specified value.

--- a/backend/ebiten-backend/cimgui_backend_impl.go
+++ b/backend/ebiten-backend/cimgui_backend_impl.go
@@ -114,7 +114,7 @@ func (b *EbitenBackend) SetDropCallback(backend.DropCallback) {
 	panic("SetDropCallback is not implemented for Ebiten backend yet.")
 }
 
-func (b *EbitenBackend) SetCloseCallback(cb backend.WindowCloseCallback[EbitenBackendFlags]) {
+func (b *EbitenBackend) SetCloseCallback(cb backend.WindowCloseCallback) {
 	b.closeCb = cb
 }
 

--- a/backend/ebiten-backend/ebiten_backend.go
+++ b/backend/ebiten-backend/ebiten_backend.go
@@ -29,7 +29,7 @@ type EbitenBackend struct {
 	afterRender,
 	beforeDestroy,
 	loop func()
-	closeCb backend.WindowCloseCallback[EbitenBackendFlags]
+	closeCb backend.WindowCloseCallback
 
 	// ebiten stuff
 	filter                      ebiten.Filter
@@ -112,7 +112,7 @@ func (e *EbitenBackend) SetContext(ctx *imgui.Context) *EbitenBackend {
 // This is usually called inside the game's Update() function.
 func (e *EbitenBackend) BeginFrame() {
 	if ebiten.IsWindowBeingClosed() && e.closeCb != nil {
-		e.closeCb(e)
+		e.closeCb()
 	}
 
 	if e.beforeRender != nil {

--- a/backend/glfwbackend/glfw_backend.go
+++ b/backend/glfwbackend/glfw_backend.go
@@ -382,9 +382,9 @@ func (b *GLFWBackend) SetDropCallback(cbfun backend.DropCallback) {
 	C.igGLFWWindow_SetDropCallbackCB(b.handle())
 }
 
-func (b *GLFWBackend) SetCloseCallback(cbfun backend.WindowCloseCallback[GLFWWindowFlags]) {
+func (b *GLFWBackend) SetCloseCallback(cbfun backend.WindowCloseCallback) {
 	b.closeCB = func(_ unsafe.Pointer) {
-		cbfun(b)
+		cbfun()
 	}
 
 	C.igGLFWWindow_SetCloseCallback(b.handle())

--- a/backend/sdlbackend/sdl_backend.go
+++ b/backend/sdlbackend/sdl_backend.go
@@ -414,9 +414,9 @@ func (b *SDLBackend) SetDropCallback(cbfun backend.DropCallback) {
 	// C.igSDLWindow_SetDropCallbackCB(b.handle())
 }
 
-func (b *SDLBackend) SetCloseCallback(cbfun backend.WindowCloseCallback[SDLWindowFlags]) {
+func (b *SDLBackend) SetCloseCallback(cbfun backend.WindowCloseCallback) {
 	b.closeCB = func(_ unsafe.Pointer) {
-		cbfun(b)
+		cbfun()
 	}
 
 	// TODO: not implemented

--- a/examples/ebiten-game-in-texture/main.go
+++ b/examples/ebiten-game-in-texture/main.go
@@ -69,7 +69,7 @@ func main() {
 		})
 	*/
 
-	currentBackend.SetCloseCallback(func(b backend.Backend[ebitenbackend.EbitenBackendFlags]) {
+	currentBackend.SetCloseCallback(func() {
 		fmt.Println("window is closing")
 	})
 

--- a/examples/ebiten/main.go
+++ b/examples/ebiten/main.go
@@ -29,7 +29,7 @@ func main() {
 		})
 	*/
 
-	currentBackend.SetCloseCallback(func(b backend.Backend[ebitenbackend.EbitenBackendFlags]) {
+	currentBackend.SetCloseCallback(func() {
 		fmt.Println("window is closing")
 	})
 

--- a/examples/glfw/main.go
+++ b/examples/glfw/main.go
@@ -32,7 +32,7 @@ func main() {
 		fmt.Printf("drop triggered: %v", p)
 	})
 
-	currentBackend.SetCloseCallback(func(b backend.Backend[glfwbackend.GLFWWindowFlags]) {
+	currentBackend.SetCloseCallback(func() {
 		fmt.Println("window is closing")
 	})
 

--- a/examples/sdl/main.go
+++ b/examples/sdl/main.go
@@ -31,7 +31,7 @@ func main() {
 		fmt.Printf("drop triggered: %v", p)
 	})
 
-	currentBackend.SetCloseCallback(func(b backend.Backend[sdlbackend.SDLWindowFlags]) {
+	currentBackend.SetCloseCallback(func() {
 		fmt.Println("window is closing")
 	})
 


### PR DESCRIPTION
Unfortunately this is a breaking change (again...) but should make 'dynamic backend selection' easier.

also, this makes no sense here.