### PR TITLE
add Linux DRM/EGL backend based on go-drm-egl

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
         if: startsWith(matrix.os,'ubuntu')
         run: |
           sudo apt-get --allow-releaseinfo-change update
-          sudo apt-get install -y libgtk-3-dev libasound2-dev libxxf86vm-dev
+          sudo apt-get install -y libgtk-3-dev libasound2-dev libxxf86vm-dev libdrm-dev libgbm-dev libegl1-mesa-dev libgles2-mesa-dev pkg-config
       - name: Set up Go environment
         uses: actions/setup-go@v6
         with:

--- a/README.md
+++ b/README.md
@@ -49,10 +49,17 @@ We support the following backends:
 - [GLFW](./examples/glfw). (GLFW 3.3 + OpenGL)
 - [SDL2](./examples/sdl). (SDL 2 + OpenGL)
 - [Ebitengine](./examples/ebiten) (`import "github.com/AllenDang/cimgui-go/backend/ebitenbackend"`).
+- [DRM/EGL](./examples/drm-egl) (`import "github.com/AllenDang/cimgui-go/backend/drmeglbackend"`, Linux only).
 
 > [!important]
 > Remember that various solution use different C libraries that can conflict with each other.
 > It is recommended not to import e.g. GLFW and SDL backends at the same time as it may result in linker crash.
+
+> [!note]
+> The DRM/EGL backend is intended for embedded Linux / kiosk setups that render directly through DRM/KMS without X11 or Wayland. It currently focuses on rendering and texture upload; desktop-style window management, drag-and-drop, and input event wiring are not implemented yet.
+
+> [!tip]
+> To build the DRM/EGL example/backend, install `libdrm-dev`, `libgbm-dev`, `libegl1-mesa-dev`, `libgles2-mesa-dev`, then use `go run ./examples/drm-egl`.
 
 > [!tip]
 > Because [glfw v3.4](https://github.com/glfw/glfw) defaults to wayland when possible and wayland does not support some of imgui features, there is a `glfwbackend.ForceX11()`. Call it before creating a `glfwbackend.GLFWBakend` instance.

--- a/backend/drmeglbackend/doc.go
+++ b/backend/drmeglbackend/doc.go
@@ -1,0 +1,9 @@
+//go:build linux && cgo
+
+// Package drmeglbackend provides a Dear ImGui backend for Linux DRM/KMS + EGL.
+//
+// It is intended for embedded or kiosk-like environments where rendering happens
+// directly on a TTY without X11 or Wayland. Unlike the GLFW/SDL backends, this
+// backend does not expose a real desktop window, so several window-management
+// methods are implemented as compatibility no-ops.
+package drmeglbackend

--- a/backend/drmeglbackend/drm_egl_backend.go
+++ b/backend/drmeglbackend/drm_egl_backend.go
@@ -1,0 +1,354 @@
+//go:build linux && cgo
+
+package drmeglbackend
+
+import (
+	"errors"
+	"image"
+	"time"
+	"unsafe"
+
+	"github.com/AllenDang/cimgui-go/backend"
+	"github.com/AllenDang/cimgui-go/imgui"
+	"github.com/AllenDang/cimgui-go/impl/opengl3"
+	drm "github.com/tthhr/go-drm-egl/drm"
+)
+
+type voidCallbackFunc func()
+
+type DRMEGLWindowFlags int
+
+const (
+	DRMEGLWindowFlagsNone      DRMEGLWindowFlags = 0
+	DRMEGLWindowFlagsOffscreen DRMEGLWindowFlags = 1 << iota
+)
+
+const (
+	DRMEGLSwapIntervalImmediate = DRMEGLWindowFlags(0)
+	DRMEGLSwapIntervalVsync     = DRMEGLWindowFlags(1)
+)
+
+var (
+	ErrContextNotCreated        = errors.New("drmeglbackend: context not created")
+	ErrImmediateSwapUnsupported = errors.New("drmeglbackend: immediate swap interval is not supported by go-drm-egl")
+)
+
+var _ backend.Backend[DRMEGLWindowFlags] = &DRMEGLBackend{}
+
+type DRMEGLBackend struct {
+	afterCreateContext   voidCallbackFunc
+	loop                 voidCallbackFunc
+	beforeRender         voidCallbackFunc
+	afterRender          voidCallbackFunc
+	beforeDestroyContext voidCallbackFunc
+	dropCB               backend.DropCallback
+	closeCB              func(pointer unsafe.Pointer)
+	keyCb                backend.KeyCallback
+	sizeCb               backend.SizeChangeCallback
+
+	ctx         *drm.Context
+	shouldClose bool
+	targetFPS   uint
+	bgColor     imgui.Vec4
+	offscreen   bool
+	title       string
+	width       int
+	height      int
+}
+
+func NewDRMEGLBackend() *DRMEGLBackend {
+	return &DRMEGLBackend{
+		targetFPS: 60,
+		bgColor:   imgui.NewVec4(0.45, 0.55, 0.6, 1.0),
+		closeCB:   func(unsafe.Pointer) {},
+		dropCB:    func([]string) {},
+		keyCb:     func(int, int, int, int) {},
+		sizeCb:    func(int, int) {},
+	}
+}
+
+func (b *DRMEGLBackend) SetAfterCreateContextHook(hook func()) {
+	b.afterCreateContext = hook
+}
+
+func (b *DRMEGLBackend) AfterCreateHook() func() {
+	return b.afterCreateContext
+}
+
+func (b *DRMEGLBackend) SetBeforeDestroyContextHook(hook func()) {
+	b.beforeDestroyContext = hook
+}
+
+func (b *DRMEGLBackend) BeforeDestroyHook() func() {
+	return b.beforeDestroyContext
+}
+
+func (b *DRMEGLBackend) SetBeforeRenderHook(hook func()) {
+	b.beforeRender = hook
+}
+
+func (b *DRMEGLBackend) BeforeRenderHook() func() {
+	return b.beforeRender
+}
+
+func (b *DRMEGLBackend) SetAfterRenderHook(hook func()) {
+	b.afterRender = hook
+}
+
+func (b *DRMEGLBackend) AfterRenderHook() func() {
+	return b.afterRender
+}
+
+func (b *DRMEGLBackend) SetBgColor(color imgui.Vec4) {
+	b.bgColor = color
+}
+
+func (b *DRMEGLBackend) Run(loop func()) {
+	if b.ctx == nil {
+		panic(ErrContextNotCreated)
+	}
+
+	b.loop = loop
+	lastFrame := time.Now()
+	frameDuration := time.Second / time.Duration(maxUint(b.targetFPS, 1))
+
+	for !b.shouldClose {
+		now := time.Now()
+		delta := now.Sub(lastFrame)
+		lastFrame = now
+
+		if hook := b.beforeRender; hook != nil {
+			hook()
+		}
+
+		io := imgui.CurrentIO()
+		io.SetDisplaySize(imgui.NewVec2(float32(b.ctx.Width()), float32(b.ctx.Height())))
+		io.SetDeltaTime(float32(delta.Seconds()))
+
+		drm.ViewPort(0, 0, b.ctx.Width(), b.ctx.Height())
+		opengl3.NewFrame()
+		imgui.NewFrame()
+
+		if b.loop != nil {
+			b.loop()
+		}
+
+		imgui.Render()
+		drm.ClearColor(b.bgColor.X, b.bgColor.Y, b.bgColor.Z, b.bgColor.W)
+		drm.Clear(drm.COLOR_BUFFER_BIT)
+		opengl3.RenderDrawData(imgui.CurrentDrawData())
+		drm.RenderFrame(b.ctx)
+
+		if hook := b.afterRender; hook != nil {
+			hook()
+		}
+
+		if sleep := frameDuration - time.Since(now); sleep > 0 {
+			time.Sleep(sleep)
+		}
+	}
+
+	b.destroy()
+}
+
+func (b *DRMEGLBackend) destroy() {
+	opengl3.Shutdown()
+	if hook := b.beforeDestroyContext; hook != nil {
+		hook()
+	}
+	imgui.DestroyContext()
+	if b.ctx != nil {
+		b.ctx.Cleanup()
+		b.ctx = nil
+	}
+	if b.closeCB != nil {
+		b.closeCB(nil)
+	}
+}
+
+func (b *DRMEGLBackend) LoopFunc() func() {
+	return b.loop
+}
+
+func (b *DRMEGLBackend) DropCallback() backend.DropCallback {
+	return b.dropCB
+}
+
+func (b *DRMEGLBackend) CloseCallback() func(wnd unsafe.Pointer) {
+	return b.closeCB
+}
+
+func (b *DRMEGLBackend) SetWindowPos(_, _ int) {}
+
+func (b *DRMEGLBackend) GetWindowPos() (x, y int32) {
+	return 0, 0
+}
+
+func (b *DRMEGLBackend) SetWindowSize(width, height int) {
+	b.width = width
+	b.height = height
+}
+
+func (b *DRMEGLBackend) SetWindowSizeLimits(_, _, _, _ int) {}
+
+func (b *DRMEGLBackend) SetWindowTitle(title string) {
+	b.title = title
+}
+
+func (b *DRMEGLBackend) DisplaySize() (width, height int32) {
+	if b.ctx == nil {
+		return int32(b.width), int32(b.height)
+	}
+	return int32(b.ctx.Width()), int32(b.ctx.Height())
+}
+
+func (b *DRMEGLBackend) ContentScale() (xScale, yScale float32) {
+	return 1, 1
+}
+
+func (b *DRMEGLBackend) SetShouldClose(value bool) {
+	b.shouldClose = value
+}
+
+func (b *DRMEGLBackend) SetTargetFPS(fps uint) {
+	b.targetFPS = maxUint(fps, 1)
+}
+
+func (b *DRMEGLBackend) Refresh() {}
+
+func (b *DRMEGLBackend) CreateTexture(pixels unsafe.Pointer, width, height int) imgui.TextureRef {
+	tex := drm.GenTextures(1)
+	drm.BindTexture(drm.TEXTURE_2D, tex)
+	drm.TexParameteri(drm.TEXTURE_2D, drm.TEXTURE_MIN_FILTER, int32(drm.LINEAR))
+	drm.TexParameteri(drm.TEXTURE_2D, drm.TEXTURE_MAG_FILTER, int32(drm.LINEAR))
+	drm.TexParameteri(drm.TEXTURE_2D, drm.TEXTURE_WRAP_S, int32(drm.CLAMP_TO_EDGE))
+	drm.TexParameteri(drm.TEXTURE_2D, drm.TEXTURE_WRAP_T, int32(drm.CLAMP_TO_EDGE))
+	drm.TexImage2D(
+		drm.TEXTURE_2D,
+		0,
+		drm.RGBA,
+		int32(width),
+		int32(height),
+		0,
+		drm.RGBA,
+		drm.UNSIGNED_BYTE,
+		pixels,
+	)
+	drm.BindTexture(drm.TEXTURE_2D, 0)
+	return *imgui.NewTextureRefTextureID(imgui.TextureID(tex))
+}
+
+func (b *DRMEGLBackend) CreateTextureRgba(img *image.RGBA, width, height int) imgui.TextureRef {
+	return b.CreateTexture(unsafe.Pointer(&img.Pix[0]), width, height)
+}
+
+func (b *DRMEGLBackend) DeleteTexture(id imgui.TextureRef) {
+	tex := uint32(id.TexID())
+	drm.DeleteTextures(tex)
+}
+
+func (b *DRMEGLBackend) CreateWindow(title string, width, height int) {
+	b.title = title
+	b.width = width
+	b.height = height
+
+	requestWidth, requestHeight := 0, 0
+	if b.offscreen {
+		requestWidth = width
+		requestHeight = height
+	}
+
+	ctx, err := drm.Init(requestWidth, requestHeight)
+	if err != nil {
+		panic(err)
+	}
+	if !drm.MakeCurrent(ctx) {
+		ctx.Cleanup()
+		panic("drmeglbackend: failed to make EGL context current")
+	}
+
+	b.ctx = ctx
+	imgui.CreateContext()
+	imgui.StyleColorsDark()
+
+	if hook := b.afterCreateContext; hook != nil {
+		hook()
+	}
+
+	if !opengl3.InitV("#version 300 es") {
+		b.destroy()
+		panic("drmeglbackend: failed to initialize imgui opengl3 renderer")
+	}
+
+	if cb := b.sizeCb; cb != nil {
+		cb(ctx.Width(), ctx.Height())
+	}
+}
+
+func (b *DRMEGLBackend) SetDropCallback(cbfun backend.DropCallback) {
+	if cbfun == nil {
+		b.dropCB = func([]string) {}
+		return
+	}
+	b.dropCB = cbfun
+}
+
+func (b *DRMEGLBackend) SetCloseCallback(cbfun backend.WindowCloseCallback) {
+	if cbfun == nil {
+		b.closeCB = func(unsafe.Pointer) {}
+		return
+	}
+	b.closeCB = func(_ unsafe.Pointer) {
+		cbfun()
+	}
+}
+
+func (b *DRMEGLBackend) SetWindowFlags(flag DRMEGLWindowFlags, value int) {
+	if flag == DRMEGLWindowFlagsOffscreen {
+		b.offscreen = value != 0
+	}
+}
+
+func (b *DRMEGLBackend) SetIcons(...image.Image) {}
+
+func (b *DRMEGLBackend) SetKeyCallback(cbfun backend.KeyCallback) {
+	if cbfun == nil {
+		b.keyCb = func(int, int, int, int) {}
+		return
+	}
+	b.keyCb = cbfun
+}
+
+func (b *DRMEGLBackend) KeyCallback() backend.KeyCallback {
+	return b.keyCb
+}
+
+func (b *DRMEGLBackend) SetSizeChangeCallback(cbfun backend.SizeChangeCallback) {
+	if cbfun == nil {
+		b.sizeCb = func(int, int) {}
+		return
+	}
+	b.sizeCb = cbfun
+}
+
+func (b *DRMEGLBackend) SizeCallback() backend.SizeChangeCallback {
+	return b.sizeCb
+}
+
+func (b *DRMEGLBackend) SetSwapInterval(interval DRMEGLWindowFlags) error {
+	if interval == DRMEGLSwapIntervalVsync {
+		return nil
+	}
+	return ErrImmediateSwapUnsupported
+}
+
+func (b *DRMEGLBackend) SetCursorPos(_, _ float64) {}
+
+func (b *DRMEGLBackend) SetInputMode(_, _ DRMEGLWindowFlags) {}
+
+func maxUint(a, floor uint) uint {
+	if a < floor {
+		return floor
+	}
+	return a
+}

--- a/examples/drm-egl/Makefile
+++ b/examples/drm-egl/Makefile
@@ -1,0 +1,7 @@
+all: run
+
+build:
+	go build -v -o example-drm-egl .
+
+run: build
+	./example-drm-egl

--- a/examples/drm-egl/main.go
+++ b/examples/drm-egl/main.go
@@ -1,0 +1,28 @@
+//go:build linux && cgo
+
+package main
+
+import (
+	"runtime"
+
+	"github.com/AllenDang/cimgui-go/backend"
+	"github.com/AllenDang/cimgui-go/backend/drmeglbackend"
+	"github.com/AllenDang/cimgui-go/examples/common"
+	"github.com/AllenDang/cimgui-go/imgui"
+)
+
+var currentBackend backend.Backend[drmeglbackend.DRMEGLWindowFlags]
+
+func init() {
+	runtime.LockOSThread()
+}
+
+func main() {
+	common.Initialize()
+	currentBackend, _ = backend.CreateBackend(drmeglbackend.NewDRMEGLBackend())
+	currentBackend.SetAfterCreateContextHook(common.AfterCreateContext)
+	currentBackend.SetBeforeDestroyContextHook(common.BeforeDestroyContext)
+	currentBackend.SetBgColor(imgui.NewVec4(0.08, 0.10, 0.12, 1.0))
+	currentBackend.CreateWindow("Hello from cimgui-go DRM/EGL", 0, 0)
+	currentBackend.Run(common.Loop)
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/AllenDang/cimgui-go
 
 go 1.24.0
 
-require github.com/hajimehoshi/ebiten/v2 v2.9.9
+require (
+	github.com/hajimehoshi/ebiten/v2 v2.9.9
+	github.com/tthhr/go-drm-egl v1.0.0
+)
 
 require (
 	github.com/ebitengine/gomobile v0.0.0-20250923094054-ea854a63cce1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/hajimehoshi/ebiten/v2 v2.9.9 h1:JdDag6Ndj12iD4lxQGG8kbsrh7ssj4Sbzth6r
 github.com/hajimehoshi/ebiten/v2 v2.9.9/go.mod h1:DAt4tnkYYpCvu3x9i1X/nK/vOruNXIlYq/tBXxnhrXM=
 github.com/jezek/xgb v1.1.1 h1:bE/r8ZZtSv7l9gk6nU0mYx51aXrvnyb44892TwSaqS4=
 github.com/jezek/xgb v1.1.1/go.mod h1:nrhwO0FX/enq75I7Y7G8iN1ubpSGZEiA3v9e9GyRFlk=
+github.com/tthhr/go-drm-egl v1.0.0 h1:GnGPBNZH8CN7rflyNDaGpnOCD8Y8XFjA8Zc9jpdsYNQ=
+github.com/tthhr/go-drm-egl v1.0.0/go.mod h1:j6Im0lAXU+WtgxMaSDAoB296HwQVWC2Ar1xl2aZNpgs=
 golang.org/x/image v0.31.0 h1:mLChjE2MV6g1S7oqbXC0/UcKijjm5fnJLUYKIYrLESA=
 golang.org/x/image v0.31.0/go.mod h1:R9ec5Lcp96v9FTF+ajwaH3uGxPH4fKfHHAVbUILxghA=
 golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=


### PR DESCRIPTION
### Summary
This PR introduces a new DRM (Direct Rendering Manager) rendering backend for cimgui-go. This allows ImGui to render directly to the Linux display controller without requiring a windowing system like X11 or Wayland.

### Why only Rendering?
Unlike desktop backends (GLFW/SDL), this implementation focuses strictly on Rendering. Input handling (Mouse/Keyboard) is intentionally excluded for the following reasons:
Hardware Diversity: In embedded DRM environments, input devices vary significantly. Users might use touchscreens, GPIO buttons, or custom industrial protocols rather than standard HID mice/keyboards.

Minimal Dependencies: To keep the backend lightweight and portable, we avoid hard dependencies on libinput or udev.

Flexibility: It follows the "Bring Your Own Input" philosophy. Users can easily pipe their custom input signals into ImGui by calling the io.AddXXXEvent functions manually.

### Changes：
add backend/drmeglbackend
add examples/drm-egl
require github.com/tthhr/go-drm-egl v1.0.0

### todo
Embedded Linux systems typically lack a desktop system for faster display. However, there are numerous embedded devices, and currently, it has only been successfully tested on ARM64 Rockchip and x86_64 PCs. Further adaptation will be made for more devices in the future.