### PR TITLE
codegen(preset): fix json formatting

### DIFF
--- a/cmd/codegen/cimgui-go-preset.json
+++ b/cmd/codegen/cimgui-go-preset.json
@@ -90,7 +90,7 @@
                 "((void*)0)": "0"
         },
         "DefaultArgArbitraryValue": {
-                "text_end":   0,
+                "text_end":   "0",
                 "text_end_": "0"
         },
         "ExtraCGOPreamble": [


### PR DESCRIPTION
shouldn't affect anything else just removes warning.