### PR TITLE
Fix bug in handling of pointer + length parameters

### DIFF
--- a/cmd/codegen/gengo_funcs.go
+++ b/cmd/codegen/gengo_funcs.go
@@ -403,6 +403,17 @@ func (g *goFuncsGenerator) generateFuncArgs(f FuncDef) (args []GoIdentifier, arg
 			break
 		}
 
+		// cimgui exposes arrays of wrappable values as a "T* X, int num_X"
+		// pair. The default wrappablePtrW uses internal.Wrap, which copies
+		// just the first element, so the C side reads garbage past index 0.
+		// Reinterpret the Go pointer directly as a C array pointer instead.
+		if isWrappableArrayPair(f.ArgsT, i, g.context.preset.WrappableTypes) {
+			wrapper.ArgDef = ""
+			wrapper.ArgDefNoFin = ""
+			wrapper.Finalizer = ""
+			wrapper.VarName = fmt.Sprintf("(%s)(unsafe.Pointer(%s))", wrapper.CType, a.Name)
+		}
+
 		g.shouldGenerate = true
 		if len(decl) > 0 {
 			args = append(args, GoIdentifier(decl))
@@ -411,6 +422,31 @@ func (g *goFuncsGenerator) generateFuncArgs(f FuncDef) (args []GoIdentifier, arg
 	}
 
 	return args, argWrappers
+}
+
+// isWrappableArrayPair reports whether the argument at index i is a pointer
+// to a wrappable type immediately followed by an "int num_<name>" length
+// argument.
+func isWrappableArrayPair(argsT []ArgDef, i int, wrappableTypes map[CIdentifier][3]GoIdentifier) bool {
+	if i+1 >= len(argsT) {
+		return false
+	}
+	a := argsT[i]
+	next := argsT[i+1]
+
+	if !HasSuffix(a.Type, "*") {
+		return false
+	}
+	baseType := TrimSuffix(TrimPrefix(a.Type, "const "), "*")
+	if _, ok := wrappableTypes[baseType]; !ok {
+		return false
+	}
+
+	if next.Type != "int" {
+		return false
+	}
+
+	return string(next.Name) == "num_"+string(a.Name)
 }
 
 // Generate function body

--- a/imgui/funcs.go
+++ b/imgui/funcs.go
@@ -279,20 +279,16 @@ func (self *DrawList) AddCircleFilledV(center Vec2, radius float32, col uint32, 
 
 func (self *DrawList) AddConcavePolyFilled(points *Vec2, num_points int32, col uint32) {
 	selfArg, selfFin := self.Handle()
-	pointsArg, pointsFin := internal.Wrap(points)
-	C.ImDrawList_AddConcavePolyFilled(internal.ReinterpretCast[*C.ImDrawList](selfArg), internal.ReinterpretCast[*C.ImVec2_c](pointsArg), C.int(num_points), C.ImU32(col))
+	C.ImDrawList_AddConcavePolyFilled(internal.ReinterpretCast[*C.ImDrawList](selfArg), (*C.ImVec2_c)(unsafe.Pointer(points)), C.int(num_points), C.ImU32(col))
 
 	selfFin()
-	pointsFin()
 }
 
 func (self *DrawList) AddConvexPolyFilled(points *Vec2, num_points int32, col uint32) {
 	selfArg, selfFin := self.Handle()
-	pointsArg, pointsFin := internal.Wrap(points)
-	C.ImDrawList_AddConvexPolyFilled(internal.ReinterpretCast[*C.ImDrawList](selfArg), internal.ReinterpretCast[*C.ImVec2_c](pointsArg), C.int(num_points), C.ImU32(col))
+	C.ImDrawList_AddConvexPolyFilled(internal.ReinterpretCast[*C.ImDrawList](selfArg), (*C.ImVec2_c)(unsafe.Pointer(points)), C.int(num_points), C.ImU32(col))
 
 	selfFin()
-	pointsFin()
 }
 
 // This is useful if you need to forcefully create a new draw call (to allow for dependent rendering / blending). Otherwise primitives are merged into the same draw-call as much as possible
@@ -390,11 +386,9 @@ func (self *DrawList) AddNgonFilled(center Vec2, radius float32, col uint32, num
 
 func (self *DrawList) AddPolyline(points *Vec2, num_points int32, col uint32, flags DrawFlags, thickness float32) {
 	selfArg, selfFin := self.Handle()
-	pointsArg, pointsFin := internal.Wrap(points)
-	C.ImDrawList_AddPolyline(internal.ReinterpretCast[*C.ImDrawList](selfArg), internal.ReinterpretCast[*C.ImVec2_c](pointsArg), C.int(num_points), C.ImU32(col), C.ImDrawFlags(flags), C.float(thickness))
+	C.ImDrawList_AddPolyline(internal.ReinterpretCast[*C.ImDrawList](selfArg), (*C.ImVec2_c)(unsafe.Pointer(points)), C.int(num_points), C.ImU32(col), C.ImDrawFlags(flags), C.float(thickness))
 
 	selfFin()
-	pointsFin()
 }
 
 // AddQuadV parameter default value hint:


### PR DESCRIPTION
Previously, the codegen would end up copying the first element of the array to the stack, then taking a pointer to that, leading to garbage in all elements after the first one.

Fixes DrawList.AddPolyline (et al.)