### PR TITLE
feat(codegen): allow to skip files

### DIFF
--- a/cmd/codegen/cimgui-go-preset.json
+++ b/cmd/codegen/cimgui-go-preset.json
@@ -49,6 +49,8 @@
                 "ImU64":                  true,
                 "ImGuiInputTextCallback": true
         },
+        "SkipFiles": [
+        ],
         "TypedefsPoolSize": 32,
         "TypedefsCustomPoolSizes": {
         },

--- a/cmd/codegen/gengo_funcs.go
+++ b/cmd/codegen/gengo_funcs.go
@@ -54,6 +54,14 @@ func GenerateGoFuncs(
 			continue
 		}
 
+		if MapContainsAny(f.Location, context.preset.SkipFiles) {
+			if context.flags.ShowNotGenerated {
+				glg.Warnf("File %s skipped: %s%s", f.Location, f.FuncName, f.Args)
+			}
+
+			continue
+		}
+
 		args, argWrappers := generator.generateFuncArgs(f)
 
 		if len(f.ArgsT) == 0 {
@@ -65,6 +73,7 @@ func GenerateGoFuncs(
 			if context.flags.ShowNotGenerated {
 				glg.Errorf("not generated: %s%s", f.FuncName, f.Args)
 			}
+
 			continue
 		} else {
 			if context.flags.ShowGenerated {

--- a/cmd/codegen/helpers.go
+++ b/cmd/codegen/helpers.go
@@ -25,8 +25,8 @@ func ReplaceAll[s, t, u ~string](str s, old t, new u) s {
 	return s(strings.ReplaceAll(string(str), string(old), string(new)))
 }
 
-func Contains[s ~string](str s, substr string) bool {
-	return strings.Contains(string(str), substr)
+func Contains[t ~string, s ~string](str s, substr t) bool {
+	return strings.Contains(string(str), string(substr))
 }
 
 func Split[s ~string](str s, sep string) []s {
@@ -93,4 +93,14 @@ func RemoveMapValues[T comparable, S any](m map[T]S) map[T]bool {
 	}
 
 	return result
+}
+
+func MapContainsAny[T ~string, S ~string](key T, dict []S) bool {
+	for _, v := range dict {
+		if Contains(key, v) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/cmd/codegen/presets.go
+++ b/cmd/codegen/presets.go
@@ -16,6 +16,9 @@ type Preset struct {
 	// SkipTypedefs typedefs from typedefs_dict.json to be skipped
 	// e.g. for hardcoded typedefs or typedefs which are obvious (e.g. ImU16 becomes uint16 without extra type information)
 	SkipTypedefs map[CIdentifier]bool
+	// SkipFiles contains filenames (probably without extension) refering to location field in definitions.json.
+	// This could aso contain line number in form of filename:lineN.
+	SkipFiles []string
 	// TypedefsPoolSize sets a default size for callbacks pool.
 	// Rembmber to set this as it defaults to 0 and you'll get no callbacks!
 	TypedefsPoolSize int


### PR DESCRIPTION
this has no real usage at current codebase, but in a future PR I'm going to upgrade to the latest cimgui which adds freetype support.

I'll want to exclude this freetype support from go generation, as it adds more problems and we don't need it right now.

The easiest way to achive this is just disabling one particular file but that feature sounds useful in general for the generator