### PR TITLE
workflow/compile-cimgui/macos: remove build dir after building for x86 and before arm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,10 @@ jobs:
         run: cmake --build ./build --target clean
         working-directory: ./thirdparty/SDL
 
+      - name: Nuke old build directory
+        working-directory: ./thirdparty/SDL
+        run: rm -rf build
+
       - name: configure sdl for arm64
         run: cmake -S . -Bbuild -DCMAKE_OSX_ARCHITECTURES=arm64
         working-directory: ./thirdparty/SDL


### PR DESCRIPTION
this was a part of #466.
Submitting as a separate PR for clearity reasons.

The purpose of this is to remove entire build directory on macOS job after building for x86. For some reasons arm build started to crash our CI if this was not removed.