### PR TITLE
workflows(golangci): upgrade golangci-lint version to v2.1.6

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: golangci/golangci-lint-action@v7.0.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v2.0.1
+          version: v2.1.6
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir


### PR DESCRIPTION
requried by #426 