### PR TITLE
fix(codegen): do not further modify names if Replace

### DIFF
--- a/cmd/codegen/gengo.go
+++ b/cmd/codegen/gengo.go
@@ -31,6 +31,7 @@ func (c CIdentifier) trimImGuiPrefix(ctx *Context) CIdentifier {
 func (c CIdentifier) renameGoIdentifier(ctx *Context) GoIdentifier {
 	if r, ok := ctx.preset.Replace[c]; ok {
 		c = CIdentifier(r)
+		return GoIdentifier(c)
 	}
 
 	c = TrimSuffix(c, "_Nil")

--- a/cmd/codegen/presets.go
+++ b/cmd/codegen/presets.go
@@ -36,6 +36,7 @@ type Preset struct {
 	TypedefsCustomPoolSizes map[CIdentifier]int
 	// Replace is a map for C -> Go names conversion.
 	// It allows you to force-rename anything (including functions and enums)
+	// With Replace all further processing will be skipped (prefix, e.t.c.)
 	Replace map[CIdentifier]GoIdentifier
 	// TrimPrefix allows to remove unwanted prefixes from everything during C->Go renaming.
 	// NOTE: order sensitive!


### PR DESCRIPTION
If name present in Replace table, no further changes will be done (including removing Get prefix)

part of #448 