### PR TITLE
sdl: add clipboard getter and setter

### DIFF
--- a/backend/sdlbackend/sdl_backend.cpp
+++ b/backend/sdlbackend/sdl_backend.cpp
@@ -254,6 +254,10 @@ void igSDLWindow_SetSize(SDL_Window *window, int width, int height) { SDL_SetWin
 
 void igSDLWindow_SetTitle(SDL_Window *window, const char *title) { SDL_SetWindowTitle(window, title); }
 
+void igSDL_SetClipboard(const char *text) { SDL_SetClipboardText(text); }
+
+void igSDL_Free(char* str) { SDL_free(str); }
+
 void igSDLWindow_SetSizeLimits(SDL_Window *window, int minWidth, int minHeight, int maxWidth, int maxHeight) {
   SDL_SetWindowMinimumSize(window, minWidth, minHeight);
   SDL_SetWindowMaximumSize(window, maxWidth, maxHeight);

--- a/backend/sdlbackend/sdl_backend.go
+++ b/backend/sdlbackend/sdl_backend.go
@@ -357,6 +357,20 @@ func (b *SDLBackend) SetWindowTitle(title string) {
 	C.igSDLWindow_SetTitle(b.handle(), (*C.char)(titleArg))
 }
 
+func (b *SDLBackend) SetClipboard(text string) {
+	clipboardArg, clipboardFin := internal.WrapString[C.char](text)
+	defer clipboardFin()
+
+	C.igSDL_SetClipboard((*C.char)(clipboardArg))
+}
+
+func (b *SDLBackend) Clipboard() string {
+	cText := C.SDL_GetClipboardText()
+	defer C.igSDL_Free(cText)
+
+	return C.GoString(cText)
+}
+
 // The minimum and maximum size of the content area of a windowed mode window.
 // To specify only a minimum size or only a maximum one, set the other pair to -1
 // e.g. SetWindowSizeLimits(640, 480, -1, -1)

--- a/backend/sdlbackend/sdl_backend.h
+++ b/backend/sdlbackend/sdl_backend.h
@@ -190,6 +190,8 @@ extern void igSDLWindow_GetWindowPos(SDL_Window *window, int *x, int *y);
 extern void igSDLWindow_SetSize(SDL_Window *window, int width, int height);
 extern void igSDLWindow_SetTitle(SDL_Window *window, const char *title);
 extern void igSDLWindow_SetSizeLimits(SDL_Window *window, int minWidth, int minHeight, int maxWidth, int maxHeight);
+
+extern void igSDL_SetClipboard(const char *text);
 //extern void igSDLWindow_SetCloseCallback(SDL_Window *window);
 //extern void igSDLWindow_SetKeyCallback(SDL_Window *window);
 //extern void igSDLWindow_SetSizeCallback(SDL_Window *window);
@@ -198,6 +200,8 @@ extern void igRefresh();
 extern ImTextureID igCreateTexture(unsigned char *pixels, int width, int height);
 extern void igDeleteTexture(ImTextureID id);
 extern void igSDLWindowHint(SDL_WindowFlags hint, int value);
+
+extern void igSDL_Free(char* str);
 
 //extern void dropCallback(int, char **);
 //extern void closeCallback(SDL_Window *window);


### PR DESCRIPTION
This commit adds .SetClipboard(text) and .Clipboard() functions to the SDL backend. These functions are not available in the Backend interface yet.